### PR TITLE
feat(#16): free→paid model transition alert (Block A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Free→paid model transition alert (issue #16, Block A). When a model that
+  was previously seen at explicit `$0` (subscription or zero-price entry in
+  `pricing.yaml`) starts incurring cost, a one-shot warning is injected into
+  the next `pre_llm_call` context so the agent can surface it to the user.
+  The alert fires once per session per transition and is cleared immediately
+  after injection.
+- `known_free_models` SQLite table (schema v5) persists every `(model,
+  provider)` pair observed at explicit `$0`, enabling cross-session detection.
+  `is_explicitly_priced(model, provider)` distinguishes genuinely-free models
+  from unknown-model `$0` fallbacks so only real free-tier models are tracked.
+- Backward-compatible backfill: on every plugin load, `register()` scans all
+  explicitly-`$0` models from `pricing.yaml` and `_DEFAULT_PRICING` and seeds
+  `known_free_models` with a `provider=''` wildcard row. Pre-v5 users who
+  already had subscription models are covered automatically on first upgrade
+  without requiring a prior `$0` call in the new version.
+- `pricing.get_known_free_models()` — returns all model names with explicit
+  `input=0.0 AND output=0.0` from custom and default pricing; used by the
+  backfill and available for external inspection.
+- `db.backfill_known_free_models(models)` — inserts `(model, provider='')` 
+  wildcard rows; `INSERT OR IGNORE` makes it safe to call on every load.
+
 ## [0.4.1] - 2026-06-14
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -159,6 +159,21 @@ def register(ctx) -> None:  # noqa: ANN001
     _try_pricing_refresh(tele_log)
 
     # ------------------------------------------------------------------
+    # Backward-compat backfill: seed known_free_models for users upgrading
+    # from pre-v5 installs who have subscription or zero-price models in
+    # their pricing.yaml but no persisted rows yet (INSERT OR IGNORE — safe
+    # to call on every load; only new rows cost anything).
+    # ------------------------------------------------------------------
+    try:
+        _free_models = pricing.get_known_free_models()
+        if _free_models:
+            _n = db.backfill_known_free_models(_free_models)
+            if _n:
+                tele_log.info("backfilled %d known-free model(s) for free→paid alert", _n)
+    except Exception as exc:
+        tele_log.error("known_free_models backfill failed: %s", exc)
+
+    # ------------------------------------------------------------------
     # on_session_start
     # Fired once per new session.
     # kwargs: session_id, model, platform

--- a/__init__.py
+++ b/__init__.py
@@ -34,6 +34,13 @@ _approx_lock = threading.Lock()
 # ---------------------------------------------------------------------------
 _nous_estimated_warned: set = set()
 
+# Free→paid transition alerts (issue #16).
+# Maps session_id → (model, cost_usd) for the first paid call after a series
+# of $0 calls on the same (model, provider). Injected into context by
+# pre_llm_call and cleared immediately after injection so it fires only once.
+_pending_free_paid_alerts: dict[str, tuple[str, float]] = {}
+_pending_free_paid_lock = threading.Lock()
+
 # Characters per token estimate (used when usage=None)
 _CHARS_PER_TOKEN = 4
 
@@ -263,6 +270,24 @@ def register(ctx) -> None:  # noqa: ANN001
             cost = pricing.estimate_cost(full_usage, effective_model, provider)
             latency_ms = int(api_duration * 1000)
 
+            # Free→paid transition detection (issue #16).
+            # Only models with explicit pricing (not unknown-model fallback) are
+            # tracked: an unknown model at $0 is not "free by design" and should
+            # not trigger a false alert when it later gets a real price entry.
+            if cost == 0.0 and pricing.is_explicitly_priced(effective_model, provider):
+                db.record_free_model(effective_model, provider)
+            elif cost > 0.0 and db.is_known_free_model(effective_model, provider):
+                with _pending_free_paid_lock:
+                    if session_id not in _pending_free_paid_alerts:
+                        _pending_free_paid_alerts[session_id] = (effective_model, cost)
+                tele_log.info(
+                    "free→paid transition detected: model=%r provider=%r cost=%.6f session=%s",
+                    effective_model,
+                    provider,
+                    cost,
+                    session_id,
+                )
+
             db.record_llm_call(
                 session_id=session_id,
                 ts=_utcnow(),
@@ -408,10 +433,29 @@ def register(ctx) -> None:  # noqa: ANN001
                 return None
             verdicts = budget.evaluate_run(run)
             budget.enforce_cron_pause(verdicts)
+            ctx_parts: list[str] = []
             ctx_text = budget.alert_context(verdicts)
             if ctx_text:
                 tele_log.info("budget alert injected for session=%s", session_id)
-                return {"context": ctx_text}
+                ctx_parts.append(ctx_text)
+            with _pending_free_paid_lock:
+                alert = _pending_free_paid_alerts.pop(session_id, None)
+            if alert:
+                alert_model, alert_cost = alert
+                ctx_parts.append(
+                    f"⚠️ [hermes-telemetry] Model `{alert_model}` was previously $0.00 "
+                    f"— this call cost ${alert_cost:.4f}. "
+                    f"If this is unexpected, check your pricing config or `_subscription` "
+                    f"tag in ~/.hermes/telemetry/pricing.yaml."
+                )
+                tele_log.info(
+                    "free→paid alert injected for session=%s model=%r cost=%.6f",
+                    session_id,
+                    alert_model,
+                    alert_cost,
+                )
+            if ctx_parts:
+                return {"context": "\n\n".join(ctx_parts)}
         except Exception as exc:
             tele_log.error("pre_llm_call (budget) hook failed: %s", exc)
         return None

--- a/db.py
+++ b/db.py
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 4
+_SCHEMA_VERSION = 5
 _local = threading.local()
 
 # Serializes first-time schema setup across threads. Each thread opens its own
@@ -141,6 +141,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _migrate_v2(conn)
     _migrate_v3(conn)
     _migrate_v4(conn)
+    _migrate_v5(conn)
 
 
 def _migrate_v2(conn: sqlite3.Connection) -> None:
@@ -228,6 +229,27 @@ def _migrate_v4(conn: sqlite3.Connection) -> None:
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (4, ?)",
+        (_utcnow(),),
+    )
+
+
+def _migrate_v5(conn: sqlite3.Connection) -> None:
+    """Add v5 schema: known_free_models table for free→paid transition alerts."""
+    cur = conn.execute("SELECT version FROM schema_version WHERE version = 5")
+    if cur.fetchone() is not None:
+        return
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS known_free_models (
+            model         TEXT NOT NULL,
+            provider      TEXT NOT NULL DEFAULT '',
+            first_seen_at TEXT NOT NULL,
+            PRIMARY KEY (model, provider)
+        )
+    """)
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (5, ?)",
         (_utcnow(),),
     )
 
@@ -736,3 +758,30 @@ def estimated_price_share(scope: str, scope_id: str, since_iso: str) -> float:
     total = row["total"] or 0
     est = row["est_calls"] or 0
     return est / total if total else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Free→paid model tracking (issue #16)
+# ---------------------------------------------------------------------------
+def record_free_model(model: str, provider: str = "") -> None:
+    """Persist a (model, provider) pair as known-free.
+
+    Called whenever a call resolves to cost==0 with explicit pricing (not an
+    unknown model). Subsequent calls to the same pair that cost >0 trigger the
+    free→paid alert. INSERT OR IGNORE so we never overwrite first_seen_at.
+    """
+    conn = _get_conn()
+    conn.execute(
+        "INSERT OR IGNORE INTO known_free_models(model, provider, first_seen_at) VALUES (?, ?, ?)",
+        (model, provider, _utcnow()),
+    )
+
+
+def is_known_free_model(model: str, provider: str = "") -> bool:
+    """Return True if this (model, provider) pair was previously seen at $0."""
+    conn = _get_conn()
+    row = conn.execute(
+        "SELECT 1 FROM known_free_models WHERE model = ? AND provider = ?",
+        (model, provider),
+    ).fetchone()
+    return row is not None

--- a/db.py
+++ b/db.py
@@ -778,10 +778,35 @@ def record_free_model(model: str, provider: str = "") -> None:
 
 
 def is_known_free_model(model: str, provider: str = "") -> bool:
-    """Return True if this (model, provider) pair was previously seen at $0."""
+    """Return True if this (model, provider) pair was previously seen at $0.
+
+    Also matches rows with provider='' (wildcard sentinel written by
+    backfill_known_free_models for pre-v5 installs that had no per-provider rows).
+    """
     conn = _get_conn()
     row = conn.execute(
-        "SELECT 1 FROM known_free_models WHERE model = ? AND provider = ?",
+        "SELECT 1 FROM known_free_models WHERE model = ? AND (provider = ? OR provider = '')",
         (model, provider),
     ).fetchone()
     return row is not None
+
+
+def backfill_known_free_models(models: list) -> int:
+    """Insert known-free models with provider='' (wildcard) for backward compat.
+
+    Called once at plugin load for models that were explicitly $0 before the
+    known_free_models table existed. INSERT OR IGNORE never overwrites real rows
+    (rows with a specific provider take precedence and are unaffected).
+    Returns the count of rows actually inserted.
+    """
+    conn = _get_conn()
+    now = _utcnow()
+    inserted = 0
+    for model in models:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO known_free_models(model, provider, first_seen_at)"
+            " VALUES (?, '', ?)",
+            (model, now),
+        )
+        inserted += cur.rowcount
+    return inserted

--- a/pricing.py
+++ b/pricing.py
@@ -445,6 +445,42 @@ def is_explicitly_priced(model: str, provider: str = "") -> bool:
     return _resolve_pricing(model, provider) is not None
 
 
+def get_known_free_models() -> list:
+    """Return all model names that are explicitly priced at input=0 AND output=0.
+
+    Used at plugin load to backfill known_free_models for pre-v5 installs that
+    had subscription or zero-price models but no persistent free-model rows yet.
+    Only models that would actually produce cost==0 via estimate_cost are included —
+    this mirrors the condition in post_api_request that calls record_free_model.
+    Subscription models with nonzero prices are excluded (they cost money and
+    should never appear in known_free_models).
+    """
+    result: list[str] = []
+    seen: set[str] = set()
+    custom = _load_custom_pricing()
+    custom_models = custom.get("models", {})
+
+    for model, prices in custom_models.items():
+        if (
+            model not in seen
+            and float(prices.get("input", -1)) == 0.0
+            and float(prices.get("output", -1)) == 0.0
+        ):
+            result.append(model)
+            seen.add(model)
+
+    for model, prices in _DEFAULT_PRICING.items():
+        if (
+            model not in seen
+            and float(prices.get("input", -1)) == 0.0
+            and float(prices.get("output", -1)) == 0.0
+        ):
+            result.append(model)
+            seen.add(model)
+
+    return result
+
+
 def reload_custom_pricing() -> None:
     """Force-reload the user pricing file (useful in tests)."""
     global _custom_pricing

--- a/pricing.py
+++ b/pricing.py
@@ -434,6 +434,17 @@ def estimate_cost(usage: dict, model: str, provider: str = "") -> float:
     return cost
 
 
+def is_explicitly_priced(model: str, provider: str = "") -> bool:
+    """Return True if *model* has an explicit pricing entry (even if $0).
+
+    Distinguishes genuinely-free models (explicit zero price or _subscription)
+    from unknown models (no entry at all, which also produce cost==0 via the
+    fallback). Only explicitly-priced-at-$0 models are recorded in
+    known_free_models and can trigger the free→paid transition alert.
+    """
+    return _resolve_pricing(model, provider) is not None
+
+
 def reload_custom_pricing() -> None:
     """Force-reload the user pricing file (useful in tests)."""
     global _custom_pricing

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -645,7 +645,7 @@ def test_record_free_model_is_idempotent():
 
 def test_known_free_model_is_provider_scoped():
     db.record_free_model("owl-alpha", "nous")
-    # Same model under a different provider is NOT known-free
+    # Specific-provider row does NOT match other providers (no wildcard row present)
     assert not db.is_known_free_model("owl-alpha", "openrouter")
     assert not db.is_known_free_model("owl-alpha", "")
 
@@ -659,3 +659,46 @@ def test_schema_v5_recorded():
 
     versions = {row[0] for row in _get_conn().execute("SELECT version FROM schema_version")}
     assert 5 in versions
+
+
+# ---------------------------------------------------------------------------
+# backfill_known_free_models — backward-compat wildcard rows (issue #16)
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_inserts_wildcard_rows():
+    """backfill_known_free_models inserts rows with provider=''."""
+    n = db.backfill_known_free_models(["owl-alpha", "hermes-4-qwen"])
+    assert n == 2
+    conn = db._get_conn()
+    rows = conn.execute(
+        "SELECT provider FROM known_free_models WHERE model IN ('owl-alpha', 'hermes-4-qwen')"
+    ).fetchall()
+    assert all(r[0] == "" for r in rows)
+
+
+def test_backfill_wildcard_matches_any_provider():
+    """After backfill, is_known_free_model returns True regardless of provider."""
+    db.backfill_known_free_models(["owl-alpha"])
+    assert db.is_known_free_model("owl-alpha", "nous")
+    assert db.is_known_free_model("owl-alpha", "openrouter")
+    assert db.is_known_free_model("owl-alpha", "nvidia")
+    assert db.is_known_free_model("owl-alpha", "")
+
+
+def test_backfill_is_idempotent():
+    """Second backfill call returns 0 — INSERT OR IGNORE prevents duplicates."""
+    assert db.backfill_known_free_models(["owl-alpha"]) == 1
+    assert db.backfill_known_free_models(["owl-alpha"]) == 0
+
+
+def test_backfill_does_not_overwrite_specific_provider_row():
+    """Backfill and record_free_model coexist — separate PRIMARY KEY rows."""
+    db.record_free_model("owl-alpha", "nous")
+    db.backfill_known_free_models(["owl-alpha"])
+    conn = db._get_conn()
+    rows = conn.execute(
+        "SELECT provider FROM known_free_models WHERE model = 'owl-alpha'"
+    ).fetchall()
+    providers = {r[0] for r in rows}
+    assert providers == {"nous", ""}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -624,3 +624,38 @@ def test_orphan_session_appears_in_stats_summary():
     assert summary["total_runs"] >= 1
     assert summary["tokens_in"] >= 1000
     assert summary["cost_usd"] >= 0.005
+
+
+# ---------------------------------------------------------------------------
+# known_free_models — free→paid tracking (issue #16)
+# ---------------------------------------------------------------------------
+
+
+def test_record_and_detect_known_free_model():
+    assert not db.is_known_free_model("owl-alpha", "nous")
+    db.record_free_model("owl-alpha", "nous")
+    assert db.is_known_free_model("owl-alpha", "nous")
+
+
+def test_record_free_model_is_idempotent():
+    db.record_free_model("owl-alpha", "nous")
+    db.record_free_model("owl-alpha", "nous")  # should not raise
+    assert db.is_known_free_model("owl-alpha", "nous")
+
+
+def test_known_free_model_is_provider_scoped():
+    db.record_free_model("owl-alpha", "nous")
+    # Same model under a different provider is NOT known-free
+    assert not db.is_known_free_model("owl-alpha", "openrouter")
+    assert not db.is_known_free_model("owl-alpha", "")
+
+
+def test_unknown_model_is_not_known_free():
+    assert not db.is_known_free_model("completely-unknown-model-xyz", "nvidia")
+
+
+def test_schema_v5_recorded():
+    from db import _get_conn
+
+    versions = {row[0] for row in _get_conn().execute("SELECT version FROM schema_version")}
+    assert 5 in versions

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -105,3 +105,71 @@ def test_plugin_yaml_uses_provides_hooks():
     assert "hooks" not in data, (
         "plugin.yaml must not use legacy 'hooks:' key — rename to 'provides_hooks:'"
     )
+
+
+# ---------------------------------------------------------------------------
+# Free→paid transition alert (issue #16)
+# ---------------------------------------------------------------------------
+
+
+def test_free_to_paid_alert_queued_when_known_free_model_costs_money(tmp_path, monkeypatch):
+    """post_api_request queues an alert when a previously-free model goes paid."""
+    import db
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "telemetry").mkdir()
+    db.close_thread_conn()  # force fresh connection to new HERMES_HOME
+
+    # Seed the model as known-free
+    db.record_free_model("owl-alpha", "nous")
+
+    # Directly exercise the detection logic via the module-level dict
+    _init_mod._pending_free_paid_alerts.clear()
+    # (full hook invocation requires a live PluginContext — we test the dict path)
+    model = "owl-alpha"
+    provider = "nous"
+    cost = 1.5
+    if cost > 0.0 and db.is_known_free_model(model, provider):
+        with _init_mod._pending_free_paid_lock:
+            if "sess-alert-test" not in _init_mod._pending_free_paid_alerts:
+                _init_mod._pending_free_paid_alerts["sess-alert-test"] = (model, cost)
+
+    assert "sess-alert-test" in _init_mod._pending_free_paid_alerts
+    queued_model, queued_cost = _init_mod._pending_free_paid_alerts["sess-alert-test"]
+    assert queued_model == "owl-alpha"
+    assert abs(queued_cost - 1.5) < 1e-9
+
+
+def test_unknown_model_does_not_queue_free_to_paid_alert(tmp_path, monkeypatch):
+    """Unknown models at $0 do NOT get recorded as known-free (no false alerts)."""
+    import db
+    import pricing
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "telemetry").mkdir()
+    db.close_thread_conn()
+
+    model = "nvidia/nemotron-3-ultra:free"
+    provider = "nvidia"
+
+    # Unknown model: is_explicitly_priced returns False → should NOT be recorded
+    assert not pricing.is_explicitly_priced(model, provider)
+
+    # Simulate what post_api_request does: only record if explicitly priced
+    cost = 0.0
+    if cost == 0.0 and pricing.is_explicitly_priced(model, provider):
+        db.record_free_model(model, provider)
+
+    assert not db.is_known_free_model(model, provider)
+
+
+def test_free_to_paid_alert_fires_only_once_per_session():
+    """Alert is cleared from _pending after first pre_llm_call injection."""
+    _init_mod._pending_free_paid_alerts["sess-once"] = ("some-model", 0.99)
+    with _init_mod._pending_free_paid_lock:
+        alert = _init_mod._pending_free_paid_alerts.pop("sess-once", None)
+    assert alert is not None
+    # Second pop returns None — alert cleared
+    with _init_mod._pending_free_paid_lock:
+        alert2 = _init_mod._pending_free_paid_alerts.pop("sess-once", None)
+    assert alert2 is None

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -840,3 +840,50 @@ def test_is_explicitly_priced_subscription_model(tmp_path, monkeypatch):
     pricing.reload_custom_pricing()
     assert pricing.is_explicitly_priced("hermes-4-qwen-72b") is True
     pricing.reload_custom_pricing()
+
+
+# ---------------------------------------------------------------------------
+# get_known_free_models — backfill list for pre-v5 installs (issue #16)
+# ---------------------------------------------------------------------------
+
+
+def test_get_known_free_models_includes_zero_price_models():
+    """Models with explicit input=0, output=0 in the fixture are returned."""
+    models = pricing.get_known_free_models()
+    assert "owl-alpha" in models
+    assert "openrouter/owl-alpha" in models
+
+
+def test_get_known_free_models_no_duplicates():
+    """Each model appears at most once in the result."""
+    models = pricing.get_known_free_models()
+    assert len(models) == len(set(models))
+
+
+def test_get_known_free_models_excludes_paid_models():
+    """Paid models (input > 0 or output > 0) are NOT returned."""
+    models = pricing.get_known_free_models()
+    assert "claude-sonnet-4-6" not in models
+    assert "gpt-4o" not in models
+
+
+def test_get_known_free_models_includes_subscription_models(tmp_path, monkeypatch):
+    """Subscription models (_subscription: true) appear in the backfill list."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "telemetry").mkdir()
+    (tmp_path / "telemetry" / "pricing.yaml").write_text(
+        "models:\n"
+        "  hermes-4-qwen-72b:\n"
+        "    input: 0.0\n"
+        "    output: 0.0\n"
+        "    _subscription: true\n"
+        "  paid-model:\n"
+        "    input: 3.0\n"
+        "    output: 15.0\n"
+        "    _subscription: true\n"
+    )
+    pricing.reload_custom_pricing()
+    models = pricing.get_known_free_models()
+    assert "hermes-4-qwen-72b" in models
+    assert "paid-model" not in models
+    pricing.reload_custom_pricing()

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -809,3 +809,34 @@ def test_nim_seed_survives_simulated_refresh():
         {"input_tokens": 1_000_000}, "nvidia/nemotron-nano-9b", provider="nvidia"
     )
     assert abs(cost - 0.04) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# is_explicitly_priced — distinguishes genuine-free from unknown (issue #16)
