### PR TITLE
Provider-aware pricing + NVIDIA NIM seeds (issue #24, #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Provider-aware pricing lookup guard (issue #24). A pricing entry tagged
+  `_source: openrouter` in `pricing.yaml` is now only applied to calls the
+  OpenRouter provider actually served (or calls with no provider, for
+  backward compatibility). This stops an OpenRouter rate from silently
+  costing a call another provider served — e.g. the OpenRouter Qwen price
+  leaking onto a Nous Portal call. Source-less entries (`_DEFAULT_PRICING`,
+  the prefix table, hand-added overrides) stay provider-neutral.
+- NVIDIA NIM seed prices in `_DEFAULT_PRICING` (issue #12, Phase 1): five
+  Nemotron models (`nemotron-3-super-120b-a12b`, `nemotron-super-49b`,
+  `nemotron-70b-instruct`, `nemotron-nano-12b-vl`, `nemotron-nano-9b`).
+  Seeds are source-neutral and live in code, so they survive an OpenRouter
+  refresh and win over a same-id OpenRouter entry for `provider=nvidia`
+  calls. `:free` promo variants resolve to `$0` via the unknown-model
+  fallback and need no entry.
+- `_subscription: true` pricing tag — flags a flat-rate / subscription model
+  so it resolves to `$0` **without** the unknown-model warning, distinct
+  from a missing price. Lets users price e.g. a Nous-served model at `$0`
+  even when an OpenRouter entry for the same id exists.
+- `provider` parameter on `pricing.estimate_cost()` (threaded through
+  `_resolve_pricing` / `_lookup_base` / `_lookup_form`), passed from the
+  `post_api_request` hook. Defaults to `""`, preserving the previous
+  provider-blind behaviour for existing callers.
+
+### Changed
+- `pricing_refresh.py` now emits `subscription_models` in the YAML `_meta`
+  block and excludes those models from `estimated_price_models`.
+- Unknown-model pricing warnings are now de-duplicated per `(model,
+  provider)` pair instead of per model, so the same id can warn separately
+  under each provider that lacks a price for it.
+
+### Fixed
+- `_SCHEMA_VERSION` was stuck at `3` despite the `_migrate_v4` migration
+  (adds `cache_read_tokens` / `cache_write_tokens` to `runs`), so the
+  recorded schema version never matched the applied migrations. Bumped to
+  `4`.
+- Dashboard failed to import on Python 3.8/3.9 due to PEP 604 `str | None`
+  union syntax — added `from __future__ import annotations` to
+  `dashboard/serve.py`.
+
 ## [0.4.0] - 2026-06-09
 
 ### Added

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -356,6 +356,12 @@ table before applying.
 | v1 | Base tables: `runs`, `llm_calls`, `tool_calls`, `schema_version` |
 | v2 | `llm_calls`: `cache_read_tokens`, `cache_write_tokens`, `reasoning_tokens`, `estimated`. `runs`: `parent_session_id`, `estimated_llm_calls` |
 | v3 | `runs.sender_id`. New table: `budget_alerts` (anti-spam ledger) |
+| v4 | `runs`: `cache_read_tokens`, `cache_write_tokens` (per-session/cron cache breakdown) |
+
+`_SCHEMA_VERSION` in `db.py` is the latest applied version — keep it in lockstep
+with the highest `_migrate_vN`. `test_schema_idempotent` asserts the count of
+`schema_version` rows equals `_SCHEMA_VERSION`, so adding a migration without
+bumping the constant (or vice versa) fails CI.
 
 ### `_ensure_run_row` — lazy insert (added v0.3.1)
 
@@ -388,7 +394,7 @@ already uses `INSERT OR IGNORE`).
 
 ### Lookup priority chain
 
-`estimate_cost(usage, model)` resolves a price by trying these in order:
+`estimate_cost(usage, model, provider="")` resolves a price by trying these in order:
 
 1. **Custom YAML** (`~/.hermes/telemetry/pricing.yaml`, `models:` section) — exact match, case-insensitive
 2. **Built-in table** (`_DEFAULT_PRICING`) — exact match
@@ -396,9 +402,65 @@ already uses `INSERT OR IGNORE`).
 4. **Google symmetric form** — if the above misses, tries `gemini-X` ↔ `google/gemini-X`
 5. **Unknown** → returns `$0.00`, logs a one-time WARNING
 
+Every candidate is first filtered by the **provider-aware guard** (below), so a
+source-ineligible entry is skipped and the chain falls through to the next one.
+
 **Why longest-prefix-wins:** `gpt-4o-mini` must not be matched by `gpt-4o` or
 `gpt-4`. `o1-mini` must not be matched by `o1`. The sorted-by-length approach
 (candidates sorted by `-len(prefix)`) ensures specific prefixes take precedence.
