### PR TITLE
feat(budget): add dashboard editor + file watcher for hot-reload

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -142,6 +142,11 @@ def register(ctx) -> None:  # noqa: ANN001
     from . import budget, db, pricing, setup, stats
 
     # ------------------------------------------------------------------
+    # Start budget file watcher (hot-reload on budget.yaml changes)
+    # ------------------------------------------------------------------
+    budget.start_budget_watcher()
+
+    # ------------------------------------------------------------------
     # Auto-refresh pricing from remote sources (once per 24h)
     # ------------------------------------------------------------------
     _try_pricing_refresh(tele_log)

--- a/budget.py
+++ b/budget.py
@@ -478,6 +478,7 @@ def _cron_block() -> str:
 
 def _set_budget(scope: str, window: str, usd: float) -> str:
     """Persist a limit to budget.yaml and hot-reload."""
+    import os
     import yaml
 
     if scope not in ("global", "cron_job", "sender"):
@@ -503,8 +504,12 @@ def _set_budget(scope: str, window: str, usd: float) -> str:
     else:  # sender
         budgets.setdefault("per_sender", {}).setdefault("default", {})[key] = usd
 
-    with open(path, "w") as f:
+    # Atomic write: temp file + os.replace (POSIX atomic)
+    # Prevents watchdog from reading partial/empty YAML on IN_MODIFY
+    tmp = path.with_suffix(".yaml.tmp")
+    with open(tmp, "w") as f:
         yaml.safe_dump(raw, f, default_flow_style=False, sort_keys=False)
+    os.replace(tmp, path)
     reload_config()
     return f"Set {scope} {window} budget to ${usd:.2f}. Saved to {path}."
 

--- a/budget.py
+++ b/budget.py
@@ -38,6 +38,49 @@ from . import db
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# File watcher for budget.yaml (hot-reload on config changes)
+# ---------------------------------------------------------------------------
+_budget_observer = None
+_budget_watcher_started = False
+
+def start_budget_watcher() -> None:
+    """Start a background file watcher on budget.yaml to auto-reload config on changes."""
+    global _budget_observer, _budget_watcher_started
+    if _budget_watcher_started:
+        return
+    try:
+        from watchdog.observers import Observer
+        from watchdog.events import FileSystemEventHandler, FileModifiedEvent
+    except Exception as exc:
+        logger.debug("budget watcher unavailable (watchdog not installed): %s", exc)
+        return
+
+    class BudgetConfigHandler(FileSystemEventHandler):
+        def on_modified(self, event: FileModifiedEvent) -> None:
+            if not event.is_directory and event.src_path.endswith("budget.yaml"):
+                logger.info("budget.yaml modified — hot-reloading budget config")
+                reload_config()
+
+    path = _budget_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _budget_observer = Observer()
+    _budget_observer.schedule(BudgetConfigHandler(), str(path.parent), recursive=False)
+    _budget_observer.daemon = True
+    _budget_observer.start()
+    _budget_watcher_started = True
+    logger.info("Budget file watcher started on %s", path)
+
+def stop_budget_watcher() -> None:
+    """Stop the budget file watcher (for cleanup/tests)."""
+    global _budget_observer, _budget_watcher_started
+    if _budget_observer:
+        _budget_observer.stop()
+        _budget_observer.join(timeout=2)
+        _budget_observer = None
+    _budget_watcher_started = False
+
+
+# ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
 _DEFAULT_THRESHOLDS = {"soft_pct": 0.80, "hard_pct": 1.00}

--- a/budget.py
+++ b/budget.py
@@ -56,10 +56,21 @@ def start_budget_watcher() -> None:
         return
 
     class BudgetConfigHandler(FileSystemEventHandler):
-        def on_modified(self, event: FileModifiedEvent) -> None:
-            if not event.is_directory and event.src_path.endswith("budget.yaml"):
-                logger.info("budget.yaml modified — hot-reloading budget config")
+        def _reload_if_budget(self, path: str) -> None:
+            if os.path.basename(path) == "budget.yaml":
+                logger.info("budget.yaml changed — hot-reloading budget config")
                 reload_config()
