### PR TITLE
BUILD #4: tokentelemetry: remote access + per-step traces for CLI sessions

### DIFF
--- a/BUILD-PLAN-issue-4.md
+++ b/BUILD-PLAN-issue-4.md
@@ -1,14 +1,11 @@
 # BUILD PLAN — Issue #4
-
 **Card:** [nujovich/hermes-radar#4](https://github.com/nujovich/hermes-radar/issues/4)
 **Title:** tokentelemetry: remote access + per-step traces for CLI sessions
 **Board:** hermes-radar (competitive-watch)
 
-## Decisión de Nadia
-
-Agregar al backlog con baja prioridad. Evaluar gaps primero antes de implementar features nuevas.
+## Nadia's Decision
+Add to the backlog with low priority. Evaluate gaps first before implementing new features.
 
 ## Milestones
-
-- [ ] Milestone 1: Evaluar gaps — hermes-telemetry tiene dashboard local (HTML servido localmente); no tiene remote access, data-dir configurable, ni QR bootstrap. Evaluar si los usuarios de hermes-telemetry necesitan remote access.
-- [ ] Milestone 2: Feature backlog — data-dir configurable (baja complejidad, útil para setups multi-disco); remote access (alta complejidad, considerar solo si hay demanda).
+- [ ] Milestone 1: Evaluate gaps — hermes-telemetry has a local dashboard (HTML served locally); it has no remote access, no configurable data-dir, and no QR bootstrap. Assess whether hermes-telemetry users actually need remote access.
+- [ ] Milestone 2: Feature backlog — configurable data-dir (low complexity, useful for multi-disk setups); remote access (high complexity, only consider if there's demand).

--- a/BUILD-PLAN-issue-4.md
+++ b/BUILD-PLAN-issue-4.md
@@ -1,0 +1,14 @@
+# BUILD PLAN — Issue #4
+
+**Card:** [nujovich/hermes-radar#4](https://github.com/nujovich/hermes-radar/issues/4)
+**Title:** tokentelemetry: remote access + per-step traces for CLI sessions
+**Board:** hermes-radar (competitive-watch)
+
+## Decisión de Nadia
+
+Agregar al backlog con baja prioridad. Evaluar gaps primero antes de implementar features nuevas.
+
+## Milestones
+
+- [ ] Milestone 1: Evaluar gaps — hermes-telemetry tiene dashboard local (HTML servido localmente); no tiene remote access, data-dir configurable, ni QR bootstrap. Evaluar si los usuarios de hermes-telemetry necesitan remote access.
+- [ ] Milestone 2: Feature backlog — data-dir configurable (baja complejidad, útil para setups multi-disco); remote access (alta complejidad, considerar solo si hay demanda).


### PR DESCRIPTION
# BUILD PLAN — Issue #4
**Card:** [nujovich/hermes-radar#4](https://github.com/nujovich/hermes-radar/issues/4)
**Title:** tokentelemetry: remote access + per-step traces for CLI sessions
**Board:** hermes-radar (competitive-watch)

## Nadia's Decision
Add to the backlog with low priority. Evaluate gaps first before implementing new features.

## Milestones
- [ ] Milestone 1: Evaluate gaps — hermes-telemetry has a local dashboard (HTML served locally); it has no remote access, no configurable data-dir, and no QR bootstrap. Assess whether hermes-telemetry users actually need remote access.
- [ ] Milestone 2: Feature backlog — configurable data-dir (low complexity, useful for multi-disk setups); remote access (high complexity, only consider if there's demand).