### PR TITLE
feat(dashboard): configurable --host bind interface for headless deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,11 +367,47 @@ The dashboard auto-refreshes every 30 seconds. No manual reload needed.
 
 ```bash
 cd ~/.hermes/plugins/hermes-telemetry/dashboard
-python3 serve.py        # serves on http://localhost:8765
-python3 serve.py 9090   # custom port
+python3 serve.py                  # http://localhost:8765 (loopback only)
+python3 serve.py --port 9090      # custom port, still loopback
+python3 serve.py 9090             # positional port (back-compat)
 ```
 
 Then open `http://localhost:8765` in your browser.
+
+### Accessing the dashboard from another host
+
+The dashboard has **no authentication** — anyone who can reach the port sees
+every captured token, cost, and tool-call detail. By default it binds to
+`127.0.0.1`, which is unreachable from other machines.
+
+If your Hermes server is headless (Pi, VPS, NAS) and you browse from a laptop,
+two options:
+
+**Recommended — SSH tunnel** (no server-side change, leaves the safe default in
+place):
+
+```bash
+# Start the dashboard on the server as usual
+ssh server "cd ~/.hermes/plugins/hermes-telemetry/dashboard && python3 serve.py &"
+
+# Tunnel from your client
+ssh -L 8765:localhost:8765 -N server &
+
+# Browse on the client
+open http://localhost:8765
+```
+
+**Trusted-LAN shortcut — `--host 0.0.0.0`:**
+
+```bash
+python3 serve.py --host 0.0.0.0
+```
+
+The script prints a warning when binding to any non-loopback interface. Only
+use this on a network where you trust every host. **Do not expose to the
+public internet or to networks that include untrusted hosts** — the dashboard
+ships without an auth layer by design (see CONTRIBUTING.md if you want to add
+one).
 
 ---
 

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -2,11 +2,27 @@
 """hermes-telemetry dashboard server -- zero dependencies, stdlib only.
 
 Usage:
-    python serve.py           # serves on http://localhost:8765
-    python serve.py 9090      # custom port
+    python serve.py                            # http://localhost:8765 (loopback only)
+    python serve.py --port 9090                # custom port, still loopback
+    python serve.py 9090                       # positional port (back-compat)
+    python serve.py --host 0.0.0.0             # bind all interfaces (no auth!)
+
+The dashboard has no authentication. By default it binds to 127.0.0.1 so it is
+unreachable from other hosts. To view it from another machine, either:
+
+  - Open an SSH tunnel from your client:
+        ssh -L 8765:localhost:8765 <user>@<server>
+    then browse http://localhost:8765 on the client.
+
+  - Or, on a trusted LAN only, pass --host 0.0.0.0 to bind all interfaces.
+    Anyone who can reach the chosen port will see every captured token, cost,
+    and tool-call detail with no login. Do not expose this to the public
+    internet or to networks that include untrusted hosts.
 """
 
+import argparse
 import json
+import logging
 import os
 import sqlite3
 import sys
@@ -15,6 +31,11 @@ from datetime import datetime, timedelta, timezone
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8765
+
+logger = logging.getLogger("hermes_telemetry.dashboard")
 
 # ---------------------------------------------------------------------------
 # DB path
@@ -273,17 +294,88 @@ class Handler(SimpleHTTPRequestHandler):
 
 
 # ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _parse_args(argv=None):
