### PR TITLE
fix(db): lazy-create runs row when on_session_start was missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-06-06
+
+### Fixed
+- `runs` rows are now lazy-created from `record_llm_call` and `end_run` when
+  `on_session_start` was missed (issue #3). Affected any deployment where the
+  plugin was enabled on a gateway with already-running chat-platform sessions:
+  the bot's `session_id` never received the start hook, so all subsequent
+  `UPDATE runs WHERE session_id = ?` calls were silent no-ops and `/stats` /
+  `/budget` under-reported. The new private `_ensure_run_row` helper mirrors the
+  `INSERT OR IGNORE` pattern already used by `start_run`, so the happy path is
+  unchanged (no duplicate rows, `platform` / `cron_job_id` preserved).
+
 ## [0.3.0] - 2026-06-02
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -9,7 +9,7 @@ Errors are caught silently — telemetry never takes down a session.
 
 from __future__ import annotations
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 import json
 import logging

--- a/db.py
+++ b/db.py
@@ -226,6 +226,26 @@ def _run_hours_ago_expr(hours: int) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _ensure_run_row(session_id: str, ts: str) -> None:
+    """Idempotently ensure a `runs` row exists for ``session_id``.
+
+    `INSERT OR IGNORE` so any existing row (created by `start_run` on the
+    happy path) is preserved untouched. The row is opened in `running`
+    status with `ts` as `started_at`; subsequent UPDATEs in
+    `record_llm_call` / `end_run` populate the rest.
+
+    Called by `record_llm_call` and `end_run` so the `UPDATE WHERE
+    session_id = ?` paths never silently no-op for sessions whose
+    `on_session_start` hook didn't reach the plugin — see
+    hermes-agent `agent/conversation_loop.py:296` (the start hook fires
+    "once when a brand-new session is created (not on continuation)").
+    """
+    _get_conn().execute(
+        "INSERT OR IGNORE INTO runs (session_id, started_at, status) VALUES (?, ?, 'running')",
+        (session_id, ts),
+    )
+
+
 def start_run(
     session_id: str,
     model: str,
@@ -246,15 +266,8 @@ def start_run(
 
 def end_run(session_id: str, status: str, ended_at: str | None = None) -> None:
     now = ended_at or _utcnow()
+    _ensure_run_row(session_id, now)
     conn = _get_conn()
-    # Defensive lazy-create: if end_run is called for a session_id that
-    # never went through start_run or record_llm_call (e.g. a hook-event
-    # ordering quirk), still record a closing row. Idempotent — matches
-    # the INSERT OR IGNORE pattern used in start_run and record_llm_call.
-    conn.execute(
-        "INSERT OR IGNORE INTO runs (session_id, started_at, status) VALUES (?, ?, 'running')",
-        (session_id, now),
-    )
     conn.execute(
         """
         UPDATE runs
@@ -306,18 +319,7 @@ def record_llm_call(
             1 if estimated else 0,
         ),
     )
-    # Lazy-create the runs row if on_session_start was missed.
-    # This covers chat-platform sessions that pre-date plugin install
-    # and any other path where the start hook didn't fire for the
-    # plugin (the UPDATE below is otherwise a silent no-op).
-    # See hermes-agent agent/conversation_loop.py:296 — on_session_start
-    # "fired once when a brand-new session is created (not on
-    # continuation)" — so the start hook never re-fires for resumed
-    # sessions.
-    conn.execute(
-        "INSERT OR IGNORE INTO runs (session_id, started_at, status) VALUES (?, ?, 'running')",
-        (session_id, ts),
-    )
+    _ensure_run_row(session_id, ts)
     conn.execute(
         """
         UPDATE runs

--- a/db.py
+++ b/db.py
@@ -247,6 +247,14 @@ def start_run(
 def end_run(session_id: str, status: str, ended_at: str | None = None) -> None:
     now = ended_at or _utcnow()
     conn = _get_conn()
+    # Defensive lazy-create: if end_run is called for a session_id that
+    # never went through start_run or record_llm_call (e.g. a hook-event
+    # ordering quirk), still record a closing row. Idempotent — matches
+    # the INSERT OR IGNORE pattern used in start_run and record_llm_call.
+    conn.execute(
+        "INSERT OR IGNORE INTO runs (session_id, started_at, status) VALUES (?, ?, 'running')",
+        (session_id, now),
+    )
     conn.execute(
         """
         UPDATE runs
@@ -297,6 +305,18 @@ def record_llm_call(
             reasoning_tokens,
             1 if estimated else 0,
         ),
+    )
+    # Lazy-create the runs row if on_session_start was missed.
+    # This covers chat-platform sessions that pre-date plugin install
+    # and any other path where the start hook didn't fire for the
+    # plugin (the UPDATE below is otherwise a silent no-op).
+    # See hermes-agent agent/conversation_loop.py:296 — on_session_start
+    # "fired once when a brand-new session is created (not on
+    # continuation)" — so the start hook never re-fires for resumed
+    # sessions.
+    conn.execute(
+        "INSERT OR IGNORE INTO runs (session_id, started_at, status) VALUES (?, ?, 'running')",
+        (session_id, ts),
     )
     conn.execute(
         """

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-telemetry
-version: "0.3.0"
+version: "0.3.1"
 description: >-
   Observability + budget guardrails for Hermes Agent — tokens, cost, latency,
   tool calls per session and cron job. Persists to local SQLite. Exposes /stats

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-telemetry"
-version = "0.3.0"
+version = "0.3.1"
 description = "Observability + budget guardrails for Hermes Agent — tokens, cost, latency, tool calls per session and cron job."
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -461,3 +461,163 @@ def test_try_budget_alert_is_idempotent():
     assert second is False
     # A different level is a distinct alert
     assert db.try_budget_alert("global", "", "daily", "2026-05-31", "hard", 5.0, 5.0) is True
+
+
+# ---------------------------------------------------------------------------
+# Orphan-session recovery (issue #3)
+#
+# Some callers fire post_api_request / on_session_end without an earlier
+# on_session_start having reached the plugin. This happens for any chat
+# platform session that pre-existed the plugin enable, and for sessions
+# resumed across gateway restarts via resume_pending (see hermes-agent
+# gateway/session.py:889 — "Restart-interrupted session: preserve the
+# session_id"). The plugin must still aggregate those calls under a runs
+# row instead of silently no-op'ing.
+# ---------------------------------------------------------------------------
+
+
+def test_record_llm_call_lazy_creates_runs_row_when_start_missed():
+    """record_llm_call for an unknown session must create a 'running' row
+    and aggregate against it — not silently UPDATE WHERE no row matches."""
+    db.record_llm_call(
+        "orphan-session",
+        "2026-06-05T12:00:00+00:00",
+        "gemini-3-flash-preview",
+        "gemini",
+        100,
+        50,
+        0.001,
+        200,
+    )
+    conn = db._get_conn()
+    row = conn.execute(
+        "SELECT session_id, status, tokens_in, tokens_out, cost_usd, api_calls, model, provider "
+        "FROM runs WHERE session_id = ?",
+        ("orphan-session",),
+    ).fetchone()
+    assert row is not None
+    assert dict(row) == {
+        "session_id": "orphan-session",
+        "status": "running",
+        "tokens_in": 100,
+        "tokens_out": 50,
+        "cost_usd": 0.001,
+        "api_calls": 1,
+        "model": "gemini-3-flash-preview",
+        "provider": "gemini",
+    }
+
+
+def test_record_llm_call_does_not_duplicate_with_explicit_start_run():
+    """When on_session_start did fire normally, the lazy INSERT OR IGNORE in
+    record_llm_call must be a no-op — same row, aggregated correctly."""
+    db.start_run("happy-path", model="gemini-3-flash-preview", platform="cli")
+    db.record_llm_call(
+        "happy-path",
+        "2026-06-05T12:00:00+00:00",
+        "gemini-3-flash-preview",
+        "gemini",
+        100,
+        50,
+        0.001,
+        200,
+    )
+    conn = db._get_conn()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM runs WHERE session_id = ?", ("happy-path",)
+    ).fetchone()[0]
+    assert count == 1
+    row = conn.execute(
+        "SELECT platform, tokens_in, api_calls FROM runs WHERE session_id = ?", ("happy-path",)
+    ).fetchone()
+    # platform was set by start_run and preserved (not overwritten by lazy insert)
+    assert row["platform"] == "cli"
+    assert row["tokens_in"] == 100
+    assert row["api_calls"] == 1
+
+
+def test_end_run_lazy_creates_row_when_start_missed():
+    """end_run for an unknown session_id (no prior start_run, no prior
+    record_llm_call) still records a closing row. Defensive guard against
+    rare hook ordering — Nadia's review case 4."""
+    db.end_run("never-started", status="ok")
+    conn = db._get_conn()
+    row = conn.execute(
+        "SELECT session_id, status, ended_at IS NOT NULL AS has_end FROM runs WHERE session_id = ?",
+        ("never-started",),
+    ).fetchone()
+    assert row is not None
+    assert row["status"] == "ok"
+    assert row["has_end"] == 1
+
+
+def test_chat_bot_session_aggregates_after_orphan_recovery():
+    """Regression: chat-bot scenario — plugin enabled mid-session.
+    Multiple record_llm_call for the same orphan session_id, then a
+    per-turn end_run closes the run cleanly. /stats must see the
+    aggregated cost.
+    """
+    sid = "20260605_074023_3cd3bf2a"  # mimics the production session id format
+
+    # Three turns of a Telegram bot — no preceding start_run because the
+    # session pre-dated the plugin install.
+    db.record_llm_call(
+        sid,
+        "2026-06-05T17:35:48+00:00",
+        "gemini-3-flash-preview",
+        "gemini",
+        29912,
+        19,
+        0.024799,
+        2575,
+    )
+    db.record_llm_call(
+        sid,
+        "2026-06-05T17:41:39+00:00",
+        "gemini-3-flash-preview",
+        "gemini",
+        10808,
+        39,
+        0.005534,
+        2359,
+    )
+    db.record_llm_call(
+        sid,
+        "2026-06-05T17:48:30+00:00",
+        "gemini-3-flash-preview",
+        "gemini",
+        49285,
+        52,
+        0.024799,
+        1840,
+    )
+
+    # Hermes fires on_session_end per-turn (agent/conversation_loop.py:4870)
+    db.end_run(sid, status="ok")
+
+    # /stats reads from runs — must see the aggregated chat-bot cost
+    conn = db._get_conn()
+    row = conn.execute(
+        "SELECT tokens_in, tokens_out, api_calls, cost_usd, status FROM runs WHERE session_id = ?",
+        (sid,),
+    ).fetchone()
+    assert row is not None
+    assert row["api_calls"] == 3
+    assert row["tokens_in"] == 90005
+    assert row["tokens_out"] == 110
+    assert abs(row["cost_usd"] - 0.055132) < 1e-6
+    assert row["status"] == "ok"
+
+
+def test_orphan_session_appears_in_stats_summary():
+    """End-to-end: orphan-recovered session shows up in stats_summary
+    aggregates (previously invisible). 24h window includes recent insert."""
+    db.record_llm_call(
+        "orphan-stats", db._utcnow(), "gemini-3-flash-preview", "gemini", 1000, 200, 0.005, 500
+    )
+    db.end_run("orphan-stats", status="ok")
+
+    summary = db.stats_summary(window_hours=24)
+    assert summary["total_runs"] >= 1
+    assert summary["tokens_in"] >= 1000
+    assert summary["cost_usd"] >= 0.005


### PR DESCRIPTION
## Summary

Fixes the silent no-op in `record_llm_call` and `end_run` when the `runs` row doesn't exist. One `INSERT OR IGNORE` per UPDATE call site, mirroring the existing pattern in `start_run`.

The orphan-session scenario is structural for chat-platform deployments: `on_session_start` fires only for brand-new sessions and never for continuations, so any session that pre-existed the plugin enable never gets a `runs` row. All subsequent LLM calls land in `llm_calls` correctly but the `UPDATE runs WHERE session_id` is a silent no-op — `/stats`, `/budget`, and aggregations under-report.

Verified against `hermes-agent` `main` HEAD (commit `66a6b9c`):
- `agent/conversation_loop.py:296` — `on_session_start` "fired once when a brand-new session is created (not on continuation)"
- `agent/conversation_loop.py:4870` — `on_session_end` "Fired at the very end of every run_conversation call" (per-turn)
- `gateway/session.py:889` — `resume_pending` preserves the `session_id` across gateway restarts

Full source-code rationale: nujovich/hermes-telemetry#3 (comment).

Closes #3.

## Type of change
- [x] fix — bug fix

## Checklist
- [x] Tests pass locally (`pytest tests/ -v`) — **135 passed**
- [x] Lint passes (`ruff check . && ruff format --check .`)
- [x] CHANGELOG.md updated — happy to add an entry if you want, didn't see one for the previous fix-only PRs so left it out
- [ ] Version bumped — leaving for your call

## Testing

**5 new tests in `tests/test_db.py`** covering the four cases you outlined plus a chat-bot regression:

| Test | Covers |
|---|---|
| `test_record_llm_call_lazy_creates_runs_row_when_start_missed` | Your case 1: orphan session aggregates correctly |
| `test_record_llm_call_does_not_duplicate_with_explicit_start_run` | Your case 2: happy path unchanged, no row duplication, `platform` preserved |
| `test_end_run_lazy_creates_row_when_start_missed` | Your case 4: defensive `end_run` for never-started session |
| `test_chat_bot_session_aggregates_after_orphan_recovery` | Production scenario — N `record_llm_call` for the same orphan session_id then `end_run` closes cleanly |
| `test_orphan_session_appears_in_stats_summary` | End-to-end: orphan-recovered session shows up in `stats_summary` |

Your suggested case 3 ("naming consistency between `start_run` / `end_run`") didn't require a new test — the lazy `INSERT OR IGNORE` uses identical column semantics in both call sites.

```
$ pytest tests/ -v
============================= 135 passed in 16.46s =============================
```

### Production validation

Tested live on my Pi against the production scenario from #3:

**Before the fix:**
```
runs:        2 rows (only the post-install cron jobs)
Pollo:       0 rows — Telegram bot session 20260605_074023_3cd3bf2a invisible to /stats
llm_calls:   46 rows captured correctly for Pollo (the data was there, just unaggregated)
```

**After enabling this branch and sending one Telegram message:**
```
runs:        3 rows — Pollo's session now lazy-created on first record_llm_call post-fix
   session_id: 20260605_074023_3cd3bf2a
   status:     ok           ← on_session_end closed it cleanly per-turn
   api_calls:  3
   tokens_in:  102715
   tokens_out: 395
   cost_usd:   0.00818826
```

`/stats today` now sees the chat-bot spend it was previously dropping. Historical pre-fix calls remain in `llm_calls` (no retroactive aggregation — that would be a separate decision), but every new call lands in the recovered run row.

## Notes on scope

- The fix touches only `db.py` — no plugin code, no schema migration, no behavior change for paths where `on_session_start` already fired.
- `platform` and `cron_job_id` on the lazy-created row stay `NULL` since we don't know them from `record_llm_call` context. They get populated normally when `start_run` runs first (happy path). For orphan rows they remain `NULL`, which `/stats providers` and `/stats cron` already handle via `COALESCE`.
- Open to renaming the helper or moving the `INSERT OR IGNORE` into a private `_ensure_run_row(session_id, ts)` if you'd prefer a single call site — let me know.

Thanks again for the quick review on #4 — happy to iterate on this one too.
