### PR TITLE
BUILD #29: Evaluate MCP tool call tracking coverage

### DIFF
--- a/BUILD-PLAN-issue-29.md
+++ b/BUILD-PLAN-issue-29.md
@@ -1,0 +1,8 @@
+# BUILD #29 — MCP client hardening evaluation
+
+Card: https://github.com/nujovich/hermes-radar/issues/29
+
+## Milestones
+
+- [ ] Milestone 1 — Evaluate MCP tool call tracking: verify whether pre_tool_call/post_tool_call hooks cover MCP tool calls
+- [ ] Milestone 2 — Add MCP metrics to dashboard: if MCP tool calls are tracked, show them as a separate category in /stats


### PR DESCRIPTION
Card: https://github.com/nujovich/hermes-radar/issues/29

## Context

Evaluate whether hermes-telemetry already tracks MCP tool calls via the existing pre_tool_call/post_tool_call hook pipeline.

## Milestones

- [ ] Milestone 1 -- Evaluate whether MCP tool calls are tracked by existing hooks. Verify against Hermes Agent source.
- [ ] Milestone 2 -- Add MCP metrics to dashboard as a separate category (only if milestone 1 confirms coverage).