+    """Parse command-line arguments.
+
+    Back-compat: the original signature was `serve.py [port]` — a single
+    positional integer. Preserved so existing scripts and docs keep working.
+    """
+    parser = argparse.ArgumentParser(
+        prog="serve.py",
+        description="hermes-telemetry dashboard server.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  serve.py                       # bind 127.0.0.1:8765\n"
+            "  serve.py --port 9090           # custom port, still loopback\n"
+            "  serve.py 9090                  # positional port (back-compat)\n"
+            "  serve.py --host 0.0.0.0        # all interfaces (NO AUTH!)\n"
+        ),
+    )
+    parser.add_argument(
+        "--host",
+        default=DEFAULT_HOST,
+        help=(
+            f"Interface to bind to (default: {DEFAULT_HOST}). Use 0.0.0.0 to "
+            "expose on every interface — the dashboard has NO authentication, "
+            "so only do this on a trusted LAN."
+        ),
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help=f"Port to bind to (default: {DEFAULT_PORT}).",
+    )
+    parser.add_argument(
+        "port_positional",
+        nargs="?",
+        type=int,
+        default=None,
+        metavar="PORT",
+        help="Back-compat: positional port (use --port instead).",
+    )
+    args = parser.parse_args(argv)
+
+    port = args.port if args.port is not None else args.port_positional
+    if port is None:
+        port = DEFAULT_PORT
+    return args.host, port
+
+
+def _warn_if_exposed(host: str) -> None:
+    """Print a clear warning when binding to anything except loopback."""
+    if host in ("127.0.0.1", "localhost", "::1"):
+        return
+    msg = (
+        f"WARNING: binding dashboard on {host} exposes it to every host "
+        "that can reach this interface, and the dashboard has NO "
+        "authentication. Anyone who reaches the port will see every "
+        "captured token, cost, and tool-call detail. Do not expose to "
+        "the public internet or to untrusted networks."
+    )
+    print(msg, file=sys.stderr)
+    logger.warning("Dashboard bound on %s with no authentication.", host)
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
-def main():
-    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8765
+def main(argv=None):
+    host, port = _parse_args(argv)
+
     if not DB_PATH.exists():
         print(f"ERROR: telemetry DB not found at {DB_PATH}")
         print("Make sure hermes-telemetry plugin has captured data.")
         sys.exit(1)
 
-    server = HTTPServer(("127.0.0.1", port), Handler)
-    print(f"hermes-telemetry dashboard at http://localhost:{port}")
+    _warn_if_exposed(host)
+
+    server = HTTPServer((host, port), Handler)
+    display_host = "localhost" if host in ("127.0.0.1", "localhost") else host
+    print(f"hermes-telemetry dashboard at http://{display_host}:{port}")
     print("Press Ctrl+C to stop.")
     try:
         server.serve_forever()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,101 @@
