### PR TITLE
feat(pricing): native Gemini 3.x/2.5 family pricing for direct Google AI usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Gemini 3.x and 2.5 family pricing in `_DEFAULT_PRICING` (issue #2):
+  `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`,
+  `gemini-3-flash-preview`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`.
+  All entries include explicit `cache_read` matching Google's published rates.
+- Family-specific Gemini prefix entries in `_PREFIX_PRICING` to cover dated
+  variants (e.g. `gemini-3-flash-preview-20251217`).
+
+### Changed
+- `gemini-2.5-pro` entry now includes explicit `cache_read: 0.125`.
+- Direct-Google Gemini lookups (no `google/` prefix) now resolve to correct
+  prices — previously fell through to the legacy generic `gemini` prefix and
+  were priced as Flash 1.5, underestimating cost by ~6.5x for Gemini 3 Flash.
+
+### Removed
+- Deprecated Gemini entries from `_DEFAULT_PRICING`: `gemini-1.5-pro`,
+  `gemini-1.5-flash`, `gemini-2.0-flash` (removed from Google's pricing page;
+  2.0 family sunset 2026-06-01).
+- Generic `gemini` catch-all prefix in `_PREFIX_PRICING` (was Flash 1.5 pricing
+  for any unknown gemini-* variant — silently mis-priced new models). Unknown
+  Gemini variants now surface as `unknown-model` warnings instead.
+
 ## [0.3.0] - 2026-06-02
 
 ### Added

--- a/pricing.py
+++ b/pricing.py
@@ -68,10 +68,18 @@ _DEFAULT_PRICING: dict[str, dict] = {
     "meta-llama/llama-3.1-70b-instruct": dict(input=0.52, output=0.75),
     "meta-llama/llama-3.3-70b-instruct": dict(input=0.59, output=0.79),
     # ── Google ──────────────────────────────────────────────────────────────
-    "gemini-1.5-pro": dict(input=3.50, output=10.50),
-    "gemini-1.5-flash": dict(input=0.075, output=0.30),
-    "gemini-2.0-flash": dict(input=0.10, output=0.40),
-    "gemini-2.5-pro": dict(input=1.25, output=10.00),
+    # Prices verified at https://ai.google.dev/gemini-api/docs/pricing on 2026-06-05.
+    # Removed deprecated models: gemini-1.5-pro/-flash (off pricing page),
+    # gemini-2.0-flash/-lite (sunset 2026-06-01). Tiered-pricing models
+    # (gemini-2.5-pro, gemini-3.1-pro-preview) use the <=200k context tier;
+    # >200k usage is undercounted (separate issue to track).
+    "gemini-3.5-flash": dict(input=1.50, output=9.00, cache_read=0.15),
+    "gemini-3.1-pro-preview": dict(input=2.00, output=12.00, cache_read=0.20),
+    "gemini-3.1-flash-lite": dict(input=0.25, output=1.50, cache_read=0.025),
+    "gemini-3-flash-preview": dict(input=0.50, output=3.00, cache_read=0.05),
+    "gemini-2.5-pro": dict(input=1.25, output=10.00, cache_read=0.125),
+    "gemini-2.5-flash": dict(input=0.30, output=2.50, cache_read=0.03),
+    "gemini-2.5-flash-lite": dict(input=0.10, output=0.40, cache_read=0.01),
 }
 
 # Prefix-based fallback for model families (matched in order, longest first)
@@ -90,10 +98,17 @@ _PREFIX_PRICING: list[tuple[str, dict]] = [
     ("o4-mini", dict(input=1.10, output=4.40)),
     ("deepseek-r1", dict(input=0.55, output=2.19)),
     ("deepseek", dict(input=0.27, output=1.10)),
-    ("gemini-2.5", dict(input=1.25, output=10.00)),
-    ("gemini-2", dict(input=0.10, output=0.40)),
-    ("gemini-1.5-pro", dict(input=3.50, output=10.50)),
-    ("gemini", dict(input=0.075, output=0.30)),
+    # Gemini family prefixes catch dated variants (e.g. gemini-3-flash-preview-20251217).
+    # Specific prefixes only — no generic "gemini" catch-all, since Flash 1.5 is
+    # deprecated and a bare "gemini" prefix would mis-price unknown models. An
+    # unknown gemini variant now logs a warning instead of being silently mis-priced.
+    ("gemini-3.1-flash-lite", dict(input=0.25, output=1.50, cache_read=0.025)),
+    ("gemini-2.5-flash-lite", dict(input=0.10, output=0.40, cache_read=0.01)),
+    ("gemini-3.5-flash", dict(input=1.50, output=9.00, cache_read=0.15)),
+    ("gemini-3.1-pro", dict(input=2.00, output=12.00, cache_read=0.20)),
+    ("gemini-3-flash", dict(input=0.50, output=3.00, cache_read=0.05)),
+    ("gemini-2.5-flash", dict(input=0.30, output=2.50, cache_read=0.03)),
+    ("gemini-2.5-pro", dict(input=1.25, output=10.00, cache_read=0.125)),
     ("llama-3.1-405", dict(input=2.70, output=2.70)),
     ("llama-3.1-70", dict(input=0.52, output=0.75)),
     ("llama-3.3-70", dict(input=0.59, output=0.79)),

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -365,3 +365,79 @@ def test_cache_multiplier_fallback(caplog):
     # Expected: 1M * (2.50 * 0.10) / 1M = $0.25
     expected = 2.50 * 0.10
     assert abs(cost - expected) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Gemini direct-provider lookups
+#
+# Hermes hooks fire with model=gemini-3-flash-preview, provider=gemini when
+# calling Google AI Studio directly (not via OpenRouter). Verify the bare
+# Gemini family names resolve to the correct entries, including the
+# previously-buggy fallthrough where Gemini 3 was priced as Gemini 1.5 Flash.
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_3_flash_preview_direct():
+    """gemini-3-flash-preview (no google/ prefix) resolves to its real price."""
+    cost = pricing.estimate_cost(
+        {"input_tokens": 1_000_000, "output_tokens": 0}, "gemini-3-flash-preview"
+    )
+    assert abs(cost - 0.50) < 1e-6  # not 0.075 (legacy Flash 1.5 fallback)
+
+
+def test_gemini_3_flash_preview_cache_read_explicit():
+    cost = pricing.estimate_cost({"cache_read_tokens": 1_000_000}, "gemini-3-flash-preview")
+    assert abs(cost - 0.05) < 1e-6  # 10% of input — also matches Google's published price
+
+
+def test_gemini_2_5_flash_direct():
+    cost = pricing.estimate_cost(
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000}, "gemini-2.5-flash"
+    )
+    expected = 0.30 + 2.50
+    assert abs(cost - expected) < 1e-6
+
+
+def test_gemini_2_5_flash_lite_direct():
+    cost = pricing.estimate_cost({"input_tokens": 1_000_000}, "gemini-2.5-flash-lite")
+    assert abs(cost - 0.10) < 1e-6
+
+
+def test_gemini_3_5_flash_direct():
+    cost = pricing.estimate_cost({"output_tokens": 1_000_000}, "gemini-3.5-flash")
+    assert abs(cost - 9.00) < 1e-6
+
+
+def test_gemini_dated_variant_resolves_by_prefix():
+    """gemini-3-flash-preview-20251217 (dated) hits the gemini-3-flash prefix."""
+    cost = pricing.estimate_cost({"input_tokens": 1_000_000}, "gemini-3-flash-preview-20251217")
+    assert abs(cost - 0.50) < 1e-6
+
+
+def test_gemini_1_5_no_longer_resident(caplog):
+    """gemini-1.5-flash was removed from the default table (deprecated 2026-Q2).
+
+    Without the legacy 'gemini' catch-all prefix, an unknown 1.5 variant now
+    surfaces as a warning instead of being silently priced. This is the desired
+    behavior — a deprecated entry shouldn't be the silent default.
+    """
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="hermes_telemetry.pricing"):
+        cost = pricing.estimate_cost({"input_tokens": 1_000_000}, "gemini-1.5-flash-tuned")
+    # 1.5-flash prefix is gone — falls through to unknown
+    assert cost == 0.0
+
+
+def test_gemini_no_generic_catchall_regression(caplog):
+    """A bare 'gemini-anything' must NOT silently match the old generic 'gemini' prefix.
+
+    Regression guard: previously the bare 'gemini' prefix swept any unknown
+    variant into Flash 1.5 pricing ($0.075/$0.30), underestimating Gemini 3
+    direct-Google calls by ~6.5x. After the cleanup, the catch-all is removed.
+    """
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="hermes_telemetry.pricing"):
+        cost = pricing.estimate_cost({"input_tokens": 1_000_000}, "gemini-future-foo")
+    assert cost == 0.0  # not 0.075


### PR DESCRIPTION
## Summary

Native pricing entries for the current Gemini family when accessed **directly** via Google AI Studio (provider sends bare `gemini-3-flash-preview`, not `google/gemini-3-flash-preview`).

Without this change, my Hermes deployment (provider=`gemini`, model=`gemini-3-flash-preview`) silently fell through to the generic `gemini` prefix entry (Flash 1.5 pricing) and underestimated cost by ~6.5x. Verified against production data on my Pi: a real $0.024 call was reported as $0.0037.

Adds:
- 6 Gemini text-generation models in `_DEFAULT_PRICING` with explicit `cache_read` matching Google's published rates: `gemini-3.5-flash`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`, `gemini-3-flash-preview`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`.
- `cache_read: 0.125` to the existing `gemini-2.5-pro` entry.
- Family-specific Gemini prefixes (e.g. `gemini-3-flash`) so dated variants like `gemini-3-flash-preview-20251217` resolve correctly.

Removes:
- Deprecated `gemini-1.5-pro`, `gemini-1.5-flash`, `gemini-2.0-flash` (off Google's pricing page; 2.0 family sunset 2026-06-01).
- Generic `gemini` catch-all prefix — was Flash 1.5 pricing for *any* unknown gemini-* variant. Unknown variants now log the `unknown-model` warning instead of being silently mis-priced.

Prices verified at https://ai.google.dev/gemini-api/docs/pricing on 2026-06-05.

Closes #2.

## Type of change
- [x] feat — new feature
- [x] fix — bug fix (silent mis-pricing of direct-Google Gemini models)

## Checklist
- [x] Tests pass locally (`pytest tests/ -v`) — **138 passed**
- [x] Lint passes (`ruff check . && ruff format --check .`)
- [x] CHANGELOG.md updated under `[Unreleased]`
- [ ] Version bumped — leaving for you to decide if this warrants 0.3.1 or rides 0.4.0

## Testing

**8 new tests** in `tests/test_pricing.py`:

| Test | Verifies |
|---|---|
| `test_gemini_3_flash_preview_direct` | Bare name resolves to $0.50 input (not Flash 1.5's $0.075) |
| `test_gemini_3_flash_preview_cache_read_explicit` | Explicit cache_read = $0.05 (10% of input) |
| `test_gemini_2_5_flash_direct` | $0.30/$2.50 GA pricing |
| `test_gemini_2_5_flash_lite_direct` | $0.10/$0.40 GA pricing |
| `test_gemini_3_5_flash_direct` | $1.50/$9.00 GA pricing |
| `test_gemini_dated_variant_resolves_by_prefix` | `gemini-3-flash-preview-20251217` hits the `gemini-3-flash` prefix |
| `test_gemini_1_5_no_longer_resident` | Deprecated 1.5 variants now log unknown-model warning |
| `test_gemini_no_generic_catchall_regression` | Bare `gemini-future-foo` does **not** silently match the old generic prefix |

```
$ pytest tests/ -v
============================= 138 passed in 17.06s =============================
```

### Production validation

Confirmed on my Pi (Hermes 0.12.0 + Gemini 3 Flash direct via Google AI Studio):

| Call | Tokens | Cost reported (before) | Cost reported (after) | Real cost |
|---|---|---|---|---|
| 49,285 input + 52 output | — | $0.0037 | **$0.024799** | $0.024799 |
| 878 input + 48,831 cache + 162 output | — | $0.000762 | **$0.003367** | $0.003367 |

After this PR: 0.0% diff vs Google's published pricing across all observed calls.

## Screenshots / output

`/stats` reports correct cost without any custom `pricing.yaml` override:

```
hermes-telemetry — direct-Google call breakdown
  Model        : gemini-3-flash-preview
  Provider     : gemini
  Input        : 49,285 tokens  @ $0.50/M → $0.024643
  Output       :     52 tokens  @ $3.00/M → $0.000156
  Total        : $0.024799  (matches Google's published pricing exactly)
```

## Out of scope (suggesting follow-up issues)

- **Tiered pricing** for `gemini-2.5-pro` and `gemini-3.1-pro-preview` (different rates above 200k context). Current entries use the ≤200k tier; >200k usage is undercounted. Schema change needed.
- **Modality-aware pricing** (audio input on `gemini-2.5-flash` is $1.00 vs $0.30 for text). Same schema concern.
- **Per-image billing models** (`gemini-3.1-flash-image`, `gemini-2.5-flash-image`). Incompatible with current per-token schema.
- **Optional `GoogleAISource`** for auto-refresh (parallel to `OpenRouterSource`). Tracked separately if you want.

Happy to iterate on any naming/structure preferences. Thanks for the great plugin 🙌