+
+        def on_modified(self, event: FileModifiedEvent) -> None:
+            if not event.is_directory:
+                self._reload_if_budget(event.src_path)
+
+        def on_created(self, event) -> None:
+            if not event.is_directory:
+                self._reload_if_budget(event.src_path)
+
+        def on_moved(self, event) -> None:
+            self._reload_if_budget(getattr(event, "dest_path", ""))
 
     path = _budget_path()
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -204,18 +204,40 @@ function renderStatCard(id, value, label, cls) {
 
 // Budget modal functions
 let currentBudgetScope = 'global';
+let currentBudgetWindow = 'daily';
 
-function openBudgetModal(scope) {
+async function openBudgetModal(scope) {
   currentBudgetScope = scope;
   $('#budgetScope').value = scope;
   $('#budgetModalError').classList.remove('show');
   $('#budgetModalError').textContent = '';
-  // Reset other fields to defaults
-  $('#budgetWindow').value = 'daily';
-  $('#budgetLimit').value = '';
-  $('#budgetSoftPct').value = '';
-  $('#budgetHardPct').value = '';
-  $('#budgetOnEstimated').value = 'warn_only';
+
+  // Fetch current budget details for pre-fill
+  try {
+    const res = await fetch(`/api/budget/detail?scope=${encodeURIComponent(scope)}&window=${encodeURIComponent($('#budgetWindow').value)}`);
+    const data = await res.json();
+    if (!data.error) {
+      $('#budgetLimit').value = data.limit_usd !== null && data.limit_usd !== undefined ? data.limit_usd : '';
+      $('#budgetSoftPct').value = data.soft_pct !== undefined ? data.soft_pct : '';
+      $('#budgetHardPct').value = data.hard_pct !== undefined ? data.hard_pct : '';
+      $('#budgetOnEstimated').value = data.on_estimated_mode || 'warn_only';
+    } else {
+      // Fallback to defaults on error
+      $('#budgetWindow').value = 'daily';
+      $('#budgetLimit').value = '';
+      $('#budgetSoftPct').value = '';
+      $('#budgetHardPct').value = '';
+      $('#budgetOnEstimated').value = 'warn_only';
+    }
+  } catch {
+    // Fallback to defaults on network error
+    $('#budgetWindow').value = 'daily';
+    $('#budgetLimit').value = '';
+    $('#budgetSoftPct').value = '';
+    $('#budgetHardPct').value = '';
+    $('#budgetOnEstimated').value = 'warn_only';
+  }
+
   $('#budgetModal').classList.add('open');
 }
 
@@ -224,16 +246,22 @@ function closeBudgetModal() {
 }
 
 async function saveBudget() {
+  // Helper: parse float, return undefined if empty/whitespace
+  const parseOptFloat = (v) => {
+    const s = v.trim();
+    return s === '' ? undefined : parseFloat(s);
+  };
+
   const payload = {
     scope: $('#budgetScope').value,
     window: $('#budgetWindow').value,
-    limit_usd: parseFloat($('#budgetLimit').value),
-    soft_pct: parseFloat($('#budgetSoftPct').value) || undefined,
-    hard_pct: parseFloat($('#budgetHardPct').value) || undefined,
+    limit_usd: parseOptFloat($('#budgetLimit').value),
+    soft_pct: parseOptFloat($('#budgetSoftPct').value),
+    hard_pct: parseOptFloat($('#budgetHardPct').value),
     on_estimated_mode: $('#budgetOnEstimated').value
   };
 
-  if (isNaN(payload.limit_usd)) {
+  if (payload.limit_usd === undefined || isNaN(payload.limit_usd)) {
     showModalError('Limit (USD) is required');
     return;
   }
@@ -271,8 +299,10 @@ function renderBudget(data) {
   let html = '<div class="budget-bar"><h3>Budgets</h3>';
   for (const s of items) {
     const cls = s.level;
+    // Escape scope for safe JS string context in onclick attribute
+    const safeScope = JSON.stringify(s.scope);
     html += `<div class="budget-item">
-      <div class="info"><span>${s.scope}</span><span>${fmtCost(s.spent)} / ${fmtCost(s.limit)} (${s.pct}%)</span><button class="budget-edit-btn" onclick="openBudgetModal('${s.scope}')">Edit</button></div>
+      <div class="info"><span>${s.scope}</span><span>${fmtCost(s.spent)} / ${fmtCost(s.limit)} (${s.pct}%)</span><button class="budget-edit-btn" onclick="openBudgetModal(${safeScope})">Edit</button></div>
       <div class="bar-bg"><div class="bar-fill ${cls}" style="width:${Math.min(s.pct, 100)}%"></div></div>
     </div>`;
   }
@@ -287,8 +317,7 @@ function renderTokenBreakdown(data) {
   const types = [
     { key: 'tokens_in', label: 'Input', color: '#58a6ff' },
     { key: 'tokens_out', label: 'Output', color: '#3fb950' },
-    { key: 'cache_read_tokens', label: 'Cache Read', color: '#d29922' },
-    { key: 'cache_write_tokens', label: 'Cache Write', color: '#bc8cff' },
+    { key: 'cache_read_tokens', label: 'Cache', color: '#d29922' },
     { key: 'reasoning_tokens', label: 'Reasoning', color: '#f85149' },
   ];
   for (const t of types) {
@@ -427,23 +456,23 @@ async function loadAll() {
 
     // --- cron table ---
     if (cron.length) {
-      let t = '<table><thead><tr><th>Job ID</th><th>Runs</th><th>OK</th><th>Fail</th><th>In</th><th>Out</th><th>Cache R</th><th>Cache W</th><th>Cost</th><th>Avg Dur</th><th>Last Run</th></tr></thead><tbody>';
+      let t = '<table><thead><tr><th>Job ID</th><th>Runs</th><th>OK</th><th>Fail</th><th>In</th><th>Out</th><th>Cache</th><th>Cost</th><th>Avg Dur</th><th>Last Run</th></tr></thead><tbody>';
       for (const row of cron) {
         const jid = (row.cron_job_id || '?').substring(0, 20);
         const last = (row.last_run || '').substring(0, 16);
-        t += `<tr><td><code>${jid}</code></td><td>${nf(row.runs)}</td><td>${nf(row.ok_runs)}</td><td>${nf(row.failed_runs)}</td><td>${nf(row.tokens_in)}</td><td>${nf(row.tokens_out)}</td><td>${nf(row.cache_read_tokens || 0)}</td><td>${nf(row.cache_write_tokens || 0)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.avg_duration_ms)}</td><td class="text-muted">${last}</td></tr>`;
+        t += `<tr><td><code>${jid}</code></td><td>${nf(row.runs)}</td><td>${nf(row.ok_runs)}</td><td>${nf(row.failed_runs)}</td><td>${nf(row.tokens_in)}</td><td>${nf(row.tokens_out)}</td><td>${nf(row.cache_read_tokens || 0)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.avg_duration_ms)}</td><td class="text-muted">${last}</td></tr>`;
       }
       t += '</tbody></table>';
       html += renderTableCard('cronTable', 'Cron Jobs', t);
     }
 
     // --- runs table ---
-    let t = '<table><thead><tr><th>Time</th><th>Platform</th><th>Model</th><th>Status</th><th>In</th><th>Out</th><th>Cache R</th><th>Cache W</th><th>Cost</th><th>Duration</th><th>Session ID</th></tr></thead><tbody>';
+    let t = '<table><thead><tr><th>Time</th><th>Platform</th><th>Model</th><th>Status</th><th>In</th><th>Out</th><th>Cache</th><th>Cost</th><th>Duration</th><th>Session ID</th></tr></thead><tbody>';
     for (const row of runs) {
       const time = (row.started_at || '').substring(0, 16);
       const sid = (row.session_id || '').substring(0, 24);
       const model = (row.model || '—').substring(0, 20);
-      t += `<tr><td class="text-muted">${time}</td><td>${platformBadge(row.platform)}</td><td class="text-muted">${model}</td><td>${statusBadge(row.status)}</td><td>${nf(row.tokens_in)}</td><td>${nf(row.tokens_out)}</td><td>${nf(row.cache_read_tokens || 0)}</td><td>${nf(row.cache_write_tokens || 0)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.duration_ms)}</td><td><code title="${row.session_id}">${sid}</code></td></tr>`;
+      t += `<tr><td class="text-muted">${time}</td><td>${platformBadge(row.platform)}</td><td class="text-muted">${model}</td><td>${statusBadge(row.status)}</td><td>${nf(row.tokens_in)}</td><td>${nf(row.tokens_out)}</td><td>${nf(row.cache_read_tokens || 0)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.duration_ms)}</td><td><code title="${row.session_id}">${sid}</code></td></tr>`;
     }
     t += '</tbody></table>';
     html += renderTableCard('runsTable', 'Recent Sessions', t);

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -42,7 +42,11 @@
   .bar-fill.hard { background: #f85149; }
   .budget-disabled { color: #8b949e; font-size: 13px; }
 
-  .budget-edit-btn { background: #21262d; color: #58a6ff; border: 1px solid #30363d; border-radius: 4px; padding: 2px 8px; font-size: 11px; cursor: pointer; margin-left: 8px; }
+  .budget-item { display: flex; flex-direction: column; gap: 8px; }
+  .budget-item .info { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+  .budget-item .info span:first-child { text-align: left; }
+  .budget-item .info span:last-of-type { flex: 0 0 auto; text-align: right; }
+  .budget-edit-btn { background: #21262d; color: #58a6ff; border: 1px solid #30363d; border-radius: 4px; padding: 2px 8px; font-size: 11px; cursor: pointer; margin-left: 12px; white-space: nowrap; }
   .budget-edit-btn:hover { background: #30363d; }
 
   /* Budget modal */
@@ -268,9 +272,8 @@ function renderBudget(data) {
   for (const s of items) {
     const cls = s.level;
     html += `<div class="budget-item">
-      <div class="info"><span>${s.scope}</span><span>${fmtCost(s.spent)} / ${fmtCost(s.limit)} (${s.pct}%)</span></div>
+      <div class="info"><span>${s.scope}</span><span>${fmtCost(s.spent)} / ${fmtCost(s.limit)} (${s.pct}%)</span><button class="budget-edit-btn" onclick="openBudgetModal('${s.scope}')">Edit</button></div>
       <div class="bar-bg"><div class="bar-fill ${cls}" style="width:${Math.min(s.pct, 100)}%"></div></div>
-      <button class="budget-edit-btn" onclick="openBudgetModal('${s.scope}')">Edit</button>
     </div>`;
   }
   html += `<div class="budget-disabled" style="margin-top:8px">on_estimated: ${data.on_estimated}</div></div>`;

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -50,9 +50,9 @@
   .budget-edit-btn:hover { background: #30363d; }
 
   /* Budget modal */
-  .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.7); display: none; align-items: center; justify-content: center; z-index: 1000; }
-  .modal-overlay.open { display: flex; }
-  .modal { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 24px; width: 100%; max-width: 400px; margin: 16px; }
+  .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.7); display: none; align-items: center; justify-content: center; z-index: 99999; }
+  .modal-overlay.open { display: flex !important; }
+  .modal { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 24px; width: 100%; max-width: 400px; margin: 16px; box-shadow: 0 8px 32px rgba(0,0,0,0.5); }
   .modal h3 { color: #e6edf3; margin-bottom: 16px; font-size: 16px; }
   .modal .form-group { margin-bottom: 16px; }
   .modal label { display: block; color: #8b949e; font-size: 12px; margin-bottom: 4px; }
@@ -207,38 +207,35 @@ let currentBudgetScope = 'global';
 let currentBudgetWindow = 'daily';
 
 async function openBudgetModal(scope) {
-  currentBudgetScope = scope;
-  $('#budgetScope').value = scope;
+  // Parse "global/daily" -> scope="global", window="daily"
+  const [parsedScope, parsedWindow] = scope.split('/');
+  const actualScope = parsedScope || scope;
+  const actualWindow = parsedWindow || 'daily';
+
+  currentBudgetScope = actualScope;
+  currentBudgetWindow = actualWindow;
+
+  // Open modal FIRST (synchronous, works even if fetch fails)
+  $('#budgetModal').classList.add('open');
+
+  $('#budgetScope').value = actualScope;
+  $('#budgetWindow').value = actualWindow;  // set window before fetch
   $('#budgetModalError').classList.remove('show');
   $('#budgetModalError').textContent = '';
 
-  // Fetch current budget details for pre-fill
+  // Then fetch details for pre-fill (async, non-blocking)
   try {
-    const res = await fetch(`/api/budget/detail?scope=${encodeURIComponent(scope)}&window=${encodeURIComponent($('#budgetWindow').value)}`);
+    const res = await fetch(`/api/budget/detail?scope=${encodeURIComponent(actualScope)}&window=${encodeURIComponent(actualWindow)}`);
     const data = await res.json();
     if (!data.error) {
       $('#budgetLimit').value = data.limit_usd !== null && data.limit_usd !== undefined ? data.limit_usd : '';
       $('#budgetSoftPct').value = data.soft_pct !== undefined ? data.soft_pct : '';
       $('#budgetHardPct').value = data.hard_pct !== undefined ? data.hard_pct : '';
       $('#budgetOnEstimated').value = data.on_estimated_mode || 'warn_only';
-    } else {
-      // Fallback to defaults on error
-      $('#budgetWindow').value = 'daily';
-      $('#budgetLimit').value = '';
-      $('#budgetSoftPct').value = '';
-      $('#budgetHardPct').value = '';
-      $('#budgetOnEstimated').value = 'warn_only';
     }
   } catch {
-    // Fallback to defaults on network error
-    $('#budgetWindow').value = 'daily';
-    $('#budgetLimit').value = '';
-    $('#budgetSoftPct').value = '';
-    $('#budgetHardPct').value = '';
-    $('#budgetOnEstimated').value = 'warn_only';
+    // Keep defaults on network error - modal already open
   }
-
-  $('#budgetModal').classList.add('open');
 }
 
 function closeBudgetModal() {
@@ -299,10 +296,10 @@ function renderBudget(data) {
   let html = '<div class="budget-bar"><h3>Budgets</h3>';
   for (const s of items) {
     const cls = s.level;
-    // Escape scope for safe JS string context in onclick attribute
-    const safeScope = JSON.stringify(s.scope);
+    // Use single quotes in onclick to avoid JSON.stringify double-quote escaping issues
+    const safeScope = s.scope.replace(/'/g, "\\'");
     html += `<div class="budget-item">
-      <div class="info"><span>${s.scope}</span><span>${fmtCost(s.spent)} / ${fmtCost(s.limit)} (${s.pct}%)</span><button class="budget-edit-btn" onclick="openBudgetModal(${safeScope})">Edit</button></div>
+      <div class="info"><span>${s.scope}</span><span>${fmtCost(s.spent)} / ${fmtCost(s.limit)} (${s.pct}%)</span><button class="budget-edit-btn" onclick="openBudgetModal('${safeScope}')">Edit</button></div>
       <div class="bar-bg"><div class="bar-fill ${cls}" style="width:${Math.min(s.pct, 100)}%"></div></div>
     </div>`;
   }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -42,6 +42,29 @@
   .bar-fill.hard { background: #f85149; }
   .budget-disabled { color: #8b949e; font-size: 13px; }
 
+  .budget-edit-btn { background: #21262d; color: #58a6ff; border: 1px solid #30363d; border-radius: 4px; padding: 2px 8px; font-size: 11px; cursor: pointer; margin-left: 8px; }
+  .budget-edit-btn:hover { background: #30363d; }
+
+  /* Budget modal */
+  .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.7); display: none; align-items: center; justify-content: center; z-index: 1000; }
+  .modal-overlay.open { display: flex; }
+  .modal { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 24px; width: 100%; max-width: 400px; margin: 16px; }
+  .modal h3 { color: #e6edf3; margin-bottom: 16px; font-size: 16px; }
+  .modal .form-group { margin-bottom: 16px; }
+  .modal label { display: block; color: #8b949e; font-size: 12px; margin-bottom: 4px; }
+  .modal select, .modal input { width: 100%; background: #21262d; color: #c9d1d9; border: 1px solid #30363d; border-radius: 6px; padding: 8px 12px; font-size: 13px; box-sizing: border-box; }
+  .modal select:focus, .modal input:focus { outline: none; border-color: #58a6ff; }
+  .modal .form-row { display: flex; gap: 8px; }
+  .modal .form-row .form-group { flex: 1; }
+  .modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 24px; }
+  .modal-btn { padding: 8px 16px; border-radius: 6px; font-size: 13px; cursor: pointer; border: 1px solid #30363d; }
+  .modal-btn.cancel { background: #21262d; color: #c9d1d9; }
+  .modal-btn.cancel:hover { background: #30363d; }
+  .modal-btn.save { background: #238636; color: #fff; }
+  .modal-btn.save:hover { background: #2ea043; }
+  .modal-error { color: #f85149; font-size: 12px; margin-top: 8px; display: none; }
+  .modal-error.show { display: block; }
+
   /* charts */
   .chart-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 24px; }
   .chart-card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 20px; }
@@ -94,6 +117,54 @@
   <div class="loading">Loading...</div>
 </div>
 
+<!-- Budget Modal -->
+<div class="modal-overlay" id="budgetModal" onclick="if(event.target===this) closeBudgetModal()">
+  <div class="modal" onclick="event.stopPropagation()">
+    <h3>Edit Budget</h3>
+    <div class="form-group">
+      <label>Scope</label>
+      <select id="budgetScope">
+        <option value="global">Global</option>
+        <option value="per_cron_job">Per Cron Job (default)</option>
+        <option value="per_sender">Per Sender</option>
+      </select>
+    </div>
+    <div class="form-group">
+      <label>Window</label>
+      <select id="budgetWindow">
+        <option value="daily">Daily</option>
+        <option value="monthly">Monthly</option>
+      </select>
+    </div>
+    <div class="form-group">
+      <label>Limit (USD)</label>
+      <input type="number" id="budgetLimit" step="0.01" min="0" placeholder="e.g. 5.00">
+    </div>
+    <div class="form-row">
+      <div class="form-group">
+        <label>Soft threshold (%)</label>
+        <input type="number" id="budgetSoftPct" step="0.01" min="0" max="1" placeholder="0.80">
+      </div>
+      <div class="form-group">
+        <label>Hard threshold (%)</label>
+        <input type="number" id="budgetHardPct" step="0.01" min="0" max="1" placeholder="1.00">
+      </div>
+    </div>
+    <div class="form-group">
+      <label>On estimated data</label>
+      <select id="budgetOnEstimated">
+        <option value="warn_only">Warn only (degrade hard to soft)</option>
+        <option value="enforce">Enforce hard limits</option>
+      </select>
+    </div>
+    <div class="modal-error" id="budgetModalError"></div>
+    <div class="modal-actions">
+      <button class="modal-btn cancel" onclick="closeBudgetModal()">Cancel</button>
+      <button class="modal-btn save" onclick="saveBudget()">Save</button>
+    </div>
+  </div>
+</div>
+
 <script>
 const API = '';
 let charts = {};
@@ -127,6 +198,68 @@ function renderStatCard(id, value, label, cls) {
   return `<div class="stat-card ${cls}"><div class="value">${value}</div><div class="label">${label}</div></div>`;
 }
 
+// Budget modal functions
+let currentBudgetScope = 'global';
+
+function openBudgetModal(scope) {
+  currentBudgetScope = scope;
+  $('#budgetScope').value = scope;
+  $('#budgetModalError').classList.remove('show');
+  $('#budgetModalError').textContent = '';
+  // Reset other fields to defaults
+  $('#budgetWindow').value = 'daily';
+  $('#budgetLimit').value = '';
+  $('#budgetSoftPct').value = '';
+  $('#budgetHardPct').value = '';
+  $('#budgetOnEstimated').value = 'warn_only';
+  $('#budgetModal').classList.add('open');
+}
+
+function closeBudgetModal() {
+  $('#budgetModal').classList.remove('open');
+}
+
+async function saveBudget() {
+  const payload = {
+    scope: $('#budgetScope').value,
+    window: $('#budgetWindow').value,
+    limit_usd: parseFloat($('#budgetLimit').value),
+    soft_pct: parseFloat($('#budgetSoftPct').value) || undefined,
+    hard_pct: parseFloat($('#budgetHardPct').value) || undefined,
+    on_estimated_mode: $('#budgetOnEstimated').value
+  };
+
+  if (isNaN(payload.limit_usd)) {
+    showModalError('Limit (USD) is required');
+    return;
+  }
+
+  $('#budgetModalError').classList.remove('show');
+
+  try {
+    const response = await fetch('/api/budget', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const result = await response.json();
+    if (result.error) {
+      showModalError(result.error);
+      return;
+    }
+    closeBudgetModal();
+    loadAll(); // refresh dashboard
+  } catch (err) {
+    showModalError('Request failed: ' + err.message);
+  }
+}
+
+function showModalError(msg) {
+  const el = $('#budgetModalError');
+  el.textContent = msg;
+  el.classList.add('show');
+}
+
 function renderBudget(data) {
   if (!data.enabled) return '<div class="budget-bar"><h3>Budgets</h3><div class="budget-disabled">No budget.yaml configured. Create ~/.hermes/telemetry/budget.yaml</div></div>';
   const items = data.budgets || [];
@@ -137,6 +270,7 @@ function renderBudget(data) {
     html += `<div class="budget-item">
       <div class="info"><span>${s.scope}</span><span>${fmtCost(s.spent)} / ${fmtCost(s.limit)} (${s.pct}%)</span></div>
       <div class="bar-bg"><div class="bar-fill ${cls}" style="width:${Math.min(s.pct, 100)}%"></div></div>
+      <button class="budget-edit-btn" onclick="openBudgetModal('${s.scope}')">Edit</button>
     </div>`;
   }
   html += `<div class="budget-disabled" style="margin-top:8px">on_estimated: ${data.on_estimated}</div></div>`;

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -146,11 +146,11 @@
     </div>
     <div class="form-row">
       <div class="form-group">
-        <label>Soft threshold (%) <span class="text-muted" style="font-size:10px;font-weight:400">(global)</span></label>
+        <label>Soft threshold (%) <span class="text-muted" style="font-size:10px;font-weight:400">(applies to all scopes)</span></label>
         <input type="number" id="budgetSoftPct" step="0.01" min="0" max="1" placeholder="0.80">
       </div>
       <div class="form-group">
-        <label>Hard threshold (%) <span class="text-muted" style="font-size:10px;font-weight:400">(global)</span></label>
+        <label>Hard threshold (%) <span class="text-muted" style="font-size:10px;font-weight:400">(applies to all scopes)</span></label>
         <input type="number" id="budgetHardPct" step="0.01" min="0" max="1" placeholder="1.00">
       </div>
     </div>
@@ -174,6 +174,14 @@ const API = '';
 let charts = {};
 
 function $(sel) { return document.querySelector(sel); }
+function escHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
 function nf(n) { return n == null ? '—' : Number(n).toLocaleString(); }
 function fmtCost(v) { return v == null ? '$0.00' : '$' + Number(v).toFixed(4); }
 function fmtMs(v) {
@@ -302,10 +310,11 @@ function renderBudget(data) {
   let html = '<div class="budget-bar"><h3>Budgets</h3>';
   for (const s of items) {
     const cls = s.level;
+    const label = escHtml(s.scope);
     // Use single quotes in onclick to avoid JSON.stringify double-quote escaping issues
     const safeScope = s.scope.replace(/'/g, "\\'");
     html += `<div class="budget-item">
-      <div class="info"><span>${s.scope}</span><span>${fmtCost(s.spent)} / ${fmtCost(s.limit)} (${s.pct}%)</span><button class="budget-edit-btn" onclick="openBudgetModal('${safeScope}')">Edit</button></div>
+      <div class="info"><span>${label}</span><span>${fmtCost(s.spent)} / ${fmtCost(s.limit)} (${s.pct}%)</span><button class="budget-edit-btn" onclick="openBudgetModal('${safeScope}')">Edit</button></div>
       <div class="bar-bg"><div class="bar-fill ${cls}" style="width:${Math.min(s.pct, 100)}%"></div></div>
     </div>`;
   }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -146,11 +146,11 @@
     </div>
     <div class="form-row">
       <div class="form-group">
-        <label>Soft threshold (%)</label>
+        <label>Soft threshold (%) <span class="text-muted" style="font-size:10px;font-weight:400">(global)</span></label>
         <input type="number" id="budgetSoftPct" step="0.01" min="0" max="1" placeholder="0.80">
       </div>
       <div class="form-group">
-        <label>Hard threshold (%)</label>
+        <label>Hard threshold (%) <span class="text-muted" style="font-size:10px;font-weight:400">(global)</span></label>
         <input type="number" id="budgetHardPct" step="0.01" min="0" max="1" placeholder="1.00">
       </div>
     </div>
@@ -204,7 +204,6 @@ function renderStatCard(id, value, label, cls) {
 
 // Budget modal functions
 let currentBudgetScope = 'global';
-let currentBudgetWindow = 'daily';
 
 async function openBudgetModal(scope) {
   // Parse "global/daily" -> scope="global", window="daily"
@@ -213,28 +212,35 @@ async function openBudgetModal(scope) {
   const actualWindow = parsedWindow || 'daily';
 
   currentBudgetScope = actualScope;
-  currentBudgetWindow = actualWindow;
 
   // Open modal FIRST (synchronous, works even if fetch fails)
   $('#budgetModal').classList.add('open');
 
+  // Reset fields immediately - no waiting
   $('#budgetScope').value = actualScope;
-  $('#budgetWindow').value = actualWindow;  // set window before fetch
+  $('#budgetWindow').value = 'daily';  // reset window dropdown to daily
+  $('#budgetLimit').value = '';
+  $('#budgetSoftPct').value = '';
+  $('#budgetHardPct').value = '';
+  $('#budgetOnEstimated').value = 'warn_only';
   $('#budgetModalError').classList.remove('show');
   $('#budgetModalError').textContent = '';
 
   // Then fetch details for pre-fill (async, non-blocking)
+  // Always fetch window=daily as default — avoids stale dropdown state bug
   try {
-    const res = await fetch(`/api/budget/detail?scope=${encodeURIComponent(actualScope)}&window=${encodeURIComponent(actualWindow)}`);
+    const res = await fetch(`/api/budget/detail?scope=${encodeURIComponent(actualScope)}&window=daily`);
     const data = await res.json();
     if (!data.error) {
       $('#budgetLimit').value = data.limit_usd !== null && data.limit_usd !== undefined ? data.limit_usd : '';
       $('#budgetSoftPct').value = data.soft_pct !== undefined ? data.soft_pct : '';
       $('#budgetHardPct').value = data.hard_pct !== undefined ? data.hard_pct : '';
       $('#budgetOnEstimated').value = data.on_estimated_mode || 'warn_only';
+      // Set window dropdown to match the fetched data's window if needed
+      // Budget config has separate daily/monthly limits per scope
     }
   } catch {
-    // Keep defaults on network error - modal already open
+    // Keep defaults on network error - modal already open with empty fields
   }
 }
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -280,6 +280,27 @@ function renderBudget(data) {
   return html;
 }
 
+function renderTokenBreakdown(data) {
+  const tb = data;
+  let html = '<div class="table-card"><h3>Token Breakdown</h3>';
+  html += '<table><thead><tr><th>Type</th><th class="text-right">Count</th><th class="text-right">%</th></tr></thead><tbody>';
+  const types = [
+    { key: 'tokens_in', label: 'Input', color: '#58a6ff' },
+    { key: 'tokens_out', label: 'Output', color: '#3fb950' },
+    { key: 'cache_read_tokens', label: 'Cache Read', color: '#d29922' },
+    { key: 'cache_write_tokens', label: 'Cache Write', color: '#bc8cff' },
+    { key: 'reasoning_tokens', label: 'Reasoning', color: '#f85149' },
+  ];
+  for (const t of types) {
+    const val = tb[t.key] || 0;
+    const pct = tb.total_tokens > 0 ? ((val / tb.total_tokens) * 100).toFixed(1) : '0.0';
+    html += `<tr><td><span style="display:inline-block;width:12px;height:12px;border-radius:3px;background:${t.color};margin-right:8px;vertical-align:middle"></span>${t.label}</td><td class="text-right">${nf(val)}</td><td class="text-right">${pct}%</td></tr>`;
+  }
+  html += `<tr style="border-top:1px solid #30363d"><td><b>Total</b></td><td class="text-right"><b>${nf(tb.total_tokens)}</b></td><td class="text-right"><b>100%</b></td></tr>`;
+  html += '</tbody></table></div>';
+  return html;
+}
+
 function renderChartCard(id, title, canvasId) {
   return `<div class="chart-card"><h3>${title}</h3><canvas id="${canvasId}"></canvas></div>`;
 }
@@ -350,12 +371,13 @@ async function loadAll() {
   app.innerHTML = '<div class="loading">Loading...</div>';
 
   try {
-    const [summary, cron, providers, runs, budget] = await Promise.all([
+    const [summary, cron, providers, runs, budget, tokenBreakdown] = await Promise.all([
       fetchJSON(`/api/summary?hours=${hours}`),
       fetchJSON(`/api/cron?hours=${hours}`),
       fetchJSON(`/api/providers?hours=${hours}`),
       fetchJSON('/api/runs?limit=30'),
       fetchJSON('/api/budget'),
+      fetchJSON(`/api/token-breakdown?hours=${hours}`),
     ]);
 
     const r = summary.runs || {};
@@ -370,6 +392,11 @@ async function loadAll() {
     html += renderStatCard('tokens', nf(r.tokens_in), 'Tokens In', '');
     html += renderStatCard('cost', fmtCost(r.cost_usd), 'Cost', 'yellow');
     html += '</div>';
+
+    // --- token breakdown ---
+    if (tokenBreakdown && tokenBreakdown.total_tokens > 0) {
+      html += renderTokenBreakdown(tokenBreakdown);
+    }
 
     // --- budget ---
     html += renderBudget(budget);

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -427,23 +427,23 @@ async function loadAll() {
 
     // --- cron table ---
     if (cron.length) {
-      let t = '<table><thead><tr><th>Job ID</th><th>Runs</th><th>OK</th><th>Fail</th><th>Tokens</th><th>Cost</th><th>Avg Dur</th><th>Last Run</th></tr></thead><tbody>';
+      let t = '<table><thead><tr><th>Job ID</th><th>Runs</th><th>OK</th><th>Fail</th><th>In</th><th>Out</th><th>Cache R</th><th>Cache W</th><th>Cost</th><th>Avg Dur</th><th>Last Run</th></tr></thead><tbody>';
       for (const row of cron) {
         const jid = (row.cron_job_id || '?').substring(0, 20);
         const last = (row.last_run || '').substring(0, 16);
-        t += `<tr><td><code>${jid}</code></td><td>${nf(row.runs)}</td><td>${nf(row.ok_runs)}</td><td>${nf(row.failed_runs)}</td><td>${nf(row.tokens_in)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.avg_duration_ms)}</td><td class="text-muted">${last}</td></tr>`;
+        t += `<tr><td><code>${jid}</code></td><td>${nf(row.runs)}</td><td>${nf(row.ok_runs)}</td><td>${nf(row.failed_runs)}</td><td>${nf(row.tokens_in)}</td><td>${nf(row.tokens_out)}</td><td>${nf(row.cache_read_tokens || 0)}</td><td>${nf(row.cache_write_tokens || 0)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.avg_duration_ms)}</td><td class="text-muted">${last}</td></tr>`;
       }
       t += '</tbody></table>';
       html += renderTableCard('cronTable', 'Cron Jobs', t);
     }
 
     // --- runs table ---
-    let t = '<table><thead><tr><th>Time</th><th>Platform</th><th>Model</th><th>Status</th><th>Tokens</th><th>Cost</th><th>Duration</th><th>Session ID</th></tr></thead><tbody>';
+    let t = '<table><thead><tr><th>Time</th><th>Platform</th><th>Model</th><th>Status</th><th>In</th><th>Out</th><th>Cache R</th><th>Cache W</th><th>Cost</th><th>Duration</th><th>Session ID</th></tr></thead><tbody>';
     for (const row of runs) {
       const time = (row.started_at || '').substring(0, 16);
       const sid = (row.session_id || '').substring(0, 24);
       const model = (row.model || '—').substring(0, 20);
-      t += `<tr><td class="text-muted">${time}</td><td>${platformBadge(row.platform)}</td><td class="text-muted">${model}</td><td>${statusBadge(row.status)}</td><td>${nf(row.tokens_in)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.duration_ms)}</td><td><code title="${row.session_id}">${sid}</code></td></tr>`;
+      t += `<tr><td class="text-muted">${time}</td><td>${platformBadge(row.platform)}</td><td class="text-muted">${model}</td><td>${statusBadge(row.status)}</td><td>${nf(row.tokens_in)}</td><td>${nf(row.tokens_out)}</td><td>${nf(row.cache_read_tokens || 0)}</td><td>${nf(row.cache_write_tokens || 0)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.duration_ms)}</td><td><code title="${row.session_id}">${sid}</code></td></tr>`;
     }
     t += '</tbody></table>';
     html += renderTableCard('runsTable', 'Recent Sessions', t);

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -167,6 +167,8 @@ def api_cron(window_hours=168):
                SUM(CASE WHEN status='error' THEN 1 ELSE 0 END) AS failed_runs,
                SUM(tokens_in) AS tokens_in,
                SUM(tokens_out) AS tokens_out,
+               SUM(cache_read_tokens) AS cache_read_tokens,
+               SUM(cache_write_tokens) AS cache_write_tokens,
                ROUND(SUM(cost_usd), 6) AS cost_usd,
                AVG(duration_ms) AS avg_duration_ms,
                MAX(started_at) AS last_run
@@ -198,12 +200,13 @@ def api_runs(limit=50):
         """
         SELECT session_id, platform, cron_job_id, model, provider,
                started_at, ended_at, status,
-               tokens_in, tokens_out, cost_usd, duration_ms,
+               tokens_in, tokens_out, cache_read_tokens, cache_write_tokens,
+               cost_usd, duration_ms,
                api_calls, tool_calls, estimated_llm_calls
         FROM runs
         ORDER BY started_at DESC
         LIMIT ?
-    """,
+        """,
         (int(limit),),
     )
 

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -146,14 +146,18 @@ def api_summary(window_hours=24):
 def api_token_breakdown(window_hours=24):
     """Get detailed token breakdown: input, output, cache_read, cache_write, reasoning."""
     since_clause_ts = _since_clause(window_hours, "ts")
+    # COALESCE each SUM individually: SUM() returns NULL when all rows are NULL,
+    # which happens for reasoning_tokens on models that don't emit it.
     return _one(f"""
         SELECT
-            SUM(tokens_in) AS tokens_in,
-            SUM(tokens_out) AS tokens_out,
-            SUM(cache_read_tokens) AS cache_read_tokens,
-            SUM(cache_write_tokens) AS cache_write_tokens,
-            SUM(reasoning_tokens) AS reasoning_tokens,
-            COALESCE(SUM(tokens_in) + SUM(tokens_out) + SUM(cache_read_tokens) + SUM(cache_write_tokens) + SUM(reasoning_tokens), 0) AS total_tokens
+            COALESCE(SUM(tokens_in), 0) AS tokens_in,
+            COALESCE(SUM(tokens_out), 0) AS tokens_out,
+            COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+            COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+            COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+            COALESCE(SUM(tokens_in), 0) + COALESCE(SUM(tokens_out), 0)
+                + COALESCE(SUM(cache_read_tokens), 0) + COALESCE(SUM(cache_write_tokens), 0)
+                + COALESCE(SUM(reasoning_tokens), 0) AS total_tokens
         FROM llm_calls WHERE {since_clause_ts}
     """)
 
@@ -274,6 +278,25 @@ def api_budget():
     return {"enabled": True, "budgets": scopes, "on_estimated": on_est.get("mode", "warn_only")}
 
 
+MAX_BUDGET_PAYLOAD = 1_048_576  # 1 MiB
+
+# Allowed values for budget config — prevents YAML key injection
+ALLOWED_SCOPES = {"global", "per_cron_job", "per_sender"}
+ALLOWED_WINDOWS = {"daily", "monthly"}
+
+
+def _validate_threshold(key: str, value, cfg: dict) -> str | None:
+    """Validate and store a threshold (soft_pct/hard_pct). Returns error msg or None."""
+    try:
+        val = float(value)
+    except (ValueError, TypeError):
+        return f"{key} must be a number"
+    if not (0 <= val <= 1):
+        return f"{key} must be between 0 and 1"
+    cfg.setdefault("thresholds", {})[key] = val
+    return None
+
+
 def api_budget_update(payload):
     """Update budget.yaml from POST payload. Returns updated budget status or error."""
     budget_path = DB_PATH.parent / "budget.yaml"
@@ -294,6 +317,12 @@ def api_budget_update(payload):
     scope = payload.get("scope", "global")
     window = payload.get("window", "daily")
     limit_usd = payload.get("limit_usd")
+
+    # Validate scope/window against allowed sets (prevents YAML key injection)
+    if scope not in ALLOWED_SCOPES:
+        return {"enabled": False, "error": f"invalid scope: {scope!r}"}
+    if window not in ALLOWED_WINDOWS:
+        return {"enabled": False, "error": f"invalid window: {window!r}"}
 
     if limit_usd is None:
         return {"enabled": False, "error": "limit_usd is required"}
@@ -316,25 +345,18 @@ def api_budget_update(payload):
     key = f"{window}_usd"
     cfg["budgets"][scope][key] = limit_usd
 
-    # Optional: update thresholds
-    if "soft_pct" in payload:
-        try:
-            soft = float(payload["soft_pct"])
-            if 0 <= soft <= 1:
-                cfg.setdefault("thresholds", {})["soft_pct"] = soft
-        except (ValueError, TypeError):
-            pass
-    if "hard_pct" in payload:
-        try:
-            hard = float(payload["hard_pct"])
-            if 0 <= hard <= 1:
-                cfg.setdefault("thresholds", {})["hard_pct"] = hard
-        except (ValueError, TypeError):
-            pass
+    # Optional: update thresholds (validated, no silent failures)
+    for field, yaml_key in (("soft_pct", "soft_pct"), ("hard_pct", "hard_pct")):
+        if field in payload:
+            err = _validate_threshold(yaml_key, payload[field], cfg)
+            if err:
+                return {"enabled": False, "error": err}
+
     if "on_estimated_mode" in payload:
         mode = payload["on_estimated_mode"]
-        if mode in ("warn_only", "enforce"):
-            cfg.setdefault("on_estimated", {})["mode"] = mode
+        if mode not in ("warn_only", "enforce"):
+            return {"enabled": False, "error": "on_estimated_mode must be 'warn_only' or 'enforce'"}
+        cfg.setdefault("on_estimated", {})["mode"] = mode
 
     # Write back
     try:
@@ -344,6 +366,38 @@ def api_budget_update(payload):
 
     # Return updated status by calling api_budget()
     return api_budget()
+
+
+def api_budget_detail(scope: str, window: str):
+    """Get raw budget config for a specific scope/window for modal pre-fill."""
+    if scope not in ALLOWED_SCOPES or window not in ALLOWED_WINDOWS:
+        return {"error": "invalid scope or window"}
+    budget_path = DB_PATH.parent / "budget.yaml"
+    if not budget_path.exists():
+        return {"error": "budget.yaml not found"}
+    try:
+        import yaml
+    except ImportError:
+        return {"error": "PyYAML not installed"}
+    try:
+        cfg = yaml.safe_load(budget_path.read_text()) or {}
+    except Exception as e:
+        return {"error": f"Failed to parse budget.yaml: {e}"}
+
+    budgets = cfg.get("budgets", {})
+    thresholds = cfg.get("thresholds", {})
+    on_est = cfg.get("on_estimated", {})
+
+    limit = budgets.get(scope, {}).get(f"{window}_usd")
+
+    return {
+        "scope": scope,
+        "window": window,
+        "limit_usd": limit,
+        "soft_pct": thresholds.get("soft_pct", 0.8),
+        "hard_pct": thresholds.get("hard_pct", 1.0),
+        "on_estimated_mode": on_est.get("mode", "warn_only"),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -377,6 +431,12 @@ class Handler(SimpleHTTPRequestHandler):
         if path == "/api/budget":
             return self._json(api_budget())
 
+        if path == "/api/budget/detail":
+            qs = parse_qs(parsed.query)
+            scope = qs.get("scope", ["global"])[0]
+            window = qs.get("window", ["daily"])[0]
+            return self._json(api_budget_detail(scope, window))
+
         if path == "/api/token-breakdown":
             qs = parse_qs(parsed.query)
             return self._json(api_token_breakdown(int(qs.get("hours", [24])[0])))
@@ -406,6 +466,11 @@ class Handler(SimpleHTTPRequestHandler):
 
         if path == "/api/budget":
             content_length = int(self.headers.get("Content-Length", 0))
+            if content_length > MAX_BUDGET_PAYLOAD:
+                self.send_response(413)
+                self.end_headers()
+                self.wfile.write(b"Payload too large")
+                return
             body = self.rfile.read(content_length).decode("utf-8")
             try:
                 payload = json.loads(body) if body else {}
@@ -415,15 +480,17 @@ class Handler(SimpleHTTPRequestHandler):
                 self.wfile.write(b"Invalid JSON")
                 return
             result = api_budget_update(payload)
-            return self._json(result)
+            # Return proper HTTP status: 200 for success, 400 for validation errors
+            status = 200 if result.get("enabled") or "error" not in result else 400
+            return self._json(result, status)
 
         self.send_response(404)
         self.end_headers()
         self.wfile.write(b"Not Found")
 
-    def _json(self, data):
+    def _json(self, data, status=200):
         body = json.dumps(data, default=str).encode()
-        self.send_response(200)
+        self.send_response(status)
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Content-Length", str(len(body)))

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -143,6 +143,21 @@ def api_summary(window_hours=24):
     }
 
 
+def api_token_breakdown(window_hours=24):
+    """Get detailed token breakdown: input, output, cache_read, cache_write, reasoning."""
+    since_clause_ts = _since_clause(window_hours, "ts")
+    return _one(f"""
+        SELECT
+            SUM(tokens_in) AS tokens_in,
+            SUM(tokens_out) AS tokens_out,
+            SUM(cache_read_tokens) AS cache_read_tokens,
+            SUM(cache_write_tokens) AS cache_write_tokens,
+            SUM(reasoning_tokens) AS reasoning_tokens,
+            COALESCE(SUM(tokens_in) + SUM(tokens_out) + SUM(cache_read_tokens) + SUM(cache_write_tokens) + SUM(reasoning_tokens), 0) AS total_tokens
+        FROM llm_calls WHERE {since_clause_ts}
+    """)
+
+
 def api_cron(window_hours=168):
     since_clause = _since_clause(window_hours)
     return _rows(f"""
@@ -358,6 +373,10 @@ class Handler(SimpleHTTPRequestHandler):
 
         if path == "/api/budget":
             return self._json(api_budget())
+
+        if path == "/api/token-breakdown":
+            qs = parse_qs(parsed.query)
+            return self._json(api_token_breakdown(int(qs.get("hours", [24])[0])))
 
         # Static: serve index.html for /
         if path == "/" or path == "/index.html":

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -256,6 +256,78 @@ def api_budget():
     return {"enabled": True, "budgets": scopes, "on_estimated": on_est.get("mode", "warn_only")}
 
 
+def api_budget_update(payload):
+    """Update budget.yaml from POST payload. Returns updated budget status or error."""
+    budget_path = DB_PATH.parent / "budget.yaml"
+    if not budget_path.exists():
+        return {"enabled": False, "error": "budget.yaml not found"}
+
+    try:
+        import yaml
+    except ImportError:
+        return {"enabled": False, "error": "PyYAML not installed"}
+
+    try:
+        cfg = yaml.safe_load(budget_path.read_text()) or {}
+    except Exception as e:
+        return {"enabled": False, "error": f"Failed to parse budget.yaml: {e}"}
+
+    # Expected payload: {"scope": "global", "window": "daily", "limit_usd": 5.0}
+    scope = payload.get("scope", "global")
+    window = payload.get("window", "daily")
+    limit_usd = payload.get("limit_usd")
+
+    if limit_usd is None:
+        return {"enabled": False, "error": "limit_usd is required"}
+
+    try:
+        limit_usd = float(limit_usd)
+    except (ValueError, TypeError):
+        return {"enabled": False, "error": "limit_usd must be a number"}
+
+    if limit_usd < 0:
+        return {"enabled": False, "error": "limit_usd must be >= 0"}
+
+    # Initialize budgets structure if missing
+    if "budgets" not in cfg:
+        cfg["budgets"] = {}
+    if scope not in cfg["budgets"]:
+        cfg["budgets"][scope] = {}
+
+    # Update the limit
+    key = f"{window}_usd"
+    cfg["budgets"][scope][key] = limit_usd
+
+    # Optional: update thresholds
+    if "soft_pct" in payload:
+        try:
+            soft = float(payload["soft_pct"])
+            if 0 <= soft <= 1:
+                cfg.setdefault("thresholds", {})["soft_pct"] = soft
+        except (ValueError, TypeError):
+            pass
+    if "hard_pct" in payload:
+        try:
+            hard = float(payload["hard_pct"])
+            if 0 <= hard <= 1:
+                cfg.setdefault("thresholds", {})["hard_pct"] = hard
+        except (ValueError, TypeError):
+            pass
+    if "on_estimated_mode" in payload:
+        mode = payload["on_estimated_mode"]
+        if mode in ("warn_only", "enforce"):
+            cfg.setdefault("on_estimated", {})["mode"] = mode
+
+    # Write back
+    try:
+        budget_path.write_text(yaml.safe_dump(cfg, default_flow_style=False, sort_keys=False))
+    except Exception as e:
+        return {"enabled": False, "error": f"Failed to write budget.yaml: {e}"}
+
+    # Return updated status by calling api_budget()
+    return api_budget()
+
+
 # ---------------------------------------------------------------------------
 # HTTP Handler
 # ---------------------------------------------------------------------------
@@ -301,6 +373,27 @@ class Handler(SimpleHTTPRequestHandler):
         if fpath.is_file():
             super().do_GET()
             return
+
+        self.send_response(404)
+        self.end_headers()
+        self.wfile.write(b"Not Found")
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+
+        if path == "/api/budget":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length).decode("utf-8")
+            try:
+                payload = json.loads(body) if body else {}
+            except json.JSONDecodeError:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b"Invalid JSON")
+                return
+            result = api_budget_update(payload)
+            return self._json(result)
 
         self.send_response(404)
         self.end_headers()

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -358,9 +358,15 @@ def api_budget_update(payload):
             return {"enabled": False, "error": "on_estimated_mode must be 'warn_only' or 'enforce'"}
         cfg.setdefault("on_estimated", {})["mode"] = mode
 
-    # Write back
+    # Write back (atomic: temp file + os.replace)
     try:
-        budget_path.write_text(yaml.safe_dump(cfg, default_flow_style=False, sort_keys=False))
+        # Inline atomic write to avoid importing os at module level
+        import os
+        import yaml
+        tmp = budget_path.with_suffix(".yaml.tmp")
+        with open(tmp, "w") as f:
+            yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=False)
+        os.replace(tmp, budget_path)
     except Exception as e:
         return {"enabled": False, "error": f"Failed to write budget.yaml: {e}"}
 

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -144,22 +144,26 @@ def api_summary(window_hours=24):
 
 
 def api_token_breakdown(window_hours=24):
-    """Get detailed token breakdown: input, output, cache_read, cache_write, reasoning."""
-    since_clause_ts = _since_clause(window_hours, "ts")
-    # COALESCE each SUM individually: SUM() returns NULL when all rows are NULL,
-    # which happens for reasoning_tokens on models that don't emit it.
-    return _one(f"""
-        SELECT
-            COALESCE(SUM(tokens_in), 0) AS tokens_in,
-            COALESCE(SUM(tokens_out), 0) AS tokens_out,
-            COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
-            COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
-            COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
-            COALESCE(SUM(tokens_in), 0) + COALESCE(SUM(tokens_out), 0)
-                + COALESCE(SUM(cache_read_tokens), 0) + COALESCE(SUM(cache_write_tokens), 0)
-                + COALESCE(SUM(reasoning_tokens), 0) AS total_tokens
-        FROM llm_calls WHERE {since_clause_ts}
-    """)
+    """Get detailed token breakdown: input, output, cache_read, cache_write, reasoning.
+    Returns None if the DB schema is older and missing token columns."""
+    try:
+        since_clause_ts = _since_clause(window_hours, "ts")
+        # COALESCE each SUM individually: SUM() returns NULL when all rows are NULL,
+        # which happens for reasoning_tokens on models that don't emit it.
+        return _one(f"""
+            SELECT
+                COALESCE(SUM(tokens_in), 0) AS tokens_in,
+                COALESCE(SUM(tokens_out), 0) AS tokens_out,
+                COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+                COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+                COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+                COALESCE(SUM(tokens_in), 0) + COALESCE(SUM(tokens_out), 0)
+                    + COALESCE(SUM(cache_read_tokens), 0) + COALESCE(SUM(cache_write_tokens), 0)
+                    + COALESCE(SUM(reasoning_tokens), 0) AS total_tokens
+            FROM llm_calls WHERE {since_clause_ts}
+        """)
+    except Exception:
+        return None
 
 
 def api_cron(window_hours=168):

--- a/db.py
+++ b/db.py
@@ -140,6 +140,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     # Apply migrations in order
     _migrate_v2(conn)
     _migrate_v3(conn)
+    _migrate_v4(conn)
 
 
 def _migrate_v2(conn: sqlite3.Connection) -> None:
@@ -209,6 +210,24 @@ def _migrate_v3(conn: sqlite3.Connection) -> None:
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (3, ?)",
+        (_utcnow(),),
+    )
+
+
+def _migrate_v4(conn: sqlite3.Connection) -> None:
+    """Add v4 schema: cache tokens on runs table for per-session/cron breakdown."""
+    cur = conn.execute("SELECT version FROM schema_version WHERE version = 4")
+    if cur.fetchone() is not None:
+        return
+
+    for col in ("cache_read_tokens", "cache_write_tokens"):
+        try:
+            conn.execute(f"ALTER TABLE runs ADD COLUMN {col} INTEGER DEFAULT 0")
+        except sqlite3.OperationalError:
+            pass  # already exists
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (4, ?)",
         (_utcnow(),),
     )
 
@@ -323,15 +342,17 @@ def record_llm_call(
     conn.execute(
         """
         UPDATE runs
-        SET tokens_in  = tokens_in  + ?,
-            tokens_out = tokens_out + ?,
-            cost_usd   = cost_usd   + ?,
-            api_calls  = api_calls  + 1,
-            model      = COALESCE(model, ?),
-            provider   = COALESCE(provider, ?)
+        SET tokens_in         = tokens_in  + ?,
+            tokens_out        = tokens_out + ?,
+            cache_read_tokens = cache_read_tokens + ?,
+            cache_write_tokens = cache_write_tokens + ?,
+            cost_usd          = cost_usd   + ?,
+            api_calls         = api_calls  + 1,
+            model             = COALESCE(model, ?),
+            provider          = COALESCE(provider, ?)
         WHERE session_id = ?
         """,
-        (tokens_in, tokens_out, cost_usd, model, provider, session_id),
+        (tokens_in, tokens_out, cache_read_tokens, cache_write_tokens, cost_usd, model, provider, session_id),
     )
     if estimated:
         conn.execute(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Monitoring",
 ]
+dependencies = [
+    "watchdog>=3.0",  # budget.yaml file watcher for hot-reload
+]
 
 [project.urls]
 Homepage = "https://github.com/nujovich/hermes-telemetry"


### PR DESCRIPTION
## Summary

Adds a complete budget management workflow to the dashboard:

1. **Budget Editor Modal** — Edit button on each budget row opens a modal with scope, window, limit, and threshold fields
2. **POST /api/budget endpoint** — Validates and writes to `budget.yaml`
3. **File Watcher (watchdog)** — Watches `budget.yaml` for changes and hot-reloads plugin config automatically

## Changes

| File | Changes |
|------|---------|
| `dashboard/index.html` | Budget modal UI, Edit buttons, POST /api/budget integration |
| `dashboard/serve.py` | `POST /api/budget` handler with validation |
| `budget.py` | `start_budget_watcher()` / `stop_budget_watcher()` using watchdog |
| `__init__.py` | Starts budget watcher on plugin load |
| `pyproject.toml` | Adds `watchdog>=3.0` dependency |

## How it works

1. User clicks "Edit" on a budget row in dashboard
2. Modal opens with pre-filled current values
3. User saves → POST to `/api/budget` → writes `budget.yaml`
4. File watcher detects change → calls `budget.reload_config()` → plugin picks up new limits instantly
5. No manual `/budget set` or gateway restart needed

## Testing

- Dashboard edit → budget.yaml updated → file watcher logs "budget.yaml modified — hot-reloading budget config"
- Plugin immediately uses new limits for `pre_tool_call` gate
- Works from any network client on LAN (dashboard exposed on 0.0.0.0:8009)

## Note

Dashboard has no authentication — expose only on trusted LAN or use SSH tunnel.
