### PR TITLE
BUILD #4: Remote dashboard access and per-step traces

### DIFF
--- a/BUILD-PLAN-issue-4.md
+++ b/BUILD-PLAN-issue-4.md
@@ -1,0 +1,14 @@
+# BUILD PLAN — Issue #4
+
+**Card:** nujovich/hermes-radar#4
+**Title:** Remote dashboard access and per-step traces
+**Board:** hermes-radar (competitive-watch)
+
+## Nadia's Decision
+
+Add to the backlog with low priority. Evaluate gaps first before implementing new features.
+
+## Milestones
+
+- [ ] Milestone 1: Evaluate gaps — hermes-telemetry currently serves a local-only dashboard (HTML served on localhost). Assess whether users need remote dashboard access, configurable data directory, or a streamlined connection bootstrap. Document findings.
+- [ ] Milestone 2: Feature backlog — implement configurable data directory (low complexity, useful for multi-disk setups); evaluate remote access (high complexity, only if demand exists).


### PR DESCRIPTION
## BUILD PLAN

**Card:** nujovich/hermes-radar#4

### Nadia's Decision
Add to the backlog with low priority. Evaluate gaps first before implementing new features.

### Milestones

- [ ] Milestone 1: Evaluate gaps — hermes-telemetry currently serves a local-only dashboard (HTML served on localhost). Assess whether users need remote dashboard access, configurable data directory, or a streamlined connection bootstrap. Document findings.
- [ ] Milestone 2: Feature backlog — implement configurable data directory (low complexity, useful for multi-disk setups); evaluate remote access (high complexity, only if demand exists).