+
+### Provider-aware lookup guard (added v0.4.1, issue #24)
+
+**Problem:** `pricing.yaml` is auto-populated from the OpenRouter catalog —
+every fetched entry carries `_source: openrouter`. But the same model name can
+be served by a *different* provider at a *different* price. Two real cases:
+
+- **Nous Portal** serves `qwen3.7-plus` (bare id) on a flat subscription ($0),
+  while OpenRouter lists `qwen/qwen3.7-plus` (prefixed) at a real per-token rate.
+- **NVIDIA NIM** serves `nvidia/nemotron-3-super-120b-a12b` at $0.10/$0.50 while
+  OpenRouter lists the **same exact id** at $0.09/$0.45 (a true key collision).
+
+A provider-blind, model-name-only lookup silently costs a Nous/NIM call with the
+OpenRouter rate — a plausible-but-wrong number. `_source` was decorative until
+this guard made it load-bearing.
+
+**Rule** (`_source_eligible(source, provider)`):
+
+| Entry source | Eligible for which calls |
+|--------------|--------------------------|
+| `_source: openrouter` | only `provider==""` (backward-compat/unknown) or a provider containing `"openrouter"` |
+| no `_source` (`_DEFAULT_PRICING`, `_PREFIX_PRICING`, hand-added overrides) | **always** (provider-neutral) |
+| other named source (e.g. `google-ai`) | **always** (direct-provider rate, reasonable for any caller of that id) |
+
+`provider` is the verbatim string from `post_api_request` (e.g. `"nous"`,
+`"openrouter"`; NIM **canonicalizes to `"nvidia"`** — aliases `nim`/`nvidia-nim`/
+`nemotron` are normalized by Hermes `normalize_provider()` before the hook fires,
+verified against `hermes_cli/providers.py`).
+
+**Why NIM seeds live in `_DEFAULT_PRICING` (code), not the YAML:** for the
+same-id collision, the OpenRouter entry in `models:` is excluded for a
+`provider="nvidia"` call, and the lookup falls through to the source-neutral
+seed in `_DEFAULT_PRICING`. Keeping seeds in code also makes them immune to an
+OpenRouter sync overwriting the shared key. The `:free` promo variants
+(`nvidia/...:free`) carry no seed — they resolve to `$0.00` via the
+unknown-model fallback (issue #12).
+
+### Pricing metadata tags (`_`-prefixed)
+
+Three `_`-prefixed keys live on pricing entries and are **stripped from the
+price dict** by `_load_custom_pricing` (captured into parallel structures
+`model_sources` / `subscription_models` so the price math never sees them):
+
+| Tag | Meaning | Effect |
+|-----|---------|--------|
+| `_source` | Which source wrote the entry (`openrouter`, `google-ai`, ...) | Drives the provider-aware guard |
+| `_estimated_price` | OpenRouter model with no fixed price (negative→$0) | Counted by `estimated_price_share`; degrades hard budget verdicts to soft under `warn_only` |
+| `_subscription` | A **declared** $0 (flat-sub / free-tier) rate, hand-added | Distinguishes a genuine $0 from a lookup miss; tracked in `_meta.subscription_models`; **excluded** from `estimated_price_models` |
+
+**Adding a subscription/flat-rate model:** enter it under the provider's
+**native (bare) id** with `input: 0.0`, `output: 0.0`, `_subscription: true`.
+The bare id is never returned by OpenRouter, so it never collides with an
+auto-fetched entry and survives every refresh untouched.
 
 ### Google-symmetric normalization (added v0.4.0)
 
@@ -695,6 +757,27 @@ with `pytest --basetemp=DIR`.
   `google/gemini-X` resolve to the same entry. Two-pass: try the literal ID
   first, then `_google_alt_form(model_lc)`. This is deliberately Google-specific
   — other provider prefixes carry distinct pricing semantics and must not be stripped.
+
+### v0.4.1 — Provider-aware pricing + NVIDIA NIM seeds
+
+- **Provider-aware lookup guard** (issue #24): `estimate_cost` gains an optional
+  `provider` arg threaded through `_resolve_pricing` → `_lookup_base` →
+  `_lookup_form`. `_source_eligible` rejects an `_source: openrouter` entry for a
+  non-OpenRouter call so the OpenRouter rate never leaks onto a Nous/NIM call.
+  `provider=""` preserves the old provider-blind behaviour (backward compatible).
+  See [Provider-aware lookup guard](#provider-aware-lookup-guard-added-v041-issue-24).
+- **`_subscription` tag** (Option A for Nous flat-sub): declared $0, kept distinct
+  from a lookup miss and from `_estimated_price`. Tracked in
+  `_meta.subscription_models`.
+- **NVIDIA NIM seeds** (issue #12 Phase 1): five Nemotron models added to
+  `_DEFAULT_PRICING` (source-neutral, immune to OpenRouter sync). The same-id
+  OpenRouter collision is resolved by the guard falling through to the seed.
+  Phase 2 (`NVIDIANIMPricingSource` API auto-sync) was deliberately dropped — NIM
+  bills against account tier, not a uniform public per-token list, so the seed
+  table is the durable answer.
+- **`_SCHEMA_VERSION` bump 3→4**: the `_migrate_v4` migration (cache tokens on
+  `runs`) shipped without bumping the constant, leaving `test_schema_idempotent`
+  red. Fixed here as part of documenting schema v4.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -541,6 +541,26 @@ defaults:
 
 Prices are auto-fetched from the OpenRouter API and cached locally.
 
+**Provider-aware lookup.** Each candidate is filtered by the call's provider so
+an OpenRouter-sourced price is never applied to a call another provider served
+(e.g. the OpenRouter Qwen rate must not cost a Nous Portal call, and a NIM call
+of `nvidia/...` must not borrow OpenRouter's rate for the same id). Entries
+auto-fetched from OpenRouter carry `_source: openrouter` and are skipped for
+non-OpenRouter calls; built-in and hand-added entries (no `_source`) are
+provider-neutral.
+
+**Subscription / flat-rate models.** If a provider serves a model on a flat
+subscription or free tier (incremental per-token cost = $0), declare it under
+the provider's **native model id** so it stays distinct from a lookup miss:
+
+```yaml
+models:
+  qwen3.7-plus:          # Nous Portal's native id (not the OpenRouter qwen/ form)
+    input: 0.0
+    output: 0.0
+    _subscription: true  # declared $0 — survives every OpenRouter refresh
+```
+
 ### `budget.yaml`
 
 Configure spend guardrails. No file → budgets disabled.
@@ -596,7 +616,9 @@ The plugin can automatically fetch model pricing from OpenRouter’s public API,
   - User overrides in `pricing.yaml` are **always preserved** — manual entries take priority over auto-fetched ones
   - New models from the API are added automatically
   - Previously auto-fetched models are updated when prices change
-  - Models are tagged with `_auto: true` and `_source: openrouter` for traceability
+  - Models are tagged with `_auto: true` and `_source: openrouter` — the `_source` tag is load-bearing: it drives the provider-aware guard above
+
+> **NVIDIA NIM** (`build.nvidia.com`) is supported out of the box: the Nemotron lineup ships as built-in seed prices, so NIM-served calls cost correctly even though NIM has no auto-refresh source. The seeds are immune to OpenRouter syncs, and a NIM call never borrows OpenRouter's rate for a colliding model id. `nvidia/...:free` promo variants resolve to `$0.00`.
 
 ### Estimated-Price Models
 

--- a/__init__.py
+++ b/__init__.py
@@ -260,7 +260,7 @@ def register(ctx) -> None:  # noqa: ANN001
                 "cache_write_tokens": cache_write_tok,
                 "reasoning_tokens": reasoning_tok,
             }
-            cost = pricing.estimate_cost(full_usage, effective_model)
+            cost = pricing.estimate_cost(full_usage, effective_model, provider)
             latency_ms = int(api_duration * 1000)
 
             db.record_llm_call(

--- a/budget.py
+++ b/budget.py
@@ -43,14 +43,15 @@ logger = logging.getLogger(__name__)
 _budget_observer = None
 _budget_watcher_started = False
 
+
 def start_budget_watcher() -> None:
     """Start a background file watcher on budget.yaml to auto-reload config on changes."""
     global _budget_observer, _budget_watcher_started
     if _budget_watcher_started:
         return
     try:
+        from watchdog.events import FileModifiedEvent, FileSystemEventHandler
         from watchdog.observers import Observer
-        from watchdog.events import FileSystemEventHandler, FileModifiedEvent
     except Exception as exc:
         logger.debug("budget watcher unavailable (watchdog not installed): %s", exc)
         return
@@ -80,6 +81,7 @@ def start_budget_watcher() -> None:
     _budget_observer.start()
     _budget_watcher_started = True
     logger.info("Budget file watcher started on %s", path)
+
 
 def stop_budget_watcher() -> None:
     """Stop the budget file watcher (for cleanup/tests)."""
@@ -490,6 +492,7 @@ def _cron_block() -> str:
 def _set_budget(scope: str, window: str, usd: float) -> str:
     """Persist a limit to budget.yaml and hot-reload."""
     import os
+
     import yaml
 
     if scope not in ("global", "cron_job", "sender"):

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -1405,7 +1405,9 @@ def api_daily_model_chart(window_hours=24, limit_days=90, top_n=5):
     }
 
 
-def api_model_period_trends(window_hours=24, granularity="day", metric="tokens", top_n=6, limit_periods=24):
+def api_model_period_trends(
+    window_hours=24, granularity="day", metric="tokens", top_n=6, limit_periods=24
+):
     granularity = _normalize_granularity(granularity)
     metric = (metric or "tokens").strip().lower()
     if metric not in {"tokens", "cost", "requests", "share"}:
@@ -1469,14 +1471,18 @@ def api_model_period_trends(window_hours=24, granularity="day", metric="tokens",
             period_map[period] = {
                 "period": period,
                 "period_start": row["period_start"],
-                "models": {m: {"api_calls": 0, "total_tokens": 0, "cost_usd": 0.0} for m in model_names},
+                "models": {
+                    m: {"api_calls": 0, "total_tokens": 0, "cost_usd": 0.0} for m in model_names
+                },
                 "other": {"api_calls": 0, "total_tokens": 0, "cost_usd": 0.0},
                 "totals": {"api_calls": 0, "total_tokens": 0, "cost_usd": 0.0},
             }
         bucket = period_map[period]["models"].get(row["model"]) or period_map[period]["other"]
         bucket["api_calls"] += int(row.get("api_calls") or 0)
         bucket["total_tokens"] += int(row.get("total_tokens") or 0)
-        bucket["cost_usd"] = round(float(bucket["cost_usd"] or 0) + float(row.get("cost_usd") or 0), 6)
+        bucket["cost_usd"] = round(
+            float(bucket["cost_usd"] or 0) + float(row.get("cost_usd") or 0), 6
+        )
         period_map[period]["totals"]["api_calls"] += int(row.get("api_calls") or 0)
         period_map[period]["totals"]["total_tokens"] += int(row.get("total_tokens") or 0)
         period_map[period]["totals"]["cost_usd"] = round(
@@ -1519,7 +1525,12 @@ def api_model_share_comparison(window_hours=24, granularity="day", limit=12):
         """
     )
     if not rows:
-        return {"granularity": granularity, "current_period": None, "previous_period": None, "rows": []}
+        return {
+            "granularity": granularity,
+            "current_period": None,
+            "previous_period": None,
+            "rows": [],
+        }
 
     periods = []
     period_models = {}
@@ -1527,7 +1538,10 @@ def api_model_share_comparison(window_hours=24, granularity="day", limit=12):
         period = row["period"]
         if period not in period_models:
             periods.append(period)
-            period_models[period] = {"models": {}, "totals": {"total_tokens": 0, "cost_usd": 0.0, "api_calls": 0}}
+            period_models[period] = {
+                "models": {},
+                "totals": {"total_tokens": 0, "cost_usd": 0.0, "api_calls": 0},
+            }
         period_models[period]["models"][row["model"]] = {
             "total_tokens": int(row.get("total_tokens") or 0),
             "cost_usd": float(row.get("cost_usd") or 0),
@@ -1535,7 +1549,8 @@ def api_model_share_comparison(window_hours=24, granularity="day", limit=12):
         }
         period_models[period]["totals"]["total_tokens"] += int(row.get("total_tokens") or 0)
         period_models[period]["totals"]["cost_usd"] = round(
-            float(period_models[period]["totals"]["cost_usd"] or 0) + float(row.get("cost_usd") or 0),
+            float(period_models[period]["totals"]["cost_usd"] or 0)
+            + float(row.get("cost_usd") or 0),
             6,
         )
         period_models[period]["totals"]["api_calls"] += int(row.get("api_calls") or 0)
@@ -1560,10 +1575,26 @@ def api_model_share_comparison(window_hours=24, granularity="day", limit=12):
     for model in all_models:
         cur = current["models"].get(model, {"total_tokens": 0, "cost_usd": 0.0, "api_calls": 0})
         prev = previous["models"].get(model, {"total_tokens": 0, "cost_usd": 0.0, "api_calls": 0})
-        current_token_share = round((cur["total_tokens"] / current_total_tokens) * 100, 2) if current["totals"]["total_tokens"] else 0.0
-        previous_token_share = round((prev["total_tokens"] / prev_total_tokens) * 100, 2) if previous["totals"]["total_tokens"] else 0.0
-        current_cost_share = round((float(cur["cost_usd"] or 0.0) / current_total_cost) * 100, 2) if current["totals"]["cost_usd"] else 0.0
-        previous_cost_share = round((float(prev["cost_usd"] or 0.0) / prev_total_cost) * 100, 2) if previous["totals"]["cost_usd"] else 0.0
+        current_token_share = (
+            round((cur["total_tokens"] / current_total_tokens) * 100, 2)
+            if current["totals"]["total_tokens"]
+            else 0.0
+        )
+        previous_token_share = (
+            round((prev["total_tokens"] / prev_total_tokens) * 100, 2)
+            if previous["totals"]["total_tokens"]
+            else 0.0
+        )
+        current_cost_share = (
+            round((float(cur["cost_usd"] or 0.0) / current_total_cost) * 100, 2)
+            if current["totals"]["cost_usd"]
+            else 0.0
+        )
+        previous_cost_share = (
+            round((float(prev["cost_usd"] or 0.0) / prev_total_cost) * 100, 2)
+            if previous["totals"]["cost_usd"]
+            else 0.0
+        )
         out_rows.append(
             {
                 "model": model,
@@ -1582,7 +1613,10 @@ def api_model_share_comparison(window_hours=24, granularity="day", limit=12):
                 "api_calls_delta": cur["api_calls"] - prev["api_calls"],
             }
         )
-    out_rows.sort(key=lambda r: (r["current_tokens"], r["current_cost_usd"], r["current_api_calls"]), reverse=True)
+    out_rows.sort(
+        key=lambda r: (r["current_tokens"], r["current_cost_usd"], r["current_api_calls"]),
+        reverse=True,
+    )
     return {
         "granularity": granularity,
         "current_period": current_period,
@@ -1762,7 +1796,9 @@ def _dashboard_viewer_tz(tz_name: str | None):
     return local_tz, label
 
 
-def _budget_window_bounds_utc(window: str, tz_name: str | None = None, now_utc: datetime | None = None):
+def _budget_window_bounds_utc(
+    window: str, tz_name: str | None = None, now_utc: datetime | None = None
+):
     tzinfo, tz_label = _dashboard_viewer_tz(tz_name)
     now_utc = now_utc or datetime.now(timezone.utc)
     now_local = now_utc.astimezone(tzinfo)

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -20,6 +20,8 @@ unreachable from other hosts. To view it from another machine, either:
     internet or to networks that include untrusted hosts.
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging

--- a/db.py
+++ b/db.py
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 3
+_SCHEMA_VERSION = 4
 _local = threading.local()
 
 # Serializes first-time schema setup across threads. Each thread opens its own
@@ -352,7 +352,16 @@ def record_llm_call(
             provider          = COALESCE(provider, ?)
         WHERE session_id = ?
         """,
-        (tokens_in, tokens_out, cache_read_tokens, cache_write_tokens, cost_usd, model, provider, session_id),
+        (
+            tokens_in,
+            tokens_out,
+            cache_read_tokens,
+            cache_write_tokens,
+            cost_usd,
+            model,
+            provider,
+            session_id,
+        ),
     )
     if estimated:
         conn.execute(

--- a/pricing.py
+++ b/pricing.py
@@ -63,6 +63,19 @@ _DEFAULT_PRICING: dict[str, dict] = {
     "owl-alpha": dict(input=0.00, output=0.00),
     "hermes-3-llama-3.1-405b": dict(input=3.00, output=15.00),
     "hermes-3-llama-3.1-70b": dict(input=0.70, output=0.90),
+    # ── NVIDIA NIM (build.nvidia.com direct) ─────────────────────────────────
+    # Hermes canonicalizes the NIM provider to "nvidia" (aliases nim/nvidia-nim/
+    # nemotron normalize to it). Seeds live here, source-neutral and in code, so
+    # they (1) survive an OpenRouter sync untouched and (2) are selected when the
+    # provider-aware guard excludes a same-id OpenRouter entry for a NIM call.
+    # Prices per build.nvidia.com, verified 2026-06. The `:free` promo variants
+    # (e.g. nemotron-3-ultra:free) resolve to $0 via the unknown-model fallback
+    # and need no entry — see issue #12.
+    "nvidia/nemotron-3-super-120b-a12b": dict(input=0.10, output=0.50),
+    "nvidia/nemotron-super-49b": dict(input=0.10, output=0.40),
+    "nvidia/nemotron-70b-instruct": dict(input=1.20, output=1.20),
+    "nvidia/nemotron-nano-12b-vl": dict(input=0.20, output=0.60),
+    "nvidia/nemotron-nano-9b": dict(input=0.04, output=0.16),
     # ── Meta (via OpenRouter / providers) ───────────────────────────────────
     "meta-llama/llama-3.1-405b-instruct": dict(input=2.70, output=2.70),
     "meta-llama/llama-3.1-70b-instruct": dict(input=0.52, output=0.75),
@@ -117,19 +130,34 @@ _PREFIX_PRICING: list[tuple[str, dict]] = [
 _DEFAULT_CACHE_READ_MULTIPLIER = 0.10
 _DEFAULT_CACHE_WRITE_MULTIPLIER = 1.25
 
-_warned_unknown: set[str] = set()
+_warned_unknown: set[tuple[str, str]] = set()
 _custom_pricing: dict | None = None  # parsed YAML data (models + defaults)
 
 
+def _empty_custom_pricing() -> dict:
+    return {"models": {}, "defaults": {}, "model_sources": {}, "subscription_models": set()}
+
+
 def _load_custom_pricing() -> dict:
-    """Load custom pricing YAML. Returns dict with 'models' and 'defaults' keys."""
+    """Load custom pricing YAML.
+
+    Returns a dict with keys:
+      models               — {model_lc: {price keys}}  (``_``-prefixed keys stripped)
+      defaults             — {multiplier name: float}
+      model_sources        — {model_lc: source}  (from each entry's ``_source``)
+      subscription_models  — set of model_lc flagged ``_subscription: true``
+
+    ``model_sources`` is what powers the provider-aware guard (issue #24): the
+    price-key dict has the ``_``-prefixed metadata stripped, so the source has
+    to be captured separately before stripping or the guard can't see it.
+    """
     global _custom_pricing
     if _custom_pricing is not None:
         return _custom_pricing
     hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
     pricing_file = hermes_home / "telemetry" / "pricing.yaml"
     if not pricing_file.exists():
-        _custom_pricing = {"models": {}, "defaults": {}}
+        _custom_pricing = _empty_custom_pricing()
         return _custom_pricing
     try:
         import yaml
@@ -139,33 +167,44 @@ def _load_custom_pricing() -> dict:
 
         models: dict[str, dict] = {}
         defaults: dict[str, float] = {}
+        model_sources: dict[str, str] = {}
+        subscription_models: set[str] = set()
 
-        # New format: top-level "models:" and "defaults:" sections
+        # New format has top-level "models:"/"defaults:"; legacy is a flat map of
+        # model_name -> entry. Either way, entries are dicts whose price keys we
+        # keep and whose ``_``-prefixed metadata (_source, _subscription, ...) we
+        # capture then strip.
         if "models" in data or "defaults" in data:
             raw_models = data.get("models") or {}
             raw_defaults = data.get("defaults") or {}
-            for model, entry in raw_models.items():
-                if isinstance(entry, dict):
-                    models[str(model).lower()] = {
-                        k: float(v)
-                        for k, v in entry.items()
-                        if v is not None and not k.startswith("_")
-                    }
             for k, v in raw_defaults.items():
                 with contextlib.suppress(TypeError, ValueError):
                     defaults[str(k)] = float(v)
         else:
-            # Legacy flat format: model_name: {input: ..., output: ...}
-            for model, entry in data.items():
-                if isinstance(entry, dict):
-                    models[str(model).lower()] = {
-                        k: float(v) for k, v in entry.items() if v is not None
-                    }
+            raw_models = data
 
-        _custom_pricing = {"models": models, "defaults": defaults}
+        for model, entry in raw_models.items():
+            if not isinstance(entry, dict):
+                continue
+            key = str(model).lower()
+            models[key] = {
+                k: float(v) for k, v in entry.items() if v is not None and not k.startswith("_")
+            }
+            src = entry.get("_source")
+            if src:
+                model_sources[key] = str(src).lower()
+            if entry.get("_subscription"):
+                subscription_models.add(key)
+
+        _custom_pricing = {
+            "models": models,
+            "defaults": defaults,
+            "model_sources": model_sources,
+            "subscription_models": subscription_models,
+        }
     except Exception as exc:
         logger.warning("Failed to load custom pricing from %s: %s", pricing_file, exc)
-        _custom_pricing = {"models": {}, "defaults": {}}
+        _custom_pricing = _empty_custom_pricing()
     return _custom_pricing
 
 
@@ -186,17 +225,46 @@ def _google_alt_form(model_lc: str) -> str | None:
     return None
 
 
-def _lookup_form(model_lc: str) -> dict | None:
+def _source_eligible(source: str | None, provider: str) -> bool:
+    """Whether a pricing entry from `source` may cost a call served by `provider`.
+
+    Provider-aware guard (issue #24): an OpenRouter-sourced price must never
+    cost a call a *different* provider actually served — that silently applies
+    the wrong rate (e.g. the OpenRouter Qwen price on a Nous Portal call, or the
+    OpenRouter rate on a same-id NVIDIA NIM call). Rules:
+
+    - Source-less entries (`_DEFAULT_PRICING`, the prefix table, hand-added
+      overrides with no `_source`) are provider-neutral → always eligible.
+    - `_source: openrouter` entries are eligible only when the call has no
+      provider (empty → backward-compat / unknown) or is itself OpenRouter-routed.
+    - Other named sources (e.g. `google-ai`) are not restricted: their prices are
+      direct-provider rates that stay reasonable for any caller of that model id.
+    """
+    if not source or source != "openrouter":
+        return True
+    if not provider:
+        return True
+    return "openrouter" in provider.lower()
+
+
+def _lookup_form(model_lc: str, provider: str = "") -> dict | None:
     """Exact-then-prefix lookup against custom + defaults + prefix tables.
 
     Custom wins over defaults wins over the curated prefix table (matching
     the precedence in `_lookup_base`'s callers). Among equal-length prefixes,
     the stable sort preserves source order so the higher-precedence source
     still wins.
+
+    `provider` drives the source guard (`_source_eligible`): a source-ineligible
+    custom entry is skipped so the lookup falls through to the next candidate
+    (e.g. a NIM call skips the same-id OpenRouter entry and lands on the
+    source-neutral `_DEFAULT_PRICING` seed).
     """
     custom = _load_custom_pricing()
     custom_models = custom.get("models", {})
-    if model_lc in custom_models:
+    model_sources = custom.get("model_sources", {})
+
+    if model_lc in custom_models and _source_eligible(model_sources.get(model_lc), provider):
         return custom_models[model_lc]
     if model_lc in _DEFAULT_PRICING:
         return _DEFAULT_PRICING[model_lc]
@@ -204,19 +272,20 @@ def _lookup_form(model_lc: str) -> dict | None:
     # default exact keys, plus the curated family-prefix table — longest prefix
     # wins. This lets an auto-refreshed key like 'google/gemini-3-flash-preview'
     # cover the dated variants the gateway actually sends, e.g.
-    # 'google/gemini-3-flash-preview-20251217'.
-    candidates: list[tuple[str, dict]] = [
-        *custom_models.items(),
-        *_DEFAULT_PRICING.items(),
-        *_PREFIX_PRICING,
+    # 'google/gemini-3-flash-preview-20251217'. Source-ineligible custom keys are
+    # skipped here too.
+    candidates: list[tuple[str, dict, str | None]] = [
+        *((k, v, model_sources.get(k)) for k, v in custom_models.items()),
+        *((k, v, None) for k, v in _DEFAULT_PRICING.items()),
+        *((k, v, None) for k, v in _PREFIX_PRICING),
     ]
-    for prefix, prices in sorted(candidates, key=lambda x: -len(x[0])):
-        if model_lc.startswith(prefix):
+    for prefix, prices, source in sorted(candidates, key=lambda x: -len(x[0])):
+        if model_lc.startswith(prefix) and _source_eligible(source, provider):
             return prices
     return None
 
 
-def _lookup_base(model: str) -> dict | None:
+def _lookup_base(model: str, provider: str = "") -> dict | None:
     """Return the raw pricing dict for a model (no cache derivation yet).
 
     Two-pass strategy: first try the model id as-is. If that misses, try the
@@ -226,22 +295,22 @@ def _lookup_base(model: str) -> dict | None:
     get this treatment — see `_google_alt_form`.
     """
     model_lc = model.lower()
-    result = _lookup_form(model_lc)
+    result = _lookup_form(model_lc, provider)
     if result is not None:
         return result
     alt = _google_alt_form(model_lc)
     if alt is not None:
-        return _lookup_form(alt)
+        return _lookup_form(alt, provider)
     return None
 
 
-def _resolve_pricing(model: str) -> dict | None:
+def _resolve_pricing(model: str, provider: str = "") -> dict | None:
     """Return a fully-resolved pricing dict with all 5 keys.
 
     Derives cache prices from multipliers if not explicitly set.
     Returns None if model is completely unknown.
     """
-    base = _lookup_base(model)
+    base = _lookup_base(model, provider)
     if base is None:
         return None
 
@@ -291,7 +360,7 @@ def _resolve_pricing(model: str) -> dict | None:
     )
 
 
-def estimate_cost(usage: dict, model: str) -> float:
+def estimate_cost(usage: dict, model: str, provider: str = "") -> float:
     """Return estimated cost in USD for a usage dict.
 
     usage dict keys (all optional/nullable):
@@ -300,6 +369,11 @@ def estimate_cost(usage: dict, model: str) -> float:
       cache_read_tokens   — tokens served from cache (cheaper)
       cache_write_tokens  — tokens written to cache (more expensive)
       reasoning_tokens    — reasoning/thinking tokens (billed as output by default)
+
+    `provider` (verbatim from the gateway, e.g. "nous", "nvidia", "openrouter")
+    makes the lookup provider-aware (issue #24): an OpenRouter-sourced price is
+    never applied to a call another provider served. `provider=""` keeps the
+    historical provider-blind behaviour for backward compatibility.
 
     prompt_tokens is intentionally ignored to avoid double-counting
     (prompt_tokens = input + cache_read + cache_write in Hermes canonical usage).
@@ -326,15 +400,27 @@ def estimate_cost(usage: dict, model: str) -> float:
     ):
         return 0.0
 
-    prices = _resolve_pricing(model)
+    prices = _resolve_pricing(model, provider)
     if prices is None:
-        if model not in _warned_unknown:
-            _warned_unknown.add(model)
-            logger.warning(
-                "hermes-telemetry: unknown model %r — cost recorded as $0.00. "
-                "Add to ~/.hermes/telemetry/pricing.yaml to fix.",
-                model,
-            )
+        # Dedup per (model, provider): the same model id can be unpriced under
+        # one provider yet priced under another, so each pairing warns once.
+        warn_key = (model, provider)
+        if warn_key not in _warned_unknown:
+            _warned_unknown.add(warn_key)
+            if provider:
+                logger.warning(
+                    "hermes-telemetry: no price for model %r under provider %r — "
+                    "cost recorded as $0.00. Add it (under the provider's native "
+                    "model id) to ~/.hermes/telemetry/pricing.yaml to fix.",
+                    model,
+                    provider,
+                )
+            else:
+                logger.warning(
+                    "hermes-telemetry: unknown model %r — cost recorded as $0.00. "
+                    "Add to ~/.hermes/telemetry/pricing.yaml to fix.",
+                    model,
+                )
         return 0.0
 
     cost = (

--- a/pricing_refresh.py
+++ b/pricing_refresh.py
@@ -293,8 +293,17 @@ def refresh_pricing(dry_run: bool = False) -> tuple[dict[str, dict], list[dict]]
 
     # Update meta
     meta["auto_models"] = sorted(new_auto_models)
+    # Subscription models (manual `_subscription: true`) are a *declared* $0 —
+    # a flat-sub / free-tier rate — and must stay distinguishable from a lookup
+    # failure and from estimated-price models. They are never auto-populated;
+    # they only appear because a user hand-added them (issue #24, Option A).
+    meta["subscription_models"] = sorted(
+        m for m, e in existing_models.items() if e.get("_subscription")
+    )
     meta["estimated_price_models"] = sorted(
-        m for m, e in existing_models.items() if e.get("_estimated_price")
+        m
+        for m, e in existing_models.items()
+        if e.get("_estimated_price") and not e.get("_subscription")
     )
     meta["last_refresh"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     meta["sources"] = [s.name for s in _SOURCES]

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -256,22 +256,32 @@ def test_operator_followup_api_surfaces(serve_module):
 
 def test_model_period_trends_and_share_comparison(serve_module):
     db.start_run("sess-may-m1", model="gpt-5.4", platform="cli")
-    db.record_llm_call("sess-may-m1", "2026-05-15T10:00:00+00:00", "gpt-5.4", "openai-codex", 100, 50, 0.01, 120)
+    db.record_llm_call(
+        "sess-may-m1", "2026-05-15T10:00:00+00:00", "gpt-5.4", "openai-codex", 100, 50, 0.01, 120
+    )
     db.end_run("sess-may-m1", "ok")
 
     db.start_run("sess-may-m2", model="claude", platform="discord")
-    db.record_llm_call("sess-may-m2", "2026-05-16T10:00:00+00:00", "claude", "anthropic", 50, 50, 0.02, 140)
+    db.record_llm_call(
+        "sess-may-m2", "2026-05-16T10:00:00+00:00", "claude", "anthropic", 50, 50, 0.02, 140
+    )
     db.end_run("sess-may-m2", "ok")
 
     db.start_run("sess-june-m1", model="gpt-5.4", platform="cli")
-    db.record_llm_call("sess-june-m1", "2026-06-10T10:00:00+00:00", "gpt-5.4", "openai-codex", 300, 100, 0.03, 220)
+    db.record_llm_call(
+        "sess-june-m1", "2026-06-10T10:00:00+00:00", "gpt-5.4", "openai-codex", 300, 100, 0.03, 220
+    )
     db.end_run("sess-june-m1", "ok")
 
     db.start_run("sess-june-m2", model="claude", platform="discord")
-    db.record_llm_call("sess-june-m2", "2026-06-11T10:00:00+00:00", "claude", "anthropic", 100, 100, 0.06, 180)
+    db.record_llm_call(
+        "sess-june-m2", "2026-06-11T10:00:00+00:00", "claude", "anthropic", 100, 100, 0.06, 180
+    )
     db.end_run("sess-june-m2", "ok")
 
-    trends = serve_module.api_model_period_trends(window_hours=0, granularity="month", metric="tokens", top_n=2, limit_periods=12)
+    trends = serve_module.api_model_period_trends(
+        window_hours=0, granularity="month", metric="tokens", top_n=2, limit_periods=12
+    )
     assert trends["granularity"] == "month"
     assert trends["models"] == ["gpt-5.4", "claude"]
     assert [row["period"] for row in trends["rows"]] == ["2026-05", "2026-06"]
@@ -280,7 +290,9 @@ def test_model_period_trends_and_share_comparison(serve_module):
     assert june["models"]["claude"]["total_tokens"] == 200
     assert june["totals"]["total_tokens"] == 600
 
-    comparison = serve_module.api_model_share_comparison(window_hours=0, granularity="month", limit=10)
+    comparison = serve_module.api_model_share_comparison(
+        window_hours=0, granularity="month", limit=10
+    )
     assert comparison["current_period"] == "2026-06"
     assert comparison["previous_period"] == "2026-05"
     by_model = {row["model"]: row for row in comparison["rows"]}
@@ -292,10 +304,14 @@ def test_model_period_trends_and_share_comparison(serve_module):
 
 def test_model_share_comparison_requires_two_periods(serve_module):
     db.start_run("sess-only", model="gpt-5.4", platform="cli")
-    db.record_llm_call("sess-only", "2026-06-10T10:00:00+00:00", "gpt-5.4", "openai-codex", 300, 100, 0.03, 220)
+    db.record_llm_call(
+        "sess-only", "2026-06-10T10:00:00+00:00", "gpt-5.4", "openai-codex", 300, 100, 0.03, 220
+    )
     db.end_run("sess-only", "ok")
 
-    comparison = serve_module.api_model_share_comparison(window_hours=0, granularity="month", limit=10)
+    comparison = serve_module.api_model_share_comparison(
+        window_hours=0, granularity="month", limit=10
+    )
     assert comparison["current_period"] == "2026-06"
     assert comparison["previous_period"] is None
     assert comparison["rows"] == []
@@ -303,14 +319,20 @@ def test_model_share_comparison_requires_two_periods(serve_module):
 
 def test_model_period_trends_week_groups_by_monday_start(serve_module):
     db.start_run("sess-week-a", model="gpt-5.4", platform="cli")
-    db.record_llm_call("sess-week-a", "2025-12-29T10:00:00+00:00", "gpt-5.4", "openai-codex", 100, 0, 0.01, 100)
+    db.record_llm_call(
+        "sess-week-a", "2025-12-29T10:00:00+00:00", "gpt-5.4", "openai-codex", 100, 0, 0.01, 100
+    )
     db.end_run("sess-week-a", "ok")
 
     db.start_run("sess-week-b", model="gpt-5.4", platform="cli")
-    db.record_llm_call("sess-week-b", "2026-01-02T10:00:00+00:00", "gpt-5.4", "openai-codex", 200, 0, 0.02, 100)
+    db.record_llm_call(
+        "sess-week-b", "2026-01-02T10:00:00+00:00", "gpt-5.4", "openai-codex", 200, 0, 0.02, 100
+    )
     db.end_run("sess-week-b", "ok")
 
-    trends = serve_module.api_model_period_trends(window_hours=0, granularity="week", metric="tokens", top_n=2, limit_periods=12)
+    trends = serve_module.api_model_period_trends(
+        window_hours=0, granularity="week", metric="tokens", top_n=2, limit_periods=12
+    )
     assert [row["period"] for row in trends["rows"]] == ["2025-12-29"]
     assert trends["rows"][0]["models"]["gpt-5.4"]["total_tokens"] == 300
 
@@ -360,7 +382,9 @@ def test_budget_update_returns_viewer_timezone_metadata(serve_module, tmp_path):
     serve_module.DB_PATH = db_path
     serve_module._local.c = None
 
-    updated = serve_module.api_budget_update({"scope": "global", "window": "daily", "limit_usd": 5.0}, "UTC")
+    updated = serve_module.api_budget_update(
+        {"scope": "global", "window": "daily", "limit_usd": 5.0}, "UTC"
+    )
     expected = serve_module.api_budget("UTC")
 
     updated_daily = next(x for x in updated["budgets"] if x["scope"] == "global/daily")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -337,6 +337,7 @@ def test_model_period_trends_week_groups_by_monday_start(serve_module):
     assert trends["rows"][0]["models"]["gpt-5.4"]["total_tokens"] == 300
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="zoneinfo requires Python 3.9+")
 def test_budget_window_bounds_follow_viewer_timezone_daily(serve_module):
     bounds = serve_module._budget_window_bounds_utc(
         "daily",
@@ -348,6 +349,7 @@ def test_budget_window_bounds_follow_viewer_timezone_daily(serve_module):
     assert bounds["window_end_utc"] == "2026-06-14T18:00:00+00:00"
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="zoneinfo requires Python 3.9+")
 def test_budget_window_bounds_follow_viewer_timezone_monthly(serve_module):
     bounds = serve_module._budget_window_bounds_utc(
         "monthly",

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -51,7 +51,7 @@ def test_schema_creates_tables():
 def test_schema_idempotent():
     """Calling _ensure_schema twice must not raise or duplicate version rows.
 
-    With schema v2 applied, there are exactly 2 rows (v1 and v2).
+    There is exactly one row per applied migration (v1..v_SCHEMA_VERSION).
     Repeated calls must not add more rows.
     """
     conn = db._get_conn()
@@ -59,7 +59,7 @@ def test_schema_idempotent():
     db._ensure_schema(conn)
     db._ensure_schema(conn)
     count = conn.execute("SELECT COUNT(*) FROM schema_version").fetchone()[0]
-    # One row per schema version: v1 + v2 = 2
+    # One row per schema version
     assert count == _SCHEMA_VERSION
 
 

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -605,3 +605,207 @@ def test_google_alt_form_resolves_dated_variant_via_longest_prefix(monkeypatch):
         abs(pricing.estimate_cost(usage, dated_prefixed) - pricing.estimate_cost(usage, dated_bare))
         < 1e-9
     )
+
+
+# ---------------------------------------------------------------------------
+# Provider-aware lookup (issue #24) + NVIDIA NIM seeds (issue #12 Phase 1)
+#
+# An OpenRouter-sourced price must never cost a call another provider served.
+# The guard keys on each entry's _source vs the call's provider. Seeds with no
+# _source (_DEFAULT_PRICING, prefix table, hand-added overrides) stay neutral.
+# ---------------------------------------------------------------------------
+
+
+def test_openrouter_entry_blocked_for_nous(tmp_path, monkeypatch, caplog):
+    """An OpenRouter-sourced price is not eligible for a provider=nous call."""
+    import logging
+
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "qwen3.7-plus":
+            input: 0.40
+            output: 1.60
+            _source: openrouter
+    """),
+    )
+    with caplog.at_level(logging.WARNING, logger="hermes_telemetry.pricing"):
+        cost = pricing.estimate_cost(
+            {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+            "qwen3.7-plus",
+            provider="nous",
+        )
+    assert cost == 0.0  # NOT 0.40+1.60 — OpenRouter price must not leak to Nous
+    assert any("nous" in r.message for r in caplog.records)
+
+
+def test_openrouter_entry_used_for_openrouter(tmp_path, monkeypatch):
+    """The same OpenRouter entry IS eligible for a provider=openrouter call."""
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "qwen3.7-plus":
+            input: 0.40
+            output: 1.60
+            _source: openrouter
+    """),
+    )
+    cost = pricing.estimate_cost(
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        "qwen3.7-plus",
+        provider="openrouter",
+    )
+    assert abs(cost - (0.40 + 1.60)) < 1e-9
+
+
+def test_empty_provider_keeps_backward_compat(tmp_path, monkeypatch):
+    """provider="" (default) keeps the historical provider-blind behaviour:
+    an OpenRouter entry is still eligible."""
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "qwen3.7-plus":
+            input: 0.40
+            output: 1.60
+            _source: openrouter
+    """),
+    )
+    cost = pricing.estimate_cost(
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000}, "qwen3.7-plus"
+    )
+    assert abs(cost - (0.40 + 1.60)) < 1e-9
+
+
+def test_sourceless_override_is_neutral_for_any_provider(tmp_path, monkeypatch):
+    """A hand-added entry with no _source prices any provider's call."""
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "claude-sonnet-4-6":
+            input: 99.00
+            output: 99.00
+    """),
+    )
+    for prov in ("anthropic", "nous", "openrouter", ""):
+        cost = pricing.estimate_cost({"input_tokens": 1_000_000}, "claude-sonnet-4-6", prov)
+        assert abs(cost - 99.00) < 1e-6, f"failed for provider={prov!r}"
+
+
+def test_subscription_model_zero_cost_no_warning(tmp_path, monkeypatch, caplog):
+    """A _subscription model resolves to $0.00 WITHOUT an unknown-model warning
+    (issue #24, Option A): it is a declared flat-sub rate, not a lookup miss."""
+    import logging
+
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "qwen3.7-plus":
+            input: 0.0
+            output: 0.0
+            _subscription: true
+    """),
+    )
+    with caplog.at_level(logging.WARNING, logger="hermes_telemetry.pricing"):
+        cost = pricing.estimate_cost(
+            {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+            "qwen3.7-plus",
+            provider="nous",
+        )
+    assert cost == 0.0
+    assert not any("qwen3.7-plus" in r.message for r in caplog.records)
+
+
+def test_subscription_models_tracked_in_loader(tmp_path, monkeypatch):
+    """_load_custom_pricing exposes _subscription flags and _source metadata."""
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "qwen3.7-plus":
+            input: 0.0
+            output: 0.0
+            _subscription: true
+          "qwen/qwen3.7-plus":
+            input: 0.40
+            output: 1.60
+            _source: openrouter
+    """),
+    )
+    custom = pricing._load_custom_pricing()
+    assert "qwen3.7-plus" in custom["subscription_models"]
+    assert custom["model_sources"]["qwen/qwen3.7-plus"] == "openrouter"
+    # Price-key dict must NOT carry the _-prefixed metadata
+    assert "_subscription" not in custom["models"]["qwen3.7-plus"]
+    assert "_source" not in custom["models"]["qwen/qwen3.7-plus"]
+
+
+# ── NVIDIA NIM seeds + same-id collision with OpenRouter ──
+
+
+def test_nim_seed_used_for_nvidia_provider():
+    """A NIM model resolves to its build.nvidia.com seed (no custom file)."""
+    cost = pricing.estimate_cost(
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        "nvidia/nemotron-70b-instruct",
+        provider="nvidia",
+    )
+    assert abs(cost - (1.20 + 1.20)) < 1e-9
+
+
+def test_nim_openrouter_collision_excluded_for_nvidia(tmp_path, monkeypatch):
+    """Same model id on both NIM and OpenRouter at different prices: a
+    provider=nvidia call must fall through the OpenRouter entry to the seed."""
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "nvidia/nemotron-3-super-120b-a12b":
+            input: 0.09
+            output: 0.45
+            _source: openrouter
+    """),
+    )
+    # provider=nvidia → OpenRouter entry excluded → _DEFAULT_PRICING seed (0.10/0.50)
+    cost_nim = pricing.estimate_cost(
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        "nvidia/nemotron-3-super-120b-a12b",
+        provider="nvidia",
+    )
+    assert abs(cost_nim - (0.10 + 0.50)) < 1e-9
+    # provider=openrouter → OpenRouter entry eligible (0.09/0.45)
+    cost_or = pricing.estimate_cost(
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        "nvidia/nemotron-3-super-120b-a12b",
+        provider="openrouter",
+    )
+    assert abs(cost_or - (0.09 + 0.45)) < 1e-9
+
+
+def test_nim_free_variant_resolves_zero(caplog):
+    """A :free promo variant is unpriced → $0.00 (handled by zero-cost fallback)."""
+    cost = pricing.estimate_cost(
+        {"input_tokens": 1_000_000}, "nvidia/nemotron-3-ultra:free", provider="nvidia"
+    )
+    assert cost == 0.0
+
+
+def test_nim_seed_survives_simulated_refresh():
+    """Seeds live in _DEFAULT_PRICING (code), so they are immune to a YAML
+    sync overwriting the same model id — the seed still resolves for NIM."""
+    # No custom file at all: the seed must answer directly.
+    cost = pricing.estimate_cost(
+        {"input_tokens": 1_000_000}, "nvidia/nemotron-nano-9b", provider="nvidia"
+    )
+    assert abs(cost - 0.04) < 1e-9

--- a/tests/test_pricing_refresh.py
+++ b/tests/test_pricing_refresh.py
@@ -156,3 +156,60 @@ def test_google_ai_source_fetch_returns_copies_not_references():
     assert second[first_model]["input"] != 99999.0, (
         "fetch() should return fresh copies, not references to class state"
     )
+
+
+# ---------------------------------------------------------------------------
+# Subscription-model meta + survival across refresh (issue #24, Option A)
+# ---------------------------------------------------------------------------
+
+
+def _StubSource(models: dict[str, dict]):
+    class _S(PricingSource):
+        name = "openrouter"  # impersonate OpenRouter so entries carry that source
+
+        def fetch(self) -> dict[str, dict]:
+            return {k: dict(v) for k, v in models.items()}
+
+    return _S
+
+
+def test_manual_subscription_entry_survives_refresh(tmp_path, monkeypatch):
+    """A hand-added `_subscription` entry under the provider-native (bare) id is
+    never returned by OpenRouter, so a refresh leaves it untouched and records
+    it in _meta.subscription_models — not in estimated_price_models."""
+    import yaml
+
+    import pricing_refresh
+
+    pfile = tmp_path / "pricing.yaml"
+    pfile.write_text(
+        yaml.safe_dump(
+            {
+                "models": {
+                    "qwen3.7-plus": {"input": 0.0, "output": 0.0, "_subscription": True},
+                },
+                "defaults": {"cache_read_multiplier": 0.10, "cache_write_multiplier": 1.25},
+            }
+        )
+    )
+    monkeypatch.setattr(pricing_refresh, "PRICING_FILE", pfile)
+    # OpenRouter returns the PREFIXED form — a different key, so no collision.
+    monkeypatch.setattr(
+        pricing_refresh,
+        "_SOURCES",
+        [_StubSource({"qwen/qwen3.7-plus": {"input": 0.40, "output": 1.60}})],
+    )
+
+    changes, _overrides = pricing_refresh.refresh_pricing()
+
+    written = yaml.safe_load(pfile.read_text())
+    models = written["models"]
+    meta = written["_meta"]
+    # Manual subscription entry preserved verbatim
+    assert models["qwen3.7-plus"]["_subscription"] is True
+    assert models["qwen3.7-plus"]["input"] == 0.0
+    # OpenRouter prefixed form added alongside (different key — no clobber)
+    assert models["qwen/qwen3.7-plus"]["input"] == 0.40
+    # Meta classifies the subscription model correctly
+    assert "qwen3.7-plus" in meta["subscription_models"]
+    assert "qwen3.7-plus" not in meta.get("estimated_price_models", [])


### PR DESCRIPTION
## Summary

Implements provider-aware pricing lookup to prevent OpenRouter-sourced prices from being applied to calls served by other providers (Nous Portal, NVIDIA NIM, etc.). Adds NVIDIA NIM seed prices for Nemotron models and introduces `_subscription` tag for flat-rate/free-tier models.

**Key changes:**

1. **Provider-aware guard** (`_source_eligible`): OpenRouter-sourced entries (`_source: openrouter`) are now skipped for non-OpenRouter calls, allowing the lookup to fall through to source-neutral seeds or hand-added overrides. Backward compatible — `provider=""` preserves the old provider-blind behavior.

2. **NVIDIA NIM seeds**: Five Nemotron models added to `_DEFAULT_PRICING` (source-neutral, immune to OpenRouter syncs). Resolves same-id collisions where NIM and OpenRouter list the same model at different prices.

3. **`_subscription` tag**: Declares a genuine $0 (flat-sub/free-tier) rate, distinct from a lookup miss. Tracked separately in `_meta.subscription_models` and excluded from `estimated_price_models`.

4. **Metadata extraction**: `_load_custom_pricing` now captures `_source` and `_subscription` tags into parallel structures (`model_sources`, `subscription_models`) before stripping them from the price dict, enabling the provider guard to work.

5. **Schema v3→v4**: Bumped `_SCHEMA_VERSION` to reflect the `_migrate_v4` migration (cache tokens on `runs`) that was shipped without the bump.

## Type of change
- [x] feat — new feature
- [x] refactor — no behavioral change (pricing lookup threading)
- [x] test — adding/correcting tests

## Checklist
- [x] Tests pass locally (`pytest tests/ -v`)
- [x] Lint passes (`ruff check . && ruff format --check .`)
- [x] CHANGELOG.md updated (user-facing changes)
- [x] ONBOARDING.md updated (provider-aware guard, subscription models, NIM seeds documented)

## Testing

**New test coverage:**
- `test_openrouter_entry_blocked_for_nous` — OpenRouter price rejected for non-OpenRouter provider
- `test_openrouter_entry_used_for_openrouter` — Same entry accepted for OpenRouter provider
- `test_empty_provider_keeps_backward_compat` — `provider=""` preserves old behavior
- `test_sourceless_override_is_neutral_for_any_provider` — Hand-added entries work for all providers
- `test_subscription_model_zero_cost_no_warning` — `_subscription` models don't trigger unknown-model warnings
- `test_subscription_models_tracked_in_loader` — Metadata extraction verified
- `test_nim_seed_used_for_nvidia_provider` — NIM seeds resolve for `provider="nvidia"`
- `test_nim_openrouter_collision_excluded_for_nvidia` — Same-id collision resolved correctly
- `test_nim_free_variant_resolves_zero` — `:free` promo variants cost $0
- `test_nim_seed_survives_simulated_refresh` — Seeds immune to YAML overwrites
- `test_manual_subscription_entry_survives_refresh` — Subscription entries preserved across refresh

All existing tests pass; no regressions.

## Notes

- `estimate_cost` signature changed to accept optional `provider` kwarg; threaded through `_resolve_pricing` → `_lookup_base` → `_lookup_form`
- `_warned_unknown` changed from `set[str]` to `set[tuple[str, str]]` to deduplicate per (model, provider) pair
- Warning messages now distinguish between provider-specific misses and generic unknown models
- `pricing_refresh.py` updated to track `subscription_models` in `_meta` and exclude them from `estimated_price_models`

https://claude.ai/code/session_019CrA4wSfpisJ99kP7ZiF5n