### PR TITLE
feat(pricing): symmetric lookup for gemini-X ↔ google/gemini-X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- `pricing._lookup_base` now resolves `gemini-X` and `google/gemini-X` to
+  the same entry symmetrically (issue #2 follow-up). Direct-Google and
+  OpenRouter-routed callers no longer need both forms present in the
+  pricing data to get a hit. Normalization is google-specific — other
+  provider prefixes (`anthropic/`, `meta-llama/`, `openrouter/`) keep
+  their existing semantics and are never stripped.
+
 ## [0.3.1] - 2026-06-06
 
 ### Added

--- a/pricing.py
+++ b/pricing.py
@@ -169,12 +169,33 @@ def _load_custom_pricing() -> dict:
     return _custom_pricing
 
 
-def _lookup_base(model: str) -> dict | None:
-    """Return the raw pricing dict for a model (no cache derivation yet)."""
-    model_lc = model.lower()
+def _google_alt_form(model_lc: str) -> str | None:
+    """Return the alternate Google-AI form for symmetric lookup, or None.
+
+    Maps the pair `gemini-X` ↔ `google/gemini-X` so a single canonical price
+    table answers both direct-Google and OpenRouter-routed lookups. This is
+    deliberately google-specific: other provider prefixes (`anthropic/`,
+    `meta-llama/`, `openrouter/`) carry distinct pricing semantics and must
+    never be stripped naively.
+    """
+    if model_lc.startswith("google/"):
+        bare = model_lc[len("google/") :]
+        return bare if bare.startswith("gemini-") else None
+    if model_lc.startswith("gemini-"):
+        return "google/" + model_lc
+    return None
+
+
+def _lookup_form(model_lc: str) -> dict | None:
+    """Exact-then-prefix lookup against custom + defaults + prefix tables.
+
+    Custom wins over defaults wins over the curated prefix table (matching
+    the precedence in `_lookup_base`'s callers). Among equal-length prefixes,
+    the stable sort preserves source order so the higher-precedence source
+    still wins.
+    """
     custom = _load_custom_pricing()
     custom_models = custom.get("models", {})
-    # Exact match wins, custom overrides defaults.
     if model_lc in custom_models:
         return custom_models[model_lc]
     if model_lc in _DEFAULT_PRICING:
@@ -183,18 +204,34 @@ def _lookup_base(model: str) -> dict | None:
     # default exact keys, plus the curated family-prefix table — longest prefix
     # wins. This lets an auto-refreshed key like 'google/gemini-3-flash-preview'
     # cover the dated variants the gateway actually sends, e.g.
-    # 'google/gemini-3-flash-preview-20251217'. Among equal-length prefixes the
-    # more authoritative source is preferred (custom > default > prefix table),
-    # mirroring the exact-match precedence above.
+    # 'google/gemini-3-flash-preview-20251217'.
     candidates: list[tuple[str, dict]] = [
         *custom_models.items(),
         *_DEFAULT_PRICING.items(),
         *_PREFIX_PRICING,
     ]
-    # Stable sort by descending prefix length keeps the source order for ties.
     for prefix, prices in sorted(candidates, key=lambda x: -len(x[0])):
         if model_lc.startswith(prefix):
             return prices
+    return None
+
+
+def _lookup_base(model: str) -> dict | None:
+    """Return the raw pricing dict for a model (no cache derivation yet).
+
+    Two-pass strategy: first try the model id as-is. If that misses, try the
+    Google-AI alternate form (`gemini-X` ↔ `google/gemini-X`) so direct-Google
+    and OpenRouter-routed callers get identical pricing without requiring
+    both entries to coexist in the pricing data. Non-Google prefixes never
+    get this treatment — see `_google_alt_form`.
+    """
+    model_lc = model.lower()
+    result = _lookup_form(model_lc)
+    if result is not None:
+        return result
+    alt = _google_alt_form(model_lc)
+    if alt is not None:
+        return _lookup_form(alt)
     return None
 
 

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -460,3 +460,88 @@ def test_gemini_no_generic_catchall_regression(caplog):
     with caplog.at_level(logging.WARNING, logger="hermes_telemetry.pricing"):
         cost = pricing.estimate_cost({"input_tokens": 1_000_000}, "gemini-future-foo")
     assert cost == 0.0  # not 0.075
+
+
+# ---------------------------------------------------------------------------
+# Google name normalization — issue #2 follow-up (PR 2)
+#
+# The same Gemini model can reach the gateway under two forms:
+#   - direct Google AI Studio  → bare "gemini-3-flash-preview"
+#   - OpenRouter routing       → "google/gemini-3-flash-preview"
+#
+# Both forms must resolve to the same price entry, regardless of which form
+# the pricing data carries. The normalization is google-specific — other
+# provider prefixes (anthropic/, meta-llama/, openrouter/) must never be
+# stripped naively, since they have distinct pricing semantics.
+# ---------------------------------------------------------------------------
+
+
+def test_google_prefix_and_bare_form_resolve_to_same_price():
+    """gemini-3-flash-preview ↔ google/gemini-3-flash-preview return the same entry.
+
+    The bare form lives in _DEFAULT_PRICING. The google/-prefixed form must
+    resolve via the alt-form fallback to the same dict — same input/output/
+    cache_read across the board.
+    """
+    bare = pricing._lookup_base("gemini-3-flash-preview")
+    prefixed = pricing._lookup_base("google/gemini-3-flash-preview")
+    assert bare is not None, "bare gemini-3-flash-preview missing from _DEFAULT_PRICING"
+    assert prefixed is not None, "google/gemini-3-flash-preview should normalize to bare"
+    for field in ("input", "output", "cache_read"):
+        assert bare.get(field) == prefixed.get(field), (
+            f"{field}: bare={bare.get(field)} prefixed={prefixed.get(field)}"
+        )
+
+    # End-to-end cost check — both forms must produce identical dollar amounts.
+    usage = {"input_tokens": 1_000_000, "output_tokens": 500_000}
+    cost_bare = pricing.estimate_cost(usage, "gemini-3-flash-preview")
+    cost_prefixed = pricing.estimate_cost(usage, "google/gemini-3-flash-preview")
+    assert abs(cost_bare - cost_prefixed) < 1e-9
+
+
+def test_non_google_provider_prefix_resolves_to_its_own_entry():
+    """meta-llama/llama-3.1-405b-instruct must keep resolving to its exact entry.
+
+    Regression guard: a naive "strip any provider/ prefix" implementation
+    would let meta-llama/* be re-interpreted as bare llama-*, potentially
+    masking the dedicated meta-llama/* entries in _DEFAULT_PRICING. The
+    google/ normalization is opt-in and must leave every other provider
+    prefix untouched.
+    """
+    # The exact meta-llama/* entry stays authoritative — same dict before and
+    # after this PR.
+    prefixed = pricing._lookup_base("meta-llama/llama-3.1-405b-instruct")
+    assert prefixed == {"input": 2.70, "output": 2.70}
+
+    # A meta-llama/* variant that is NOT an exact key must NOT fall back to
+    # the bare llama-3.1-405 prefix via naive stripping. It must stay None
+    # so the unknown-model warning surfaces — exactly the failure mode the
+    # google/ normalization is scoped to avoid recreating elsewhere.
+    assert pricing._lookup_base("meta-llama/llama-99-imaginary") is None
+
+    # And the alt-form helper must refuse to normalize meta-llama/*.
+    assert pricing._google_alt_form("meta-llama/llama-3.1-405b-instruct") is None
+
+
+def test_unprefixed_non_gemini_model_unaffected_by_normalization():
+    """claude-sonnet-4-6 (no provider prefix, not Gemini) resolves identically before/after.
+
+    The normalization triggers only when the model id starts with "google/"
+    or "gemini-". Anything else must take the original lookup path and
+    produce its existing price. Catches the failure mode where the alt-form
+    branch is reached for models that shouldn't be normalized at all.
+    """
+    base = pricing._lookup_base("claude-sonnet-4-6")
+    assert base is not None
+    # Direct cost via estimate_cost should match the fixture's claude-sonnet-4-6 entry
+    # (input=3.0, output=15.0).
+    cost = pricing.estimate_cost(
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        "claude-sonnet-4-6",
+    )
+    assert abs(cost - (3.0 + 15.0)) < 1e-9
+
+    # And the alt-form helper must return None for non-Gemini, non-google/* ids.
+    assert pricing._google_alt_form("claude-sonnet-4-6") is None
+    assert pricing._google_alt_form("anthropic/claude-sonnet-4-6") is None
+    assert pricing._google_alt_form("meta-llama/llama-3.1-405b-instruct") is None


### PR DESCRIPTION
## Summary

Closes the `gemini-X` ↔ `google/gemini-X` asymmetry you flagged on #4 (the "PR 2" of the original plan from #2). Lookups via either form now hit the same pricing entry without requiring both keys to coexist in the data.

Tracking issue: #2.

## Why

`_DEFAULT_PRICING` only carries bare `gemini-*` keys. Before this change, calling `google/gemini-3-flash-preview` before OpenRouter's auto-refresh had populated `pricing.yaml` would miss every level of the lookup — exact match fails, prefix scan is blocked by the `google/` prefix in front — and fall through to the unknown-model warning.

This mostly bites in three cases the existing auto-refresh pipeline doesn't cover:

- **Fresh install** before any source has run.
- **Single-source setups** where one of OpenRouterSource / GoogleAISource is disabled.
- **Manual `pricing.yaml` edits** where a user adds only one of the two forms.

#14 (GoogleAISource) populates the bare entries via auto-refresh, so in the steady state both forms coexist and direct lookups already hit. This PR is the defense-in-depth I mentioned in #14's body — same surface, different mechanism, both useful.

## What changed

**`pricing.py`**

- Extracted the existing exact-then-prefix scan into a private `_lookup_form(model_lc)` helper. Behavior unchanged.
- `_lookup_base` now does a two-pass lookup: model as-is, then the Google-alt form if it applies.
- New `_google_alt_form(model_lc)` returns the alternate Google-AI form (`gemini-X` ↔ `google/gemini-X`) or `None`. Only this pair is normalized — other provider prefixes (`anthropic/`, `meta-llama/`, `openrouter/`) are never stripped.

```python
def _lookup_base(model: str) -> dict | None:
    model_lc = model.lower()
    result = _lookup_form(model_lc)
    if result is not None:
        return result
    alt = _google_alt_form(model_lc)
    if alt is not None:
        return _lookup_form(alt)
    return None
```

The two-pass shape (as-is first, alt second) preserves precedence: if a user has an explicit `google/gemini-3-flash-preview` override in `pricing.yaml`, it still wins over the bare `_DEFAULT_PRICING` entry.

## Tests (the three cases you flagged in #2)

**1. `gemini-3-flash-preview` ↔ `google/gemini-3-flash-preview` resolve to the same entry**
- `_lookup_base` returns the same dict for both forms.
- `estimate_cost` produces identical dollar amounts end-to-end.

**2. `meta-llama/llama-3.1-405b-instruct` keeps resolving to its own exact entry**
- The exact entry in `_DEFAULT_PRICING` is still authoritative (same dict before and after).
- A non-existent `meta-llama/llama-99-imaginary` stays `None` — a naive provider-strip would have mis-normalized it onto the bare `llama-3.1-405` prefix table. Confirms the normalization is google-specific.
- `_google_alt_form("meta-llama/...")` returns `None`.

**3. Models without any provider prefix (`claude-sonnet-4-6`) are unaffected**
- Same `_lookup_base` dict, same `estimate_cost` output as before.
- `_google_alt_form` returns `None` for `claude-sonnet-4-6` and for `anthropic/claude-sonnet-4-6`.

All three pass:

```
$ pytest tests/test_pricing.py -v -k "google or normalization or non_google or unprefixed"
collected 38 items / 35 deselected / 3 selected

tests/test_pricing.py::test_google_prefix_and_bare_form_resolve_to_same_price PASSED [ 33%]
tests/test_pricing.py::test_non_google_provider_prefix_resolves_to_its_own_entry PASSED [ 66%]
tests/test_pricing.py::test_unprefixed_non_gemini_model_unaffected_by_normalization PASSED [100%]

======================= 3 passed, 35 deselected in 0.03s =======================
```

Full pricing suite stays green on the changed files (`ruff check . && ruff format --check .` clean).

## Out of scope

- **Generalizing to other provider prefixes.** This PR is explicitly google-only. If you later want a registry of "alias pairs" (e.g. `openai/gpt-4o` ↔ `gpt-4o`), it's a small extension of `_google_alt_form` — happy to follow up if you want it.
- **Auto-refresh changes.** `_load_custom_pricing` still loads `pricing.yaml` unchanged; the merge logic in `pricing_refresh.py` is untouched.
- **`_PREFIX_PRICING` consolidation.** Could be revisited once the alt-form pattern is established, but keeping it intact for this PR.

## Relationship to #14

#14 (`GoogleAISource`) and this PR are complementary:

- **#14** populates `pricing.yaml` with bare `gemini-*` entries on each refresh, so post-refresh both routing paths hit their own key directly.
- **This PR** closes the gap when one of the two keys is missing — fresh installs, disabled sources, single-form manual edits.

After both ship, every Gemini lookup hits the right price regardless of routing path, refresh state, or which sources are registered.