+# ---------------------------------------------------------------------------
+
+
+def test_is_explicitly_priced_known_model():
+    assert pricing.is_explicitly_priced("claude-sonnet-4-6") is True
+    assert pricing.is_explicitly_priced("gpt-4o") is True
+    assert pricing.is_explicitly_priced("nvidia/nemotron-70b-instruct", "nvidia") is True
+
+
+def test_is_explicitly_priced_zero_price_model():
+    assert pricing.is_explicitly_priced("owl-alpha") is True  # input=0, output=0
+
+
+def test_is_explicitly_priced_unknown_model():
+    assert pricing.is_explicitly_priced("completely-unknown-xyz-model") is False
+    assert pricing.is_explicitly_priced("nvidia/nemotron-3-ultra:free") is False
+
+
+def test_is_explicitly_priced_subscription_model(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "telemetry").mkdir()
+    (tmp_path / "telemetry" / "pricing.yaml").write_text(
+        "models:\n  hermes-4-qwen-72b:\n    input: 0.0\n    output: 0.0\n    _subscription: true\n"
+    )
+    pricing.reload_custom_pricing()
+    assert pricing.is_explicitly_priced("hermes-4-qwen-72b") is True
+    pricing.reload_custom_pricing()


### PR DESCRIPTION
## Summary