+"""Tests for dashboard/serve.py CLI parsing and bind-warning behaviour."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# The dashboard ships as a standalone script at dashboard/serve.py — not under
+# the hermes_telemetry package — so import it by file path.
+_SERVE_PATH = Path(__file__).resolve().parents[1] / "dashboard" / "serve.py"
+
+
+@pytest.fixture
+def serve_module():
+    spec = importlib.util.spec_from_file_location("dashboard_serve", _SERVE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["dashboard_serve"] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop("dashboard_serve", None)
+
+
+# ---------------------------------------------------------------------------
+# _parse_args
+# ---------------------------------------------------------------------------
+
+
+def test_parse_args_defaults(serve_module):
+    host, port = serve_module._parse_args([])
+    assert host == "127.0.0.1"
+    assert port == 8765
+
+
+def test_parse_args_custom_port_flag(serve_module):
+    host, port = serve_module._parse_args(["--port", "9090"])
+    assert host == "127.0.0.1"
+    assert port == 9090
+
+
+def test_parse_args_custom_host_flag(serve_module):
+    host, port = serve_module._parse_args(["--host", "0.0.0.0"])
+    assert host == "0.0.0.0"
+    assert port == 8765
+
+
+def test_parse_args_host_and_port(serve_module):
+    host, port = serve_module._parse_args(["--host", "192.168.1.42", "--port", "9999"])
+    assert host == "192.168.1.42"
+    assert port == 9999
+
+
+def test_parse_args_positional_port_back_compat(serve_module):
+    """Original usage `serve.py 9090` must keep working."""
+    host, port = serve_module._parse_args(["9090"])
+    assert host == "127.0.0.1"
+    assert port == 9090
+
+
+def test_parse_args_named_port_wins_over_positional(serve_module):
+    """If a user passes both forms, --port takes precedence."""
+    host, port = serve_module._parse_args(["--port", "5000", "8765"])
+    assert port == 5000
+
+
+# ---------------------------------------------------------------------------
+# _warn_if_exposed
+# ---------------------------------------------------------------------------
+
+
+def test_warn_if_exposed_quiet_for_loopback(serve_module, capsys, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="hermes_telemetry.dashboard"):
+        serve_module._warn_if_exposed("127.0.0.1")
+        serve_module._warn_if_exposed("localhost")
+        serve_module._warn_if_exposed("::1")
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_warn_if_exposed_warns_for_wildcard(serve_module, capsys, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="hermes_telemetry.dashboard"):
+        serve_module._warn_if_exposed("0.0.0.0")
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "NO" in captured.err and "authentication" in captured.err
+    assert any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+def test_warn_if_exposed_warns_for_specific_lan_ip(serve_module, capsys):
+    """Binding to a specific non-loopback IP still warrants the warning."""
+    serve_module._warn_if_exposed("192.168.1.42")
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "192.168.1.42" in captured.err


### PR DESCRIPTION
## Summary

Opt-in `--host` and `--port` flags for `dashboard/serve.py` so headless deployments can browse the dashboard from another host without an SSH tunnel — while keeping the safe `127.0.0.1` default and the no-auth design unchanged.

Validated end-to-end on my Pi: launched `serve.py --host 0.0.0.0` on the server, hit `http://192.168.18.252:8765/` directly from my Mac on the same LAN (HTTP 200, 19ms), no SSH tunnel needed.

Closes #5.

## Type of change
- [x] feat — new feature

## Checklist
- [x] Tests pass locally (`pytest tests/ -v`) — **139 passed** (9 new dashboard tests)
- [x] Lint passes (`ruff check . && ruff format --check .`)
- [ ] CHANGELOG.md updated — happy to add an entry; left out to avoid clashing with the [Unreleased] sections in #4 and #6 (let me know if you want it here)
- [ ] Version bumped — leaving for your release call

## What changed

**`dashboard/serve.py`**
- `argparse` with `--host` (default `127.0.0.1`) and `--port` (default `8765`)
- Positional `port` still accepted for back-compat (`serve.py 9090`)
- `_warn_if_exposed(host)` prints a clear warning to stderr (and logs to `hermes_telemetry.dashboard`) when binding to anything other than `127.0.0.1` / `localhost` / `::1`. Restates the no-auth caveat verbatim.

**`README.md`**
- New section "Accessing the dashboard from another host" under `## Dashboard (Web UI)` with two recipes:
  - **Recommended**: SSH tunnel (no server-side change, leaves the safe default)
  - **Trusted-LAN shortcut**: `--host 0.0.0.0` with the warning callout

**`tests/test_dashboard.py`** (new file)
- 6 tests for `_parse_args`: defaults, `--port` flag, `--host` flag, both flags together, positional back-compat, `--port` precedence over positional
- 3 tests for `_warn_if_exposed`: quiet for `127.0.0.1` / `localhost` / `::1`, warns for `0.0.0.0`, warns for a specific LAN IP

## Testing

### Unit tests

```
$ pytest tests/test_dashboard.py -v
============================= 9 passed in 0.03s ===============================

$ pytest tests/ -v
============================= 139 passed in 15.76s ============================
```

### Production validation (headless Pi + Mac client)

```
[server] $ python3 serve.py --host 0.0.0.0
WARNING: binding dashboard on 0.0.0.0 exposes it to every host that can
reach this interface, and the dashboard has NO authentication. ...
hermes-telemetry dashboard at http://0.0.0.0:8765
Press Ctrl+C to stop.

[server] $ ss -tlnp | grep 8765
LISTEN 0      5      0.0.0.0:8765       0.0.0.0:*    users:(("python3", ...))

[mac]    $ curl -s -o /dev/null -w "HTTP %{http_code} | %{size_download}b\n" \
              http://192.168.18.252:8765/
HTTP 200 | 14278b

[mac]    $ curl -s -o /dev/null -w "HTTP %{http_code}\n" \
              http://192.168.18.252:8765/api/summary
HTTP 200 | 1265b
```

### Back-compat check

```
$ python3 serve.py            # default loopback
hermes-telemetry dashboard at http://localhost:8765

$ python3 serve.py 9090       # positional, still works
hermes-telemetry dashboard at http://localhost:9090
```

## Out of scope

- **Real authentication for the dashboard** — would unlock safe public exposure but is a much larger design choice (token? basic auth? session?). Issue #5 explicitly flagged it as separate. Happy to follow up if you want a proposal.
- **Reverse-proxy guidance** (nginx, Caddy with auth) — could add a paragraph if useful, but felt out of scope for a "make the headless case work" PR.

Let me know if you'd prefer the CHANGELOG entry here or in a follow-up alongside the eventual 0.4.0 release notes.
