### PR TITLE
Simplify CI: remove build job and editable install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,32 +53,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: |
-          pip install pytest
-          pip install -e .
+        run: pip install pytest pyyaml
 
       - name: Run tests
         run: pytest tests/ -v --tb=short
-
-  # -----------------------------------------------------------------------
-  # Build — validate pyproject.toml parses cleanly
-  # -----------------------------------------------------------------------
-  build:
-    needs: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install build tools
-        run: pip install build twine
-
-      - name: Build sdist + wheel
-        run: python -m build
-
-      - name: Check metadata
-        run: twine check dist/*


### PR DESCRIPTION
## Summary
Removes the build validation job from CI and simplifies the test job's dependency installation. The build job (which validated `pyproject.toml` parsing and built sdist/wheel artifacts) is no longer needed in the CI pipeline. The test job now installs only the direct dependencies required for testing (`pytest` and `pyyaml`) instead of installing the package in editable mode.

## Type of change
- [x] chore — CI, deps, tooling

## Checklist
- [x] Tests pass locally (`pytest tests/ -v`)
- [ ] Lint passes (`ruff check . && ruff format --check .`)
- [ ] CHANGELOG.md updated (user-facing changes) — N/A
- [ ] Version bumped in `__init__.py` + `pyproject.toml` + `plugin.yaml` (if releasing) — N/A

## Testing
CI pipeline will continue to run lint and test jobs as before. The removal of the build job simplifies the workflow without affecting test coverage.

https://claude.ai/code/session_0164QJVn1FCFUcetRE58vq4f