- Adds cross-session detection of models that transition from $0 to paid
- New SQLite table `known_free_models` (schema v5) tracks every `(model, provider)` pair seen at explicit $0
- `pre_llm_call` injects a one-shot warning when a previously-free model starts costing money
- Backward-compat backfill at plugin load seeds the table for pre-v5 installs that already had subscription/zero-price models

## How it works

**Flow 1 — live tracking (same or later session)**
```
post_api_request(cost=0.0, explicitly_priced=True)
  → record_free_model(model, provider)       # INSERT OR IGNORE into known_free_models

post_api_request(cost=0.0045)               # model now costs money
  → is_known_free_model(model, provider)     # True → queue alert

pre_llm_call (next turn)
  → pop alert → inject ⚠️ into context (fires once per transition)
```

**Flow 2 — backfill on upgrade (new session after install)**
```
register() at plugin load
  → pricing.get_known_free_models()          # all models with input=0.0 AND output=0.0
  → db.backfill_known_free_models(models)    # INSERT OR IGNORE with provider='' (wildcard)

is_known_free_model(model, any_provider)
  → SQL: WHERE model=? AND (provider=? OR provider='')   # wildcard matches any provider
```

## New functions

| Function | Module | Description |
|---|---|---|
| `record_free_model(model, provider)` | `db` | Persists a known-free pair |
| `is_known_free_model(model, provider)` | `db` | Checks pair + wildcard sentinel |
| `backfill_known_free_models(models)` | `db` | Inserts `provider=''` wildcard rows for upgrade compat |
| `get_known_free_models()` | `pricing` | Returns all explicitly-$0 models from custom + default pricing |
| `is_explicitly_priced(model, provider)` | `pricing` | Distinguishes genuine-$0 from unknown-model fallback |

## Tests (automated)

253 tests, all passing (`ruff format --check . && ruff check . && pytest tests/ -v`).

New tests: `test_db.py` (+9), `test_pricing.py` (+8), `test_init.py` (+3).

## Manual test plan

Requires: repo root as working directory, `HERMES_HOME` isolated.

```bash
cd ~/hermes-telemetry
git checkout feat/free-to-paid-spend-alert
export HERMES_HOME=/tmp/hermes-test
mkdir -p $HERMES_HOME/telemetry
```

### T1 — Schema v5 applied on startup
```bash
python3 -c "
import os, sys; sys.path.insert(0, '.'); os.environ['HERMES_HOME'] = '/tmp/hermes-test'
import db
conn = db._get_conn()
print([r[0] for r in conn.execute('SELECT version FROM schema_version ORDER BY version')])
# → [1, 2, 3, 4, 5]
r = conn.execute(\"SELECT name FROM sqlite_master WHERE name='known_free_models'\").fetchone()
print(r[0] if r else 'MISSING')
# → known_free_models
"
```

### T2 — Unknown model is NOT recorded as free
```bash
python3 -c "
import os, sys; sys.path.insert(0, '.'); os.environ['HERMES_HOME'] = '/tmp/hermes-test'
import db, pricing
model, provider = 'nvidia/nemotron-3-ultra:free', 'nvidia'
print('explicitly_priced:', pricing.is_explicitly_priced(model, provider))   # → False
if pricing.is_explicitly_priced(model, provider): db.record_free_model(model, provider)
print('is_known_free:', db.is_known_free_model(model, provider))             # → False
"
```

### T3 — Explicitly-$0 model gets recorded
```bash
cat > $HERMES_HOME/telemetry/pricing.yaml << 'EOF'
models:
  hermes-4-qwen-72b:
    input: 0.0
    output: 0.0
    _subscription: true
EOF

python3 -c "
import os, sys; sys.path.insert(0, '.'); os.environ['HERMES_HOME'] = '/tmp/hermes-test'
import db, pricing
model, provider = 'hermes-4-qwen-72b', 'nous'
print('explicitly_priced:', pricing.is_explicitly_priced(model, provider))   # → True
db.record_free_model(model, provider)
conn = db._get_conn()
print(dict(conn.execute('SELECT model, provider FROM known_free_models').fetchone()))
# → {'model': 'hermes-4-qwen-72b', 'provider': 'nous'}
"
```

### T4 — Alert is queued and fires only once
```bash
python3 -c "
import os, sys, threading; sys.path.insert(0, '.'); os.environ['HERMES_HOME'] = '/tmp/hermes-test'
import db
db.record_free_model('hermes-4-qwen-72b', 'nous')
pending, lock = {}, threading.Lock()
model, provider, cost, sid = 'hermes-4-qwen-72b', 'nous', 0.0045, 'sess-test-001'
if cost > 0.0 and db.is_known_free_model(model, provider):
    with lock:
        if sid not in pending: pending[sid] = (model, cost)
print('Queued:', pending)                        # → {'sess-test-001': ('hermes-4-qwen-72b', 0.0045)}
print('1st injection:', pending.pop(sid, None))  # → ('hermes-4-qwen-72b', 0.0045)
print('2nd injection:', pending.pop(sid, None))  # → None
"
```

### T5 — Backfill on upgrade (clean DB)
```bash
rm -f $HERMES_HOME/telemetry/telemetry.db
python3 -c "
import os, sys; sys.path.insert(0, '.'); os.environ['HERMES_HOME'] = '/tmp/hermes-test'
import db, pricing
models = pricing.get_known_free_models()
print('Candidates:', models)                          # → ['hermes-4-qwen-72b', 'owl-alpha']
n1 = db.backfill_known_free_models(models)
n2 = db.backfill_known_free_models(models)
print('1st run:', n1, '/ 2nd run (idempotent):', n2)  # → 2 / 0
rows = db._get_conn().execute('SELECT model, provider FROM known_free_models').fetchall()
print([(r['model'], repr(r['provider'])) for r in rows])
# → [('hermes-4-qwen-72b', \"''\"), ('owl-alpha', \"''\")]  ← wildcard
"
```

### T6 — Wildcard row matches any provider
```bash
python3 -c "
import os, sys; sys.path.insert(0, '.'); os.environ['HERMES_HOME'] = '/tmp/hermes-test'
import db
db.backfill_known_free_models(['hermes-4-qwen-72b'])
for prov in ['nous', 'openrouter', 'nvidia', 'anthropic', '']:
    print(f'  provider={prov!r:12s} → {db.is_known_free_model(\"hermes-4-qwen-72b\", prov)}')
# → all True
"
```

### Cleanup
```bash
rm -rf /tmp/hermes-test
```

## Closes

Closes #16 (Block A — free→paid transition alert).