### PR TITLE
feat: polish home telemetry dashboard charts and settings

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -742,12 +742,25 @@ function fmtShortDayLabel(day) {
   return d ? new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(d) : day;
 }
 
+function parseHourBucketParts(value) {
+  const match = String(value || '').match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/);
+  if (!match) return null;
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+    hour: Number(match[4]),
+    minute: Number(match[5]),
+  };
+}
+
 function fmtHourLabel(value, opts = {}) {
-  const d = parseDashboardTs(`${value}:00Z`);
-  if (!d) return value;
+  const parts = parseHourBucketParts(value);
+  if (!parts) return value;
+  const localDate = new Date(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, 0, 0);
   return new Intl.DateTimeFormat(undefined, opts.full
     ? { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }
-    : { hour: 'numeric' }).format(d);
+    : { hour: 'numeric' }).format(localDate);
 }
 
 function effectiveHomeTrendGranularity(hoursValue = $('#windowSelect')?.value || '0') {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -148,6 +148,29 @@
   .usage-toolbar { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }
   .usage-toolbar-group { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
   .usage-toolbar-label { color: #8b949e; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; }
+  .metric-trend-card { padding: 0; overflow: hidden; }
+  .metric-trend-header { display: grid; grid-template-columns: repeat(8, minmax(0, 1fr)); border-bottom: 1px solid #2b3642; background: linear-gradient(180deg, #1a2430 0%, #141c25 100%); box-shadow: inset 0 -1px 0 rgba(255,255,255,0.04); }
+  .metric-trend-stat { min-width: 0; padding: 13px 10px 11px; border: 0; border-bottom: 2px solid transparent; background: transparent; color: #c9d1d9; text-align: left; cursor: pointer; transition: background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease; }
+  .metric-trend-stat + .metric-trend-stat { border-left: 1px solid rgba(255,255,255,0.06); }
+  .metric-trend-stat:hover { background: rgba(255,255,255,0.025); }
+  .metric-trend-stat.active { border-bottom-color: #22d3ee; background: linear-gradient(180deg, rgba(34,211,238,0.11) 0%, rgba(34,211,238,0.03) 100%); box-shadow: inset 0 -1px 0 rgba(34,211,238,0.22); }
+  .metric-trend-label-row { display: flex; align-items: center; gap: 4px; margin-bottom: 6px; }
+  .metric-trend-label { color: #a9b7c7; font-size: 11px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .metric-trend-info { color: #7b8794; font-size: 10px; }
+  .metric-trend-value-row { display: flex; align-items: center; gap: 6px; flex-wrap: nowrap; min-width: 0; }
+  .metric-trend-value { color: #f8fafc; font-size: 16px; font-weight: 800; line-height: 1.05; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .metric-trend-pill { display: inline-flex; align-items: center; border-radius: 999px; padding: 2px 7px; background: rgba(34,211,238,0.16); color: #67e8f9; font-size: 10px; font-weight: 700; }
+  .metric-trend-body { padding: 10px 12px 16px; }
+  .metric-trend-svg-wrap { position: relative; height: 350px; overflow: visible; }
+  .metric-trend-svg { width: 100%; height: 100%; display: block; overflow: visible; }
+  .metric-trend-tooltip { position: absolute; z-index: 3; min-width: 128px; transform: translate(-50%, -110%); background: rgba(0,0,0,0.86); border: 1px solid rgba(88,166,255,0.45); border-radius: 5px; color: #f8fafc; padding: 8px 10px; pointer-events: none; box-shadow: 0 8px 20px rgba(0,0,0,0.32); }
+  .metric-trend-tooltip-title { font-size: 13px; font-weight: 700; margin-bottom: 5px; }
+  .metric-trend-tooltip-row { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 700; }
+  .metric-trend-tooltip-box { width: 12px; height: 12px; background: #58a6ff; border: 1px solid #d9fbff; display: inline-block; }
+  .metric-trend-footer { display: none; }
+  .metric-trend-date { color: #d6e3f0; font-weight: 600; }
+  .metric-trend-series { display: inline-flex; align-items: center; gap: 8px; margin-left: auto; color: #d6e3f0; font-weight: 600; min-width: 0; }
+  .metric-trend-dot { width: 8px; height: 8px; border-radius: 999px; background: #22d3ee; }
   .delta-pos { color: #3fb950; }
   .delta-neg { color: #f85149; }
   .data-chip { max-width: 240px; }
@@ -294,6 +317,7 @@ let lastWindowHours = null;
 let currentPage = 'home';
 let currentUsageGranularity = 'day';
 let currentUsageMetric = 'tokens';
+let currentMetricTrendMetric = 'api_calls';
 let currentDrilldown = {};
 let autoRefreshTimer = null;
 let isLoading = false;
@@ -397,6 +421,11 @@ function setUsageGranularity(g) {
 function setUsageMetric(m) {
   if (!['tokens', 'cost', 'requests', 'share'].includes(m) || m === currentUsageMetric) return;
   currentUsageMetric = m;
+  loadAll({showShell:false});
+}
+function setMetricTrendMetric(metric) {
+  if (!['messages', 'api_calls', 'request_runs', 'tool_calls', 'cron_job_runs', 'cost', 'tokens', 'savings'].includes(metric) || metric === currentMetricTrendMetric) return;
+  currentMetricTrendMetric = metric;
   loadAll({showShell:false});
 }
 function badge(v, map) {
@@ -567,6 +596,82 @@ function renderTableCard(id, title, tableHtml) {
 
 function renderSegmentedButtons(options, currentValue, handlerName) {
   return `<div class="segmented-control">${options.map(opt => `<button class="segmented-btn ${opt.value === currentValue ? 'active' : ''}" onclick="${handlerName}('${opt.value}')">${escHtml(opt.label)}</button>`).join('')}</div>`;
+}
+
+function trendMetricMeta(metric) {
+  return {
+    messages: { label: 'Messages', field: 'message_runs', info: '', footer: 'Messages', color: '#22d3ee' },
+    api_calls: { label: 'API calls', field: 'api_calls', info: '', footer: 'API calls', color: '#22d3ee' },
+    request_runs: { label: 'Requests', field: 'request_runs', info: '', footer: 'Requests', color: '#22d3ee' },
+    tool_calls: { label: 'Tool calls', field: 'tool_calls', info: '', footer: 'Tool calls', color: '#22d3ee' },
+    cron_job_runs: { label: 'Cron job runs', field: 'cron_job_runs', info: '', footer: 'Cron job runs', color: '#22d3ee' },
+    cost: { label: 'Cost', field: 'cost_usd', info: '', footer: 'Cost', color: '#22d3ee' },
+    tokens: { label: 'Token usage', field: 'total_tokens', info: 'ⓘ', footer: 'Token usage', color: '#22d3ee' },
+    savings: { label: 'Savings', field: 'estimated_savings_usd', info: 'ⓘ', footer: 'Savings', color: '#22d3ee' },
+  }[metric] || { label: 'Messages', field: 'message_runs', info: '', footer: 'Messages', color: '#22d3ee' };
+}
+
+function fmtCompactMetricValue(metric, value) {
+  const n = Number(value || 0);
+  if (metric === 'cost' || metric === 'savings') {
+    return n >= 1000 ? `$${(n / 1000).toFixed(1)}k` : `$${n.toFixed(2)}`;
+  }
+  if (metric === 'tokens') {
+    if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+    return nf(n);
+  }
+  return nf(n);
+}
+
+function fmtTrendPointValue(metric, value) {
+  const n = Number(value || 0);
+  if (metric === 'cost' || metric === 'savings') return `$${n.toFixed(2)}`;
+  if (metric === 'tokens') return `${nf(n)} tokens`;
+  return nf(n);
+}
+
+function fmtShortDayLabel(day) {
+  const d = parseDashboardTs(`${day}T00:00:00Z`);
+  return d ? new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(d) : day;
+}
+
+function buildMetricTrendSummary(rows) {
+  const summary = { messages: 0, api_calls: 0, request_runs: 0, tool_calls: 0, cron_job_runs: 0, cost_usd: 0, total_tokens: 0, estimated_savings_usd: 0, savings_pct: 0 };
+  for (const row of (rows || [])) {
+    summary.messages += Number(row.message_runs || 0);
+    summary.api_calls += Number(row.api_calls || 0);
+    summary.request_runs += Number(row.request_runs || 0);
+    summary.tool_calls += Number(row.tool_calls || 0);
+    summary.cron_job_runs += Number(row.cron_job_runs || 0);
+    summary.cost_usd += Number(row.cost_usd || 0);
+    summary.total_tokens += Number(row.total_tokens || 0);
+    summary.estimated_savings_usd += Number(row.estimated_savings_usd || 0);
+  }
+  const spendBase = summary.cost_usd + summary.estimated_savings_usd;
+  summary.savings_pct = spendBase > 0 ? (summary.estimated_savings_usd / spendBase) * 100 : 0;
+  return summary;
+}
+
+function renderMetricTrendCard(rows) {
+  const trendRows = rows || [];
+  const summary = buildMetricTrendSummary(trendRows);
+  const metrics = ['messages', 'api_calls', 'request_runs', 'tool_calls', 'cron_job_runs', 'cost', 'tokens', 'savings'];
+  const stats = metrics.map(metric => {
+    const meta = trendMetricMeta(metric);
+    const raw = Number(summary[meta.field] ?? summary[metric] ?? 0);
+    const pill = metric === 'savings'
+      ? `<span class="metric-trend-pill">${Math.round(summary.savings_pct || 0)}%</span>`
+      : '';
+    return `<button class="metric-trend-stat ${metric === currentMetricTrendMetric ? 'active' : ''}" onclick="setMetricTrendMetric('${metric}')"><div class="metric-trend-label-row"><span class="metric-trend-label">${meta.label}</span>${meta.info ? `<span class="metric-trend-info">${meta.info}</span>` : ''}</div><div class="metric-trend-value-row"><span class="metric-trend-value">${fmtCompactMetricValue(metric, raw)}</span>${pill}</div></button>`;
+  }).join('');
+  return `<div class="chart-card full-width-chart metric-trend-card">
+    <div class="metric-trend-header">${stats}</div>
+    <div class="metric-trend-body">
+      ${trendRows.length ? `<div id="home-metric-trend-chart" class="metric-trend-svg-wrap"></div>` : '<div class="text-muted" style="padding:24px 0">No daily trend data available yet.</div>'}
+    </div>
+  </div>`;
 }
 
 function renderModelUsageTrendCard(trendData, shareData) {
@@ -1161,6 +1266,60 @@ function drawLineChart(canvasId, labels, datasets, yLabel) {
   });
 }
 
+function drawMetricTrendChart(canvasId, rows) {
+  destroyChart(canvasId);
+  const wrap = document.getElementById(canvasId);
+  if (!wrap || !(rows || []).length) return;
+  const meta = trendMetricMeta(currentMetricTrendMetric);
+  const labels = rows.map(row => fmtShortDayLabel(row.day));
+  const fullLabels = rows.map(row => row.day || fmtShortDayLabel(row.day));
+  const values = rows.map(row => Number(row?.[meta.field] || 0));
+  const maxValue = Math.max(...values, 0);
+  const niceMax = maxValue <= 0 ? 1 : Math.ceil((maxValue * 1.12) / 1000) * 1000;
+  const ticks = [0, niceMax / 2, niceMax];
+  const width = Math.max(900, Math.round(wrap.clientWidth || 900));
+  const height = Math.max(320, Math.round(wrap.clientHeight || 350));
+  const pad = { top: 18, right: 18, bottom: 36, left: 58 };
+  const plotW = width - pad.left - pad.right;
+  const plotH = height - pad.top - pad.bottom;
+  const xFor = (i) => pad.left + (values.length === 1 ? plotW / 2 : (i * plotW) / (values.length - 1));
+  const yFor = (v) => pad.top + plotH - ((Number(v || 0) / niceMax) * plotH);
+  const points = values.map((v, i) => ({ x: xFor(i), y: yFor(v), value: v, label: labels[i], fullLabel: fullLabels[i] }));
+  const linePath = points.map((p, i) => `${i ? 'L' : 'M'} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(' ');
+  const areaPath = `${linePath} L ${points[points.length - 1].x.toFixed(1)} ${(pad.top + plotH).toFixed(1)} L ${points[0].x.toFixed(1)} ${(pad.top + plotH).toFixed(1)} Z`;
+  const fmtAxis = (v) => currentMetricTrendMetric === 'cost' || currentMetricTrendMetric === 'savings'
+    ? `$${Number(v || 0).toFixed(2)}`
+    : (currentMetricTrendMetric === 'tokens' && v >= 1_000_000 ? `${(v / 1_000_000).toFixed(1)}M` : Number(v || 0).toLocaleString());
+  const grid = ticks.map(v => {
+    const y = yFor(v);
+    return `<line x1="${pad.left}" y1="${y}" x2="${width - pad.right}" y2="${y}" stroke="rgba(148,163,184,0.16)"/><text x="${pad.left - 10}" y="${y + 4}" text-anchor="end" fill="#e6edf3" font-size="12" font-weight="600">${escHtml(fmtAxis(v))}</text>`;
+  }).join('');
+  const xGrid = points.map(p => `<line x1="${p.x}" y1="${pad.top}" x2="${p.x}" y2="${pad.top + plotH}" stroke="rgba(148,163,184,0.09)"/><text x="${p.x}" y="${height - 8}" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">${escHtml(p.label)}</text>`).join('');
+  const circles = points.map((p, i) => `<circle cx="${p.x}" cy="${p.y}" r="5" fill="#38bdf8" stroke="#f8fafc" stroke-width="1.5" data-idx="${i}"/>`).join('');
+  wrap.innerHTML = `<svg class="metric-trend-svg" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" role="img" aria-label="${escHtml(meta.footer)} trend">
+    <defs><linearGradient id="metricTrendFill" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#38bdf8" stop-opacity="0.30"/><stop offset="100%" stop-color="#38bdf8" stop-opacity="0.05"/></linearGradient></defs>
+    <rect x="${pad.left}" y="${pad.top}" width="${plotW}" height="${plotH}" fill="transparent"/>
+    ${grid}${xGrid}
+    <path d="${areaPath}" fill="url(#metricTrendFill)"/>
+    <path d="${linePath}" fill="none" stroke="#22d3ee" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    ${circles}
+  </svg><div class="metric-trend-tooltip" id="metric-trend-tooltip"><div class="metric-trend-tooltip-title"></div><div class="metric-trend-tooltip-row"><span class="metric-trend-tooltip-box"></span><span></span></div></div>`;
+  const tooltip = wrap.querySelector('#metric-trend-tooltip');
+  const setHoverIndex = (idx) => {
+    const p = points[Math.max(0, Math.min(points.length - 1, idx))];
+    if (!p || !tooltip) return;
+    tooltip.querySelector('.metric-trend-tooltip-title').textContent = p.fullLabel;
+    tooltip.querySelector('.metric-trend-tooltip-row span:last-child').textContent = `${meta.footer}: ${fmtTrendPointValue(currentMetricTrendMetric, p.value)}`;
+    tooltip.style.left = `${(p.x / width) * 100}%`;
+    tooltip.style.top = `${(p.y / height) * 100}%`;
+  };
+  wrap.querySelectorAll('[data-idx]').forEach(el => {
+    el.addEventListener('mouseenter', () => setHoverIndex(Number(el.dataset.idx)));
+    el.addEventListener('mousemove', () => setHoverIndex(Number(el.dataset.idx)));
+  });
+  setHoverIndex(points.length - 1);
+}
+
 function drawBarChart(canvasId, labels, data, color, yLabel) {
   destroyChart(canvasId);
   const ctx = document.getElementById(canvasId).getContext('2d');
@@ -1462,6 +1621,8 @@ async function loadAll(options = {}) {
       html += renderStatCard('cost', fmtCost(r.cost_usd), 'Cost', 'yellow');
       html += '</div>';
 
+      html += renderMetricTrendCard(dailyTokenChart, hours);
+
       // --- budget ---
       html += renderBudget(budget);
 
@@ -1544,6 +1705,7 @@ async function loadAll(options = {}) {
     // --- render charts (after DOM is ready) ---
     if (currentPage === 'home') {
       const dc = summary.daily_cost || [];
+      drawMetricTrendChart('home-metric-trend-chart', dailyTokenChart);
       drawLineChart('chart-daily', dc.map(d => d.day), [{
         label: 'Cost ($)', data: dc.map(d => d.cost),
         borderColor: '#58a6ff', backgroundColor: 'rgba(88,166,255,0.15)', fill: true, tension: 0.3, pointRadius: 4,

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -229,18 +229,18 @@
         <div class="settings-group">
           <label for="windowSelect">View time</label>
           <select id="windowSelect" onchange="closeSettingsMenu(); loadAll({showShell:true})">
-            <option value="0" selected>All time</option>
-            <option value="24">Today</option>
-            <option value="168">This week</option>
-            <option value="720">This month</option>
-            <option value="0.25">Last 15m</option>
-            <option value="0.5">Last 30m</option>
-            <option value="1">Last 1h</option>
-            <option value="3">Last 3h</option>
-            <option value="24">Last 24h</option>
-            <option value="48">Last 2 days</option>
-            <option value="2160">Last 90 days</option>
-            <option value="8760">Last 1 year</option>
+            <option value="all" selected>All time</option>
+            <option value="today">Today</option>
+            <option value="this_week">This week</option>
+            <option value="this_month">This month</option>
+            <option value="15m">Last 15m</option>
+            <option value="30m">Last 30m</option>
+            <option value="1h">Last 1h</option>
+            <option value="3h">Last 3h</option>
+            <option value="24h">Last 24h</option>
+            <option value="2d">Last 2 days</option>
+            <option value="90d">Last 90 days</option>
+            <option value="1y">Last 1 year</option>
           </select>
         </div>
         <div class="settings-group">
@@ -253,6 +253,8 @@
         <div class="settings-group">
           <label for="homeTrendGranularitySelect">Chart view</label>
           <select id="homeTrendGranularitySelect" onchange="closeSettingsMenu(); setHomeTrendGranularity(this.value)">
+            <option value="auto" selected>Auto</option>
+            <option value="minute">Minute</option>
             <option value="hour">Hourly</option>
             <option value="day">Daily</option>
             <option value="week">Weekly</option>
@@ -367,10 +369,10 @@ if (window.Chart?.defaults) {
   Chart.defaults.color = '#c9d1d9';
 }
 let currentDailyTokensPage = 1;
-let lastWindowHours = null;
+let lastWindowPreset = null;
 let currentPage = 'home';
 let currentUsageGranularity = 'day';
-let currentHomeTrendGranularity = 'day';
+let currentHomeTrendGranularity = 'auto';
 let currentUsageMetric = 'tokens';
 let currentMetricTrendMetric = 'tokens';
 let currentDrilldown = {};
@@ -497,8 +499,56 @@ function closeSettingsMenu() {
   $('#settingsPanel')?.classList.remove('open');
   $('#settingsToggle')?.classList.remove('open');
 }
+function startOfToday(mode, now = new Date()) {
+  return mode === 'utc'
+    ? new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0, 0, 0, 0))
+    : new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0, 0);
+}
+function startOfWeek(mode, now = new Date()) {
+  const base = startOfToday(mode, now);
+  const weekday = mode === 'utc' ? now.getUTCDay() : now.getDay();
+  const daysFromMonday = (weekday + 6) % 7;
+  base.setDate(base.getDate() - daysFromMonday);
+  return base;
+}
+function startOfMonth(mode, now = new Date()) {
+  return mode === 'utc'
+    ? new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0))
+    : new Date(now.getFullYear(), now.getMonth(), 1, 0, 0, 0, 0);
+}
+function resolveWindowPreset(preset = $('#windowSelect')?.value || 'all', mode = currentDayBoundaryMode) {
+  const now = new Date();
+  const rollingHours = {
+    all: 0,
+    '15m': 0.25,
+    '30m': 0.5,
+    '1h': 1,
+    '3h': 3,
+    '24h': 24,
+    '2d': 48,
+    '90d': 2160,
+    '1y': 8760,
+  };
+  if (Object.prototype.hasOwnProperty.call(rollingHours, preset)) {
+    return { preset, hours: rollingHours[preset], mode: 'rolling' };
+  }
+  const start = preset === 'today'
+    ? startOfToday(mode, now)
+    : preset === 'this_week'
+      ? startOfWeek(mode, now)
+      : preset === 'this_month'
+        ? startOfMonth(mode, now)
+        : null;
+  if (!start) return { preset: 'all', hours: 0, mode: 'rolling' };
+  return { preset, hours: Math.max(0, (now.getTime() - start.getTime()) / 3600000), mode: 'calendar' };
+}
+function autoHomeTrendGranularity(preset = $('#windowSelect')?.value || 'all') {
+  if (['15m', '30m', '1h', '3h'].includes(preset)) return 'minute';
+  if (['today', '24h', '2d'].includes(preset)) return 'hour';
+  return 'day';
+}
 function granularityLabel(g) {
-  return ({ hour: 'Hourly', day: 'Daily', week: 'Weekly', month: 'Monthly' }[g]) || 'Daily';
+  return ({ minute: 'Minutely', hour: 'Hourly', day: 'Daily', week: 'Weekly', month: 'Monthly' }[g]) || 'Daily';
 }
 function setUsageGranularity(g) {
   if (!['day', 'week', 'month'].includes(g) || g === currentUsageGranularity) return;
@@ -516,7 +566,7 @@ function setMetricTrendMetric(metric) {
   loadAll({showShell:false});
 }
 function setHomeTrendGranularity(g) {
-  if (!['hour', 'day', 'week', 'month'].includes(g) || g === currentHomeTrendGranularity) return;
+  if (!['auto', 'minute', 'hour', 'day', 'week', 'month'].includes(g) || g === currentHomeTrendGranularity) return;
   currentHomeTrendGranularity = g;
   const select = $('#homeTrendGranularitySelect');
   if (select) select.value = g;
@@ -763,14 +813,24 @@ function fmtHourLabel(value, opts = {}) {
     : { hour: 'numeric' }).format(localDate);
 }
 
-function effectiveHomeTrendGranularity(hoursValue = $('#windowSelect')?.value || '0') {
-  const hours = Number(hoursValue);
-  if (currentHomeTrendGranularity === 'day' && hours > 0 && hours <= 24) return 'hour';
-  return currentHomeTrendGranularity;
+function fmtMinuteLabel(value, opts = {}) {
+  const parts = parseHourBucketParts(value);
+  if (!parts) return value;
+  const localDate = new Date(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, 0, 0);
+  return new Intl.DateTimeFormat(undefined, opts.full
+    ? { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }
+    : { hour: 'numeric', minute: '2-digit' }).format(localDate);
+}
+
+function effectiveHomeTrendGranularity(windowPreset = $('#windowSelect')?.value || 'all') {
+  return currentHomeTrendGranularity === 'auto'
+    ? autoHomeTrendGranularity(windowPreset)
+    : currentHomeTrendGranularity;
 }
 
 function fmtTrendPeriodLabel(value, granularity = effectiveHomeTrendGranularity()) {
   if (!value) return '—';
+  if (granularity === 'minute') return fmtMinuteLabel(value);
   if (granularity === 'hour') return fmtHourLabel(value);
   if (granularity === 'month') {
     const d = parseDashboardTs(`${value}-01T00:00:00Z`);
@@ -796,9 +856,9 @@ function buildMetricTrendSummary(rows) {
   return summary;
 }
 
-function renderMetricTrendCard(rows, hours, summaryOverrides = {}) {
+function renderMetricTrendCard(rows, windowPreset, summaryOverrides = {}) {
   const trendRows = rows || [];
-  const effectiveGranularity = effectiveHomeTrendGranularity(hours);
+  const effectiveGranularity = effectiveHomeTrendGranularity(windowPreset);
   const summary = { ...buildMetricTrendSummary(trendRows), ...(summaryOverrides || {}) };
   const metrics = ['tokens', 'api_calls', 'request_runs', 'messages', 'tool_calls', 'cron_job_runs', 'cost', 'savings'];
   const chartRows = getMetricTrendRows(trendRows, currentMetricTrendMetric);
@@ -994,8 +1054,34 @@ function clearInvestigationSearch() {
   loadAll({showShell:false});
 }
 
-function buildRunsQuery(hours, limit = 30) {
-  const qs = new URLSearchParams({ hours: String(hours), limit: String(limit) });
+function homeTrendLimitFor(windowPreset, hours, granularity) {
+  if (granularity === 'minute') return Math.max(20, Math.ceil(hours * 60) + 2);
+  if (granularity === 'hour') return Math.max(24, Math.ceil(hours) + 2);
+  if (granularity === 'week') return Math.max(16, Math.ceil(hours / (24 * 7)) + 2);
+  if (granularity === 'month') return Math.max(12, Math.ceil(hours / (24 * 30)) + 2);
+  return windowPreset === 'all' ? 3650 : Math.max(14, Math.ceil(hours / 24) + 2);
+}
+
+function selectedWindowLabel(windowPreset) {
+  return {
+    all: 'all time',
+    today: 'today',
+    this_week: 'this week',
+    this_month: 'this month',
+    '15m': 'last 15m',
+    '30m': 'last 30m',
+    '1h': 'last 1h',
+    '3h': 'last 3h',
+    '24h': 'last 24h',
+    '2d': 'last 2 days',
+    '90d': 'last 90 days',
+    '1y': 'last 1 year',
+  }[windowPreset] || 'selected range';
+}
+
+function buildRunsQuery(windowPreset, limit = 30) {
+  const scope = resolveWindowPreset(windowPreset);
+  const qs = new URLSearchParams({ hours: String(scope.hours), limit: String(limit) });
   for (const [key, value] of Object.entries(currentDrilldown)) {
     if (value != null && value !== '') qs.set(key, value);
   }
@@ -1435,9 +1521,11 @@ function drawMetricTrendChart(canvasId, rows) {
   const chartRows = getMetricTrendRows(rows, currentMetricTrendMetric);
   if (!canvas || !chartRows.length) return;
   const meta = trendMetricMeta(currentMetricTrendMetric);
-  const effectiveGranularity = effectiveHomeTrendGranularity();
+  const windowPreset = $('#windowSelect')?.value || 'all';
+  const effectiveGranularity = effectiveHomeTrendGranularity(windowPreset);
   const labels = chartRows.map(row => fmtTrendPeriodLabel(row.day, effectiveGranularity));
   const fullLabels = chartRows.map(row => {
+    if (effectiveGranularity === 'minute') return fmtMinuteLabel(row.day, { full: true });
     if (effectiveGranularity === 'hour') return fmtHourLabel(row.day, { full: true });
     if (effectiveGranularity === 'week') return `Week of ${row.day}`;
     if (effectiveGranularity === 'month') return fmtTrendPeriodLabel(row.day, 'month');
@@ -1789,27 +1877,29 @@ async function loadAll(options = {}) {
   isLoading = true;
   const showShell = options.showShell ?? !$('#app')?.dataset?.loaded;
   const app = $('#app');
-  const hours = $('#windowSelect').value;
+  const windowPreset = $('#windowSelect').value;
+  const windowScope = resolveWindowPreset(windowPreset);
+  const hours = String(windowScope.hours);
   const homeTrendGranularitySelect = $('#homeTrendGranularitySelect');
-  const effectiveHomeGranularity = effectiveHomeTrendGranularity(hours);
+  const effectiveHomeGranularity = effectiveHomeTrendGranularity(windowPreset);
   if (homeTrendGranularitySelect) homeTrendGranularitySelect.value = currentHomeTrendGranularity;
-  if (hours !== lastWindowHours) {
+  if (windowPreset !== lastWindowPreset) {
     currentDailyTokensPage = 1;
-    lastWindowHours = hours;
+    lastWindowPreset = windowPreset;
   }
   setLoadStatus(options.reason === 'auto' ? 'Auto loading…' : 'Loading…', 'loading');
   const startedAt = performance.now();
   if (showShell || !app.dataset.loaded) app.innerHTML = loadingShell();
 
   try {
-    const chartHours = Number(hours);
-    const chartLimitDays = hours === '0' ? 3650 : Math.max(14, Math.ceil(Number(hours) / 24) + 2);
+    const chartHours = Number(windowScope.hours);
+    const chartLimitDays = homeTrendLimitFor(windowPreset, chartHours, effectiveHomeGranularity);
     const trendLimit = currentUsageGranularity === 'month' ? 18 : currentUsageGranularity === 'week' ? 24 : 21;
     const [summary, cron, providers, providerHealth, runsData, budget, tokenBreakdown, modelTokens, modelEfficiency, dailyTokens, dailyTokenChart, dailyModelChart, modelPeriodTrends, modelShareComparison, cacheEfficiency, requestForensics, toolAnalytics, toolFailureHeatmap, errorCenter, cronFailureWaste] = await Promise.all([
       fetchJSON(`/api/summary?hours=${hours}`),
       fetchJSON(`/api/cron?hours=${hours}`),
       fetchJSON(`/api/providers?hours=${hours}`),
-      fetchJSON(`/api/provider-health?hours=${hours === '0' ? 24 : hours}`),
+      fetchJSON(`/api/provider-health?hours=${chartHours === 0 ? 24 : hours}`),
       fetchJSON(`/api/runs?limit=30&hours=${hours}`),
       fetchJSON(withViewerTimezone('/api/budget')),
       fetchJSON(`/api/token-breakdown?hours=${hours}`),
@@ -1821,10 +1911,10 @@ async function loadAll(options = {}) {
       fetchJSON(`/api/model-period-trends?hours=${hours}&granularity=${currentUsageGranularity}&metric=${currentUsageMetric}&top_n=6&limit_periods=${trendLimit}`),
       fetchJSON(`/api/model-share-comparison?hours=${hours}&granularity=${currentUsageGranularity}&limit=12`),
       fetchJSON(`/api/cache-efficiency?hours=${hours}`),
-      fetchJSON(`/api/requests?${buildRunsQuery(hours, 60)}`),
-      fetchJSON(`/api/tool-analytics?${buildRunsQuery(hours, 100)}&include_deleted=1`),
+      fetchJSON(`/api/requests?${buildRunsQuery(windowPreset, 60)}`),
+      fetchJSON(`/api/tool-analytics?${buildRunsQuery(windowPreset, 100)}&include_deleted=1`),
       fetchJSON(`/api/tool-failure-heatmap?hours=${hours}&limit=80`),
-      fetchJSON(`/api/error-center?${buildRunsQuery(hours, 100)}`),
+      fetchJSON(`/api/error-center?${buildRunsQuery(windowPreset, 100)}`),
       fetchJSON(`/api/cron-failure-waste?hours=${hours}&limit=50`),
     ]);
     if (requestId !== latestLoadRequestId) return;
@@ -1832,7 +1922,7 @@ async function loadAll(options = {}) {
     const r = summary.runs || {};
     const l = summary.llm || {};
     const runs = runsData?.rows || [];
-    const investigationRuns = await fetchJSON(`/api/runs?${buildRunsQuery(hours, 40)}`);
+    const investigationRuns = await fetchJSON(`/api/runs?${buildRunsQuery(windowPreset, 40)}`);
     if (requestId !== latestLoadRequestId) return;
     currentDailyTokensPage = dailyTokens?.page || 1;
 
@@ -1850,21 +1940,14 @@ async function loadAll(options = {}) {
       html += '</div>';
 
       const cronSummaryRuns = (cron || []).reduce((sum, row) => sum + Number(row.runs || 0), 0);
-      html += renderMetricTrendCard(dailyTokenChart, hours, { cron_job_runs: cronSummaryRuns });
+      html += renderMetricTrendCard(dailyTokenChart, windowPreset, { cron_job_runs: cronSummaryRuns });
 
       // --- budget ---
       html += renderBudget(budget);
 
       // --- charts row 1: daily cost + top tools ---
       let dailyTitle;
-      switch (hours) {
-        case '24': dailyTitle = 'Daily Cost (last 24h)'; break;
-        case '168': dailyTitle = 'Daily Cost (last 7 days)'; break;
-        case '720': dailyTitle = 'Daily Cost (last 30 days)'; break;
-        case '2160': dailyTitle = 'Daily Cost (last 90 days)'; break;
-        case '0': dailyTitle = 'Daily Cost (all time)'; break;
-        default: dailyTitle = 'Daily Cost';
-      }
+      dailyTitle = `Daily Cost (${selectedWindowLabel(windowPreset)})`;
       html += '<div class="chart-row">';
       html += renderChartCard('dailyCost', dailyTitle, 'chart-daily');
       html += renderChartCard('topTools', 'Top Tools by Calls', 'chart-tools');

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -253,6 +253,7 @@
         <div class="settings-group">
           <label for="homeTrendGranularitySelect">Chart view</label>
           <select id="homeTrendGranularitySelect" onchange="closeSettingsMenu(); setHomeTrendGranularity(this.value)">
+            <option value="hour">Hourly</option>
             <option value="day">Daily</option>
             <option value="week">Weekly</option>
             <option value="month">Monthly</option>
@@ -497,7 +498,7 @@ function closeSettingsMenu() {
   $('#settingsToggle')?.classList.remove('open');
 }
 function granularityLabel(g) {
-  return ({ day: 'Daily', week: 'Weekly', month: 'Monthly' }[g]) || 'Daily';
+  return ({ hour: 'Hourly', day: 'Daily', week: 'Weekly', month: 'Monthly' }[g]) || 'Daily';
 }
 function setUsageGranularity(g) {
   if (!['day', 'week', 'month'].includes(g) || g === currentUsageGranularity) return;
@@ -515,7 +516,7 @@ function setMetricTrendMetric(metric) {
   loadAll({showShell:false});
 }
 function setHomeTrendGranularity(g) {
-  if (!['day', 'week', 'month'].includes(g) || g === currentHomeTrendGranularity) return;
+  if (!['hour', 'day', 'week', 'month'].includes(g) || g === currentHomeTrendGranularity) return;
   currentHomeTrendGranularity = g;
   const select = $('#homeTrendGranularitySelect');
   if (select) select.value = g;
@@ -741,8 +742,23 @@ function fmtShortDayLabel(day) {
   return d ? new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(d) : day;
 }
 
-function fmtTrendPeriodLabel(value, granularity = currentHomeTrendGranularity) {
+function fmtHourLabel(value, opts = {}) {
+  const d = parseDashboardTs(`${value}:00Z`);
+  if (!d) return value;
+  return new Intl.DateTimeFormat(undefined, opts.full
+    ? { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }
+    : { hour: 'numeric' }).format(d);
+}
+
+function effectiveHomeTrendGranularity(hoursValue = $('#windowSelect')?.value || '0') {
+  const hours = Number(hoursValue);
+  if (currentHomeTrendGranularity === 'day' && hours > 0 && hours <= 24) return 'hour';
+  return currentHomeTrendGranularity;
+}
+
+function fmtTrendPeriodLabel(value, granularity = effectiveHomeTrendGranularity()) {
   if (!value) return '—';
+  if (granularity === 'hour') return fmtHourLabel(value);
   if (granularity === 'month') {
     const d = parseDashboardTs(`${value}-01T00:00:00Z`);
     return d ? new Intl.DateTimeFormat(undefined, { month: 'short', year: 'numeric' }).format(d) : value;
@@ -769,6 +785,7 @@ function buildMetricTrendSummary(rows) {
 
 function renderMetricTrendCard(rows, hours, summaryOverrides = {}) {
   const trendRows = rows || [];
+  const effectiveGranularity = effectiveHomeTrendGranularity(hours);
   const summary = { ...buildMetricTrendSummary(trendRows), ...(summaryOverrides || {}) };
   const metrics = ['tokens', 'api_calls', 'request_runs', 'messages', 'tool_calls', 'cron_job_runs', 'cost', 'savings'];
   const chartRows = getMetricTrendRows(trendRows, currentMetricTrendMetric);
@@ -780,7 +797,7 @@ function renderMetricTrendCard(rows, hours, summaryOverrides = {}) {
       : '';
     return `<button class="metric-trend-stat ${metric === currentMetricTrendMetric ? 'active' : ''}" onclick="setMetricTrendMetric('${metric}')"><div class="metric-trend-label-row"><span class="metric-trend-label">${meta.label}</span>${meta.info ? `<span class="metric-trend-info">${meta.info}</span>` : ''}</div><div class="metric-trend-value-row"><span class="metric-trend-value">${fmtCompactMetricValue(metric, raw)}</span>${pill}</div></button>`;
   }).join('');
-  const emptyLabel = granularityLabel(currentHomeTrendGranularity).toLowerCase();
+  const emptyLabel = granularityLabel(effectiveGranularity).toLowerCase();
   return `<div class="chart-card full-width-chart metric-trend-card">
     <div class="metric-trend-header">${stats}</div>
     <div class="metric-trend-body">
@@ -1405,8 +1422,14 @@ function drawMetricTrendChart(canvasId, rows) {
   const chartRows = getMetricTrendRows(rows, currentMetricTrendMetric);
   if (!canvas || !chartRows.length) return;
   const meta = trendMetricMeta(currentMetricTrendMetric);
-  const labels = chartRows.map(row => fmtTrendPeriodLabel(row.day, currentHomeTrendGranularity));
-  const fullLabels = chartRows.map(row => currentHomeTrendGranularity === 'week' ? `Week of ${row.day}` : currentHomeTrendGranularity === 'month' ? fmtTrendPeriodLabel(row.day, 'month') : (row.day || fmtTrendPeriodLabel(row.day, 'day')));
+  const effectiveGranularity = effectiveHomeTrendGranularity();
+  const labels = chartRows.map(row => fmtTrendPeriodLabel(row.day, effectiveGranularity));
+  const fullLabels = chartRows.map(row => {
+    if (effectiveGranularity === 'hour') return fmtHourLabel(row.day, { full: true });
+    if (effectiveGranularity === 'week') return `Week of ${row.day}`;
+    if (effectiveGranularity === 'month') return fmtTrendPeriodLabel(row.day, 'month');
+    return row.day || fmtTrendPeriodLabel(row.day, 'day');
+  });
   const tokenDatasets = [
     { key: 'total_tokens', label: 'Total', borderColor: '#22d3ee', backgroundColor: 'rgba(34,211,238,0.16)', fill: true, tension: 0.32, pointRadius: 3, pointHoverRadius: 5, borderWidth: 3, yAxisID: 'y' },
     { key: 'tokens_in', label: 'Input', borderColor: '#4f8cff', backgroundColor: 'rgba(79,140,255,0)', fill: false, tension: 0.28, pointRadius: 2, pointHoverRadius: 4, borderWidth: 2.5, yAxisID: 'y1' },
@@ -1755,6 +1778,7 @@ async function loadAll(options = {}) {
   const app = $('#app');
   const hours = $('#windowSelect').value;
   const homeTrendGranularitySelect = $('#homeTrendGranularitySelect');
+  const effectiveHomeGranularity = effectiveHomeTrendGranularity(hours);
   if (homeTrendGranularitySelect) homeTrendGranularitySelect.value = currentHomeTrendGranularity;
   if (hours !== lastWindowHours) {
     currentDailyTokensPage = 1;
@@ -1779,7 +1803,7 @@ async function loadAll(options = {}) {
       fetchJSON(`/api/model-tokens?hours=${hours}&limit=100`),
       fetchJSON(`/api/model-efficiency?hours=${hours}&limit=50`),
       fetchJSON(`/api/daily-tokens?hours=${hours}&page=${currentDailyTokensPage}&per_page=15`),
-      fetchJSON(`/api/daily-token-chart?hours=${chartHours}&limit_days=${chartLimitDays}&include_deleted=1&granularity=${currentHomeTrendGranularity}`),
+      fetchJSON(`/api/daily-token-chart?hours=${chartHours}&limit_days=${chartLimitDays}&include_deleted=1&granularity=${effectiveHomeGranularity}`),
       fetchJSON(`/api/daily-model-chart?hours=${chartHours}&limit_days=${chartLimitDays}&top_n=5&include_deleted=1`),
       fetchJSON(`/api/model-period-trends?hours=${hours}&granularity=${currentUsageGranularity}&metric=${currentUsageMetric}&top_n=6&limit_periods=${trendLimit}`),
       fetchJSON(`/api/model-share-comparison?hours=${hours}&granularity=${currentUsageGranularity}&limit=12`),

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7,7 +7,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0f1117; color: #c9d1d9; min-height: 100vh; }
+  body { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0f1117; color: #c9d1d9; min-height: 100vh; }
   .header { background: #161b22; border-bottom: 1px solid #30363d; padding: 16px 24px; display: flex; align-items: center; justify-content: space-between; gap: 16px; }
   .header-left { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
   .header h1 { font-size: 18px; font-weight: 600; color: #e6edf3; }
@@ -17,7 +17,7 @@
   .page-tab:hover { background: #30363d; border-color: #58a6ff; }
   .page-tab.active { color: #ffffff; border-color: #58a6ff; background: linear-gradient(180deg, #1f6feb 0%, #1a4f9c 100%); box-shadow: 0 0 0 1px rgba(88,166,255,0.25), 0 6px 16px rgba(31,111,235,0.18); }
   .page-title { font-size: 18px; font-weight: 600; color: #e6edf3; margin-bottom: 18px; }
-  .header .actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+  .header .actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-left: auto; }
   .header select { background: #21262d; color: #c9d1d9; border: 1px solid #30363d; border-radius: 6px; padding: 6px 12px; font-size: 13px; cursor: pointer; }
   .header select:focus { outline: none; border-color: #58a6ff; }
   .header .refresh-btn { background: #21262d; color: #c9d1d9; border: 1px solid #30363d; border-radius: 6px; padding: 6px 12px; cursor: pointer; font-size: 13px; }
@@ -26,6 +26,20 @@
   .load-status { min-width: 92px; color: #8b949e; font-size: 12px; text-align: right; }
   .load-status.is-loading { color: #58a6ff; }
   .load-status.is-error { color: #f85149; }
+  .settings-menu { position: relative; }
+  .settings-btn { width: 32px; height: 32px; display: inline-flex; align-items: center; justify-content: center; background: linear-gradient(180deg, #202833 0%, #161d26 100%); color: #e6edf3; border: 1px solid #344252; border-radius: 10px; cursor: pointer; font-size: 14px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.05), 0 8px 18px rgba(0,0,0,0.22); transition: border-color 0.18s ease, background 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease; }
+  .settings-btn:hover, .settings-btn.open { background: linear-gradient(180deg, #243141 0%, #19222d 100%); border-color: #67e8f9; box-shadow: inset 0 1px 0 rgba(255,255,255,0.06), 0 10px 22px rgba(0,0,0,0.28); transform: translateY(-1px); }
+  .settings-panel { position: absolute; top: calc(100% + 10px); right: 0; width: 236px; background: linear-gradient(180deg, rgba(23,30,39,0.98) 0%, rgba(16,22,30,0.985) 100%); border: 1px solid #334255; border-radius: 14px; padding: 10px; box-shadow: 0 20px 48px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.04); display: none; z-index: 50; }
+  .settings-panel.open { display: block; }
+  .settings-panel-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; padding: 2px 2px 8px; margin-bottom: 8px; border-bottom: 1px solid rgba(255,255,255,0.06); }
+  .settings-panel-title { color: #f8fafc; font-size: 12px; font-weight: 800; letter-spacing: 0.02em; }
+  .settings-panel-subtitle { color: #7f8b99; font-size: 10px; }
+  .settings-group { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; padding: 2px 0; }
+  .settings-group:last-child { margin-bottom: 0; }
+  .settings-group label { font-size: 10px; color: #8ea2b5; text-transform: uppercase; letter-spacing: 0.6px; font-weight: 800; }
+  .settings-group select { width: 100%; background: linear-gradient(180deg, #111821 0%, #0d141c 100%); color: #e6edf3; border: 1px solid #2e3948; border-radius: 9px; padding: 8px 10px; font-size: 12px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.03); color-scheme: dark; appearance: none; -webkit-appearance: none; }
+  .settings-group select option { background: #0f141b; color: #e6edf3; }
+  .settings-group select:focus { outline: none; border-color: #67e8f9; box-shadow: 0 0 0 3px rgba(34,211,238,0.12); }
 
   .container { max-width: 1200px; margin: 0 auto; padding: 24px; }
 
@@ -102,12 +116,20 @@
   .text-right { text-align: right; }
   .text-muted { color: #8b949e; }
 
+  @media (max-width: 1200px) {
+    .metric-trend-header { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  }
+
   @media (max-width: 768px) {
     .chart-row { grid-template-columns: 1fr; }
     .stat-grid { grid-template-columns: repeat(2, 1fr); }
+    .header { flex-direction: column; align-items: flex-start; }
+    .actions { width: 100%; justify-content: flex-start; margin-left: 0; }
+    .metric-trend-header { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .metric-trend-stat { padding: 12px 10px 10px; }
+    .metric-trend-value { font-size: 15px; }
   }
-
-  .loading { text-align: center; padding: 60px; color: #8b949e; }
+  .loading { text-align: center; color: #8b949e; }
   .loading-shell { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 22px; color: #8b949e; }
   .loading-title { color: #e6edf3; font-size: 16px; font-weight: 700; margin-bottom: 8px; }
   .loading-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin-top: 18px; }
@@ -150,27 +172,18 @@
   .usage-toolbar-label { color: #8b949e; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.4px; }
   .metric-trend-card { padding: 0; overflow: hidden; }
   .metric-trend-header { display: grid; grid-template-columns: repeat(8, minmax(0, 1fr)); border-bottom: 1px solid #2b3642; background: linear-gradient(180deg, #1a2430 0%, #141c25 100%); box-shadow: inset 0 -1px 0 rgba(255,255,255,0.04); }
-  .metric-trend-stat { min-width: 0; padding: 13px 10px 11px; border: 0; border-bottom: 2px solid transparent; background: transparent; color: #c9d1d9; text-align: left; cursor: pointer; transition: background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease; }
+  .metric-trend-stat { min-width: 0; padding: 14px 12px 12px; border: 0; border-bottom: 2px solid transparent; background: transparent; color: #c9d1d9; text-align: left; cursor: pointer; transition: background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease; }
   .metric-trend-stat + .metric-trend-stat { border-left: 1px solid rgba(255,255,255,0.06); }
   .metric-trend-stat:hover { background: rgba(255,255,255,0.025); }
   .metric-trend-stat.active { border-bottom-color: #22d3ee; background: linear-gradient(180deg, rgba(34,211,238,0.11) 0%, rgba(34,211,238,0.03) 100%); box-shadow: inset 0 -1px 0 rgba(34,211,238,0.22); }
-  .metric-trend-label-row { display: flex; align-items: center; gap: 4px; margin-bottom: 6px; }
-  .metric-trend-label { color: #a9b7c7; font-size: 11px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .metric-trend-label-row { display: flex; align-items: center; gap: 4px; margin-bottom: 6px; min-width: 0; }
+  .metric-trend-label { color: #a9b7c7; font-size: 11px; font-weight: 700; letter-spacing: 0.02em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .metric-trend-info { color: #7b8794; font-size: 10px; }
   .metric-trend-value-row { display: flex; align-items: center; gap: 6px; flex-wrap: nowrap; min-width: 0; }
-  .metric-trend-value { color: #f8fafc; font-size: 16px; font-weight: 800; line-height: 1.05; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .metric-trend-value { color: #f8fafc; font-size: 17px; font-weight: 800; line-height: 1.05; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .metric-trend-pill { display: inline-flex; align-items: center; border-radius: 999px; padding: 2px 7px; background: rgba(34,211,238,0.16); color: #67e8f9; font-size: 10px; font-weight: 700; }
-  .metric-trend-body { padding: 10px 12px 16px; }
-  .metric-trend-svg-wrap { position: relative; height: 350px; overflow: visible; }
-  .metric-trend-svg { width: 100%; height: 100%; display: block; overflow: visible; }
-  .metric-trend-tooltip { position: absolute; z-index: 3; min-width: 128px; transform: translate(-50%, -110%); background: rgba(0,0,0,0.86); border: 1px solid rgba(88,166,255,0.45); border-radius: 5px; color: #f8fafc; padding: 8px 10px; pointer-events: none; box-shadow: 0 8px 20px rgba(0,0,0,0.32); }
-  .metric-trend-tooltip-title { font-size: 13px; font-weight: 700; margin-bottom: 5px; }
-  .metric-trend-tooltip-row { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 700; }
-  .metric-trend-tooltip-box { width: 12px; height: 12px; background: #58a6ff; border: 1px solid #d9fbff; display: inline-block; }
-  .metric-trend-footer { display: none; }
-  .metric-trend-date { color: #d6e3f0; font-weight: 600; }
-  .metric-trend-series { display: inline-flex; align-items: center; gap: 8px; margin-left: auto; color: #d6e3f0; font-weight: 600; min-width: 0; }
-  .metric-trend-dot { width: 8px; height: 8px; border-radius: 999px; background: #22d3ee; }
+  .metric-trend-body { padding: 14px 16px 18px; }
+  .metric-trend-canvas-wrap { position: relative; height: 380px; }
   .delta-pos { color: #3fb950; }
   .delta-neg { color: #f85149; }
   .data-chip { max-width: 240px; }
@@ -204,23 +217,59 @@
     </div>
   </div>
   <div class="actions">
-    <select id="windowSelect" onchange="loadAll({showShell:true})">
-      <option value="24">Last 24h</option>
-      <option value="168">Last 7 days</option>
-      <option value="720">Last 30 days</option>
-      <option value="2160">Last 90 days</option>
-      <option value="0" selected>All time</option>
-    </select>
-    <span class="header-label">Auto</span>
-    <select id="autoRefreshSelect" onchange="setAutoRefresh(this.value)">
-      <option value="0">Off</option>
-      <option value="5000">5s</option>
-      <option value="10000">10s</option>
-      <option value="20000">20s</option>
-      <option value="60000">1min</option>
-    </select>
-    <button class="refresh-btn" onclick="loadAll({showShell:false})">&#x21bb; Refresh</button>
     <span id="loadStatus" class="load-status">Idle</span>
+    <button class="refresh-btn" onclick="loadAll({showShell:false})">&#x21bb; Refresh</button>
+    <div class="settings-menu">
+      <button id="settingsToggle" class="settings-btn" onclick="toggleSettingsMenu(event)" aria-label="Dashboard settings" title="Dashboard settings">⚙</button>
+      <div id="settingsPanel" class="settings-panel">
+        <div class="settings-panel-head">
+          <div class="settings-panel-title">Dashboard view</div>
+          <div class="settings-panel-subtitle">Home controls</div>
+        </div>
+        <div class="settings-group">
+          <label for="windowSelect">View time</label>
+          <select id="windowSelect" onchange="closeSettingsMenu(); loadAll({showShell:true})">
+            <option value="0" selected>All time</option>
+            <option value="24">Today</option>
+            <option value="168">This week</option>
+            <option value="720">This month</option>
+            <option value="0.25">Last 15m</option>
+            <option value="0.5">Last 30m</option>
+            <option value="1">Last 1h</option>
+            <option value="3">Last 3h</option>
+            <option value="24">Last 24h</option>
+            <option value="48">Last 2 days</option>
+            <option value="2160">Last 90 days</option>
+            <option value="8760">Last 1 year</option>
+          </select>
+        </div>
+        <div class="settings-group">
+          <label for="dayBoundarySelect">Day boundary</label>
+          <select id="dayBoundarySelect" onchange="closeSettingsMenu(); setDayBoundaryMode(this.value)">
+            <option value="local">Local time</option>
+            <option value="utc">UTC</option>
+          </select>
+        </div>
+        <div class="settings-group">
+          <label for="homeTrendGranularitySelect">Chart view</label>
+          <select id="homeTrendGranularitySelect" onchange="closeSettingsMenu(); setHomeTrendGranularity(this.value)">
+            <option value="day">Daily</option>
+            <option value="week">Weekly</option>
+            <option value="month">Monthly</option>
+          </select>
+        </div>
+        <div class="settings-group">
+          <label for="autoRefreshSelect">Auto refresh</label>
+          <select id="autoRefreshSelect" onchange="closeSettingsMenu(); setAutoRefresh(this.value)">
+            <option value="0">Off</option>
+            <option value="5000">5s</option>
+            <option value="10000">10s</option>
+            <option value="20000">20s</option>
+            <option value="60000">1min</option>
+          </select>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -312,18 +361,26 @@
 <script>
 const API = '';
 let charts = {};
+if (window.Chart?.defaults) {
+  Chart.defaults.font.family = "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+  Chart.defaults.color = '#c9d1d9';
+}
 let currentDailyTokensPage = 1;
 let lastWindowHours = null;
 let currentPage = 'home';
 let currentUsageGranularity = 'day';
+let currentHomeTrendGranularity = 'day';
 let currentUsageMetric = 'tokens';
-let currentMetricTrendMetric = 'api_calls';
+let currentMetricTrendMetric = 'tokens';
 let currentDrilldown = {};
 let autoRefreshTimer = null;
 let isLoading = false;
 let latestLoadRequestId = 0;
 let latestDrawerRequestId = 0;
 let latestRequestDrawerRequestId = 0;
+const viewerTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+const DAY_BOUNDARY_STORAGE_KEY = 'telemetryDayBoundaryMode';
+let currentDayBoundaryMode = localStorage.getItem(DAY_BOUNDARY_STORAGE_KEY) || 'local';
 
 function $(sel) { return document.querySelector(sel); }
 function escHtml(s) {
@@ -344,10 +401,12 @@ function fmtMs(v) {
   if (ms >= 1000) return (ms/1000).toFixed(1) + 's';
   return Math.round(ms) + 'ms';
 }
-const viewerTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+function dashboardTimezoneParam() {
+  return currentDayBoundaryMode === 'utc' ? 'UTC' : viewerTimeZone;
+}
 function withViewerTimezone(url) {
   const u = new URL(url, window.location.origin);
-  u.searchParams.set('tz', viewerTimeZone);
+  u.searchParams.set('tz', dashboardTimezoneParam());
   return `${u.pathname}${u.search}`;
 }
 function parseDashboardTs(value) {
@@ -410,6 +469,33 @@ function initAutoRefresh() {
   const ms = allowed.has(saved) ? saved : '20000';
   setAutoRefresh(ms);
 }
+function setDayBoundaryMode(value) {
+  const mode = value === 'utc' ? 'utc' : 'local';
+  currentDayBoundaryMode = mode;
+  localStorage.setItem(DAY_BOUNDARY_STORAGE_KEY, mode);
+  const select = $('#dayBoundarySelect');
+  if (select) select.value = mode;
+  loadAll({showShell:false});
+}
+function initDayBoundaryMode() {
+  const mode = currentDayBoundaryMode === 'utc' ? 'utc' : 'local';
+  currentDayBoundaryMode = mode;
+  const select = $('#dayBoundarySelect');
+  if (select) select.value = mode;
+}
+function toggleSettingsMenu(event) {
+  event?.stopPropagation?.();
+  const panel = $('#settingsPanel');
+  const btn = $('#settingsToggle');
+  if (!panel || !btn) return;
+  const open = !panel.classList.contains('open');
+  panel.classList.toggle('open', open);
+  btn.classList.toggle('open', open);
+}
+function closeSettingsMenu() {
+  $('#settingsPanel')?.classList.remove('open');
+  $('#settingsToggle')?.classList.remove('open');
+}
 function granularityLabel(g) {
   return ({ day: 'Daily', week: 'Weekly', month: 'Monthly' }[g]) || 'Daily';
 }
@@ -428,6 +514,13 @@ function setMetricTrendMetric(metric) {
   currentMetricTrendMetric = metric;
   loadAll({showShell:false});
 }
+function setHomeTrendGranularity(g) {
+  if (!['day', 'week', 'month'].includes(g) || g === currentHomeTrendGranularity) return;
+  currentHomeTrendGranularity = g;
+  const select = $('#homeTrendGranularitySelect');
+  if (select) select.value = g;
+  loadAll({showShell:false});
+}
 function badge(v, map) {
   const cls = map[v] || 'cli';
   return `<span class="badge ${cls}">${escHtml(v || '—')}</span>`;
@@ -436,7 +529,7 @@ const statusBadge = v => badge(v, { ok: 'ok', error: 'error', interrupted: 'erro
 const platformBadge = v => badge(v || 'cli', { cron: 'cron', cli: 'cli', telegram: 'cli', discord: 'cli' });
 
 async function fetchJSON(url) {
-  const r = await fetch(url);
+  const r = await fetch(withViewerTimezone(url));
   if (!r.ok) throw new Error(`HTTP ${r.status}`);
   return r.json();
 }
@@ -600,15 +693,15 @@ function renderSegmentedButtons(options, currentValue, handlerName) {
 
 function trendMetricMeta(metric) {
   return {
+    tokens: { label: 'Token usage', field: 'total_tokens', info: '', footer: 'Token usage', color: '#22d3ee' },
+    api_calls: { label: 'LLM calls', field: 'api_calls', info: '', footer: 'LLM calls', color: '#22d3ee' },
+    request_runs: { label: 'Sessions', field: 'request_runs', info: '', footer: 'Sessions', color: '#22d3ee' },
     messages: { label: 'Messages', field: 'message_runs', info: '', footer: 'Messages', color: '#22d3ee' },
-    api_calls: { label: 'API calls', field: 'api_calls', info: '', footer: 'API calls', color: '#22d3ee' },
-    request_runs: { label: 'Requests', field: 'request_runs', info: '', footer: 'Requests', color: '#22d3ee' },
     tool_calls: { label: 'Tool calls', field: 'tool_calls', info: '', footer: 'Tool calls', color: '#22d3ee' },
-    cron_job_runs: { label: 'Cron job runs', field: 'cron_job_runs', info: '', footer: 'Cron job runs', color: '#22d3ee' },
+    cron_job_runs: { label: 'Cron runs', field: 'cron_job_runs', info: '', footer: 'Cron runs', color: '#22d3ee' },
     cost: { label: 'Cost', field: 'cost_usd', info: '', footer: 'Cost', color: '#22d3ee' },
-    tokens: { label: 'Token usage', field: 'total_tokens', info: 'ⓘ', footer: 'Token usage', color: '#22d3ee' },
-    savings: { label: 'Savings', field: 'estimated_savings_usd', info: 'ⓘ', footer: 'Savings', color: '#22d3ee' },
-  }[metric] || { label: 'Messages', field: 'message_runs', info: '', footer: 'Messages', color: '#22d3ee' };
+    savings: { label: 'Savings', field: 'estimated_savings_usd', info: '', footer: 'Savings', color: '#22d3ee' },
+  }[metric] || { label: 'Token usage', field: 'total_tokens', info: '', footer: 'Token usage', color: '#22d3ee' };
 }
 
 function fmtCompactMetricValue(metric, value) {
@@ -632,9 +725,29 @@ function fmtTrendPointValue(metric, value) {
   return nf(n);
 }
 
+function fmtMetricAxisValue(metric, value) {
+  const n = Number(value || 0);
+  if (metric === 'cost' || metric === 'savings') return `$${n.toFixed(2)}`;
+  if (metric === 'tokens') {
+    if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+  }
+  return nf(n);
+}
+
 function fmtShortDayLabel(day) {
   const d = parseDashboardTs(`${day}T00:00:00Z`);
   return d ? new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(d) : day;
+}
+
+function fmtTrendPeriodLabel(value, granularity = currentHomeTrendGranularity) {
+  if (!value) return '—';
+  if (granularity === 'month') {
+    const d = parseDashboardTs(`${value}-01T00:00:00Z`);
+    return d ? new Intl.DateTimeFormat(undefined, { month: 'short', year: 'numeric' }).format(d) : value;
+  }
+  return fmtShortDayLabel(value);
 }
 
 function buildMetricTrendSummary(rows) {
@@ -654,10 +767,11 @@ function buildMetricTrendSummary(rows) {
   return summary;
 }
 
-function renderMetricTrendCard(rows) {
+function renderMetricTrendCard(rows, hours, summaryOverrides = {}) {
   const trendRows = rows || [];
-  const summary = buildMetricTrendSummary(trendRows);
-  const metrics = ['messages', 'api_calls', 'request_runs', 'tool_calls', 'cron_job_runs', 'cost', 'tokens', 'savings'];
+  const summary = { ...buildMetricTrendSummary(trendRows), ...(summaryOverrides || {}) };
+  const metrics = ['tokens', 'api_calls', 'request_runs', 'messages', 'tool_calls', 'cron_job_runs', 'cost', 'savings'];
+  const chartRows = getMetricTrendRows(trendRows, currentMetricTrendMetric);
   const stats = metrics.map(metric => {
     const meta = trendMetricMeta(metric);
     const raw = Number(summary[meta.field] ?? summary[metric] ?? 0);
@@ -666,12 +780,31 @@ function renderMetricTrendCard(rows) {
       : '';
     return `<button class="metric-trend-stat ${metric === currentMetricTrendMetric ? 'active' : ''}" onclick="setMetricTrendMetric('${metric}')"><div class="metric-trend-label-row"><span class="metric-trend-label">${meta.label}</span>${meta.info ? `<span class="metric-trend-info">${meta.info}</span>` : ''}</div><div class="metric-trend-value-row"><span class="metric-trend-value">${fmtCompactMetricValue(metric, raw)}</span>${pill}</div></button>`;
   }).join('');
+  const emptyLabel = granularityLabel(currentHomeTrendGranularity).toLowerCase();
   return `<div class="chart-card full-width-chart metric-trend-card">
     <div class="metric-trend-header">${stats}</div>
     <div class="metric-trend-body">
-      ${trendRows.length ? `<div id="home-metric-trend-chart" class="metric-trend-svg-wrap"></div>` : '<div class="text-muted" style="padding:24px 0">No daily trend data available yet.</div>'}
+      ${chartRows.length ? `<div class="metric-trend-canvas-wrap"><canvas id="home-metric-trend-chart"></canvas></div>` : `<div class="text-muted" style="padding:24px 0">No ${emptyLabel} trend data available yet.</div>`}
     </div>
   </div>`;
+}
+
+function metricTrendValueForRow(row, metric) {
+  if (!row) return 0;
+  if (metric === 'tokens') {
+    return Number(row.total_tokens || row.tokens_in || row.tokens_out || row.cache_read_tokens || 0);
+  }
+  if (metric === 'savings') return Number(row.estimated_savings_usd || 0);
+  const meta = trendMetricMeta(metric);
+  return Number(row?.[meta.field] || 0);
+}
+
+function getMetricTrendRows(rows, metric = currentMetricTrendMetric) {
+  const trendRows = Array.isArray(rows) ? rows : [];
+  if (!trendRows.length) return trendRows;
+  const firstActiveIdx = trendRows.findIndex(row => metricTrendValueForRow(row, metric) > 0);
+  if (firstActiveIdx === -1 || firstActiveIdx === 0) return trendRows;
+  return trendRows.slice(Math.max(0, firstActiveIdx - 1));
 }
 
 function renderModelUsageTrendCard(trendData, shareData) {
@@ -1268,56 +1401,103 @@ function drawLineChart(canvasId, labels, datasets, yLabel) {
 
 function drawMetricTrendChart(canvasId, rows) {
   destroyChart(canvasId);
-  const wrap = document.getElementById(canvasId);
-  if (!wrap || !(rows || []).length) return;
+  const canvas = document.getElementById(canvasId);
+  const chartRows = getMetricTrendRows(rows, currentMetricTrendMetric);
+  if (!canvas || !chartRows.length) return;
   const meta = trendMetricMeta(currentMetricTrendMetric);
-  const labels = rows.map(row => fmtShortDayLabel(row.day));
-  const fullLabels = rows.map(row => row.day || fmtShortDayLabel(row.day));
-  const values = rows.map(row => Number(row?.[meta.field] || 0));
-  const maxValue = Math.max(...values, 0);
-  const niceMax = maxValue <= 0 ? 1 : Math.ceil((maxValue * 1.12) / 1000) * 1000;
-  const ticks = [0, niceMax / 2, niceMax];
-  const width = Math.max(900, Math.round(wrap.clientWidth || 900));
-  const height = Math.max(320, Math.round(wrap.clientHeight || 350));
-  const pad = { top: 18, right: 18, bottom: 36, left: 58 };
-  const plotW = width - pad.left - pad.right;
-  const plotH = height - pad.top - pad.bottom;
-  const xFor = (i) => pad.left + (values.length === 1 ? plotW / 2 : (i * plotW) / (values.length - 1));
-  const yFor = (v) => pad.top + plotH - ((Number(v || 0) / niceMax) * plotH);
-  const points = values.map((v, i) => ({ x: xFor(i), y: yFor(v), value: v, label: labels[i], fullLabel: fullLabels[i] }));
-  const linePath = points.map((p, i) => `${i ? 'L' : 'M'} ${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(' ');
-  const areaPath = `${linePath} L ${points[points.length - 1].x.toFixed(1)} ${(pad.top + plotH).toFixed(1)} L ${points[0].x.toFixed(1)} ${(pad.top + plotH).toFixed(1)} Z`;
-  const fmtAxis = (v) => currentMetricTrendMetric === 'cost' || currentMetricTrendMetric === 'savings'
-    ? `$${Number(v || 0).toFixed(2)}`
-    : (currentMetricTrendMetric === 'tokens' && v >= 1_000_000 ? `${(v / 1_000_000).toFixed(1)}M` : Number(v || 0).toLocaleString());
-  const grid = ticks.map(v => {
-    const y = yFor(v);
-    return `<line x1="${pad.left}" y1="${y}" x2="${width - pad.right}" y2="${y}" stroke="rgba(148,163,184,0.16)"/><text x="${pad.left - 10}" y="${y + 4}" text-anchor="end" fill="#e6edf3" font-size="12" font-weight="600">${escHtml(fmtAxis(v))}</text>`;
-  }).join('');
-  const xGrid = points.map(p => `<line x1="${p.x}" y1="${pad.top}" x2="${p.x}" y2="${pad.top + plotH}" stroke="rgba(148,163,184,0.09)"/><text x="${p.x}" y="${height - 8}" text-anchor="middle" fill="#e6edf3" font-size="12" font-weight="600">${escHtml(p.label)}</text>`).join('');
-  const circles = points.map((p, i) => `<circle cx="${p.x}" cy="${p.y}" r="5" fill="#38bdf8" stroke="#f8fafc" stroke-width="1.5" data-idx="${i}"/>`).join('');
-  wrap.innerHTML = `<svg class="metric-trend-svg" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none" role="img" aria-label="${escHtml(meta.footer)} trend">
-    <defs><linearGradient id="metricTrendFill" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="#38bdf8" stop-opacity="0.30"/><stop offset="100%" stop-color="#38bdf8" stop-opacity="0.05"/></linearGradient></defs>
-    <rect x="${pad.left}" y="${pad.top}" width="${plotW}" height="${plotH}" fill="transparent"/>
-    ${grid}${xGrid}
-    <path d="${areaPath}" fill="url(#metricTrendFill)"/>
-    <path d="${linePath}" fill="none" stroke="#22d3ee" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-    ${circles}
-  </svg><div class="metric-trend-tooltip" id="metric-trend-tooltip"><div class="metric-trend-tooltip-title"></div><div class="metric-trend-tooltip-row"><span class="metric-trend-tooltip-box"></span><span></span></div></div>`;
-  const tooltip = wrap.querySelector('#metric-trend-tooltip');
-  const setHoverIndex = (idx) => {
-    const p = points[Math.max(0, Math.min(points.length - 1, idx))];
-    if (!p || !tooltip) return;
-    tooltip.querySelector('.metric-trend-tooltip-title').textContent = p.fullLabel;
-    tooltip.querySelector('.metric-trend-tooltip-row span:last-child').textContent = `${meta.footer}: ${fmtTrendPointValue(currentMetricTrendMetric, p.value)}`;
-    tooltip.style.left = `${(p.x / width) * 100}%`;
-    tooltip.style.top = `${(p.y / height) * 100}%`;
-  };
-  wrap.querySelectorAll('[data-idx]').forEach(el => {
-    el.addEventListener('mouseenter', () => setHoverIndex(Number(el.dataset.idx)));
-    el.addEventListener('mousemove', () => setHoverIndex(Number(el.dataset.idx)));
+  const labels = chartRows.map(row => fmtTrendPeriodLabel(row.day, currentHomeTrendGranularity));
+  const fullLabels = chartRows.map(row => currentHomeTrendGranularity === 'week' ? `Week of ${row.day}` : currentHomeTrendGranularity === 'month' ? fmtTrendPeriodLabel(row.day, 'month') : (row.day || fmtTrendPeriodLabel(row.day, 'day')));
+  const tokenDatasets = [
+    { key: 'total_tokens', label: 'Total', borderColor: '#22d3ee', backgroundColor: 'rgba(34,211,238,0.16)', fill: true, tension: 0.32, pointRadius: 3, pointHoverRadius: 5, borderWidth: 3, yAxisID: 'y' },
+    { key: 'tokens_in', label: 'Input', borderColor: '#4f8cff', backgroundColor: 'rgba(79,140,255,0)', fill: false, tension: 0.28, pointRadius: 2, pointHoverRadius: 4, borderWidth: 2.5, yAxisID: 'y1' },
+    { key: 'tokens_out', label: 'Output', borderColor: '#f59e0b', backgroundColor: 'rgba(245,158,11,0)', fill: false, tension: 0.24, pointRadius: 2, pointHoverRadius: 4, borderWidth: 2.5, yAxisID: 'y1', borderDash: [6, 4] },
+    { key: 'cache_read_tokens', label: 'Cache read', borderColor: '#7dd3a0', backgroundColor: 'rgba(125,211,160,0)', fill: false, tension: 0.26, pointRadius: 2, pointHoverRadius: 4, borderWidth: 2.5, yAxisID: 'y', borderDash: [10, 5] },
+  ];
+  const chosen = currentMetricTrendMetric === 'tokens'
+    ? tokenDatasets
+    : [{ key: meta.field, label: meta.footer, borderColor: '#22d3ee', backgroundColor: 'rgba(34,211,238,0.18)', fill: true, tension: 0.3, pointRadius: 4, pointHoverRadius: 5, borderWidth: 3, yAxisID: 'y' }];
+  const datasets = chosen.map(series => ({
+    label: series.label,
+    data: chartRows.map(row => Number(row?.[series.key] || 0)),
+    borderColor: series.borderColor,
+    backgroundColor: series.backgroundColor,
+    fill: series.fill,
+    tension: series.tension,
+    pointRadius: series.pointRadius,
+    pointHoverRadius: series.pointHoverRadius,
+    pointBackgroundColor: series.borderColor,
+    pointBorderColor: '#dbeafe',
+    pointBorderWidth: 1.5,
+    borderWidth: series.borderWidth,
+    borderDash: series.borderDash || [],
+    yAxisID: series.yAxisID,
+  }));
+  const ctx = canvas.getContext('2d');
+  const showAllXTicks = labels.length <= 14;
+  charts[canvasId] = new Chart(ctx, {
+    type: 'line',
+    data: { labels, datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      layout: { padding: { top: 8, right: 10, bottom: 24, left: 4 } },
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: {
+          display: currentMetricTrendMetric === 'tokens',
+          labels: { color: '#a9b7c7', font: { size: 11, weight: '600' }, boxWidth: 14, boxHeight: 3, padding: 14, usePointStyle: false },
+        },
+        tooltip: {
+          backgroundColor: 'rgba(8,12,19,0.98)',
+          borderColor: 'rgba(88,166,255,0.40)',
+          borderWidth: 1,
+          titleColor: '#f8fafc',
+          bodyColor: '#f8fafc',
+          titleFont: { size: 12, weight: '700' },
+          bodyFont: { size: 11, weight: '600' },
+          cornerRadius: 10,
+          caretPadding: 8,
+          boxPadding: 4,
+          displayColors: true,
+          padding: 10,
+          callbacks: {
+            title(items) {
+              const idx = items?.[0]?.dataIndex ?? 0;
+              return fullLabels[idx] || '';
+            },
+            label(item) {
+              return `${item.dataset.label}: ${fmtTrendPointValue(currentMetricTrendMetric, item.parsed.y)}`;
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          offset: false,
+          ticks: { color: '#dce6f2', font: { size: 12, weight: '600' }, autoSkip: !showAllXTicks, maxTicksLimit: showAllXTicks ? labels.length : 12, maxRotation: 0, minRotation: 0, padding: 4 },
+          grid: { color: 'rgba(148,163,184,0.09)' },
+        },
+        y: {
+          ticks: {
+            color: '#e6edf3',
+            font: { size: 12, weight: '600' },
+            callback: (value) => fmtMetricAxisValue(currentMetricTrendMetric, value),
+          },
+          grid: { color: 'rgba(148,163,184,0.16)' },
+        },
+        y1: {
+          display: currentMetricTrendMetric === 'tokens',
+          position: 'right',
+          ticks: {
+            color: '#8b949e',
+            font: { size: 11 },
+            callback: (value) => fmtMetricAxisValue('tokens', value),
+          },
+          grid: { display: false },
+        },
+      },
+    },
   });
-  setHoverIndex(points.length - 1);
 }
 
 function drawBarChart(canvasId, labels, data, color, yLabel) {
@@ -1476,7 +1656,7 @@ function drawDoughnutChart(canvasId, labels, data, colors, onSliceClick) {
 function renderDailyCombinedSvg(hostId, dailyTokenChart, dailyModelChart) {
   const host = document.getElementById(hostId);
   if (!host) return;
-  const rows = dailyTokenChart || [];
+  const rawRows = dailyTokenChart || [];
   const modelRowsByDay = Object.fromEntries((dailyModelChart?.rows || []).map(r => [r.day, r]));
   const modelNames = dailyModelChart?.models || [];
   const modelColors = ['#bc8cff', '#8b949e', '#58a6ff', '#3fb950', '#d29922', '#f85149'];
@@ -1486,6 +1666,14 @@ function renderDailyCombinedSvg(hostId, dailyTokenChart, dailyModelChart) {
     { label: 'Cache Read', color: '#d29922', key: 'cache_read_tokens' },
     { label: 'Reasoning', color: '#f85149', key: 'reasoning_tokens' },
   ];
+  const rowTotal = (row) => {
+    const tokenTotal = tokenSeries.reduce((sum, s) => sum + Number(row?.[s.key] || 0), 0);
+    const modelRow = modelRowsByDay[row?.day] || {};
+    const modelTotal = Object.values(modelRow.models || {}).reduce((sum, value) => sum + Number(value || 0), 0) + Number(modelRow.other || 0);
+    return tokenTotal + modelTotal;
+  };
+  const firstActiveIdx = rawRows.findIndex(row => rowTotal(row) > 0);
+  const rows = firstActiveIdx <= 1 ? rawRows : rawRows.slice(firstActiveIdx - 1);
   const legendItems = [
     ...tokenSeries.map(s => ({ label: s.label, color: s.color })),
     ...modelNames.map((m, i) => ({ label: `Model: ${(m || '—').replace(/^openrouter\//, '').substring(0, 18)}`, color: modelColors[i % modelColors.length] })),
@@ -1566,6 +1754,8 @@ async function loadAll(options = {}) {
   const showShell = options.showShell ?? !$('#app')?.dataset?.loaded;
   const app = $('#app');
   const hours = $('#windowSelect').value;
+  const homeTrendGranularitySelect = $('#homeTrendGranularitySelect');
+  if (homeTrendGranularitySelect) homeTrendGranularitySelect.value = currentHomeTrendGranularity;
   if (hours !== lastWindowHours) {
     currentDailyTokensPage = 1;
     lastWindowHours = hours;
@@ -1575,7 +1765,8 @@ async function loadAll(options = {}) {
   if (showShell || !app.dataset.loaded) app.innerHTML = loadingShell();
 
   try {
-    const chartHours = hours === '0' ? 2160 : Number(hours);
+    const chartHours = Number(hours);
+    const chartLimitDays = hours === '0' ? 3650 : Math.max(14, Math.ceil(Number(hours) / 24) + 2);
     const trendLimit = currentUsageGranularity === 'month' ? 18 : currentUsageGranularity === 'week' ? 24 : 21;
     const [summary, cron, providers, providerHealth, runsData, budget, tokenBreakdown, modelTokens, modelEfficiency, dailyTokens, dailyTokenChart, dailyModelChart, modelPeriodTrends, modelShareComparison, cacheEfficiency, requestForensics, toolAnalytics, toolFailureHeatmap, errorCenter, cronFailureWaste] = await Promise.all([
       fetchJSON(`/api/summary?hours=${hours}`),
@@ -1588,13 +1779,13 @@ async function loadAll(options = {}) {
       fetchJSON(`/api/model-tokens?hours=${hours}&limit=100`),
       fetchJSON(`/api/model-efficiency?hours=${hours}&limit=50`),
       fetchJSON(`/api/daily-tokens?hours=${hours}&page=${currentDailyTokensPage}&per_page=15`),
-      fetchJSON(`/api/daily-token-chart?hours=${chartHours}&limit_days=90`),
-      fetchJSON(`/api/daily-model-chart?hours=${chartHours}&limit_days=90&top_n=5`),
+      fetchJSON(`/api/daily-token-chart?hours=${chartHours}&limit_days=${chartLimitDays}&include_deleted=1&granularity=${currentHomeTrendGranularity}`),
+      fetchJSON(`/api/daily-model-chart?hours=${chartHours}&limit_days=${chartLimitDays}&top_n=5&include_deleted=1`),
       fetchJSON(`/api/model-period-trends?hours=${hours}&granularity=${currentUsageGranularity}&metric=${currentUsageMetric}&top_n=6&limit_periods=${trendLimit}`),
       fetchJSON(`/api/model-share-comparison?hours=${hours}&granularity=${currentUsageGranularity}&limit=12`),
       fetchJSON(`/api/cache-efficiency?hours=${hours}`),
       fetchJSON(`/api/requests?${buildRunsQuery(hours, 60)}`),
-      fetchJSON(`/api/tool-analytics?${buildRunsQuery(hours, 100)}`),
+      fetchJSON(`/api/tool-analytics?${buildRunsQuery(hours, 100)}&include_deleted=1`),
       fetchJSON(`/api/tool-failure-heatmap?hours=${hours}&limit=80`),
       fetchJSON(`/api/error-center?${buildRunsQuery(hours, 100)}`),
       fetchJSON(`/api/cron-failure-waste?hours=${hours}&limit=50`),
@@ -1621,7 +1812,8 @@ async function loadAll(options = {}) {
       html += renderStatCard('cost', fmtCost(r.cost_usd), 'Cost', 'yellow');
       html += '</div>';
 
-      html += renderMetricTrendCard(dailyTokenChart, hours);
+      const cronSummaryRuns = (cron || []).reduce((sum, row) => sum + Number(row.runs || 0), 0);
+      html += renderMetricTrendCard(dailyTokenChart, hours, { cron_job_runs: cronSummaryRuns });
 
       // --- budget ---
       html += renderBudget(budget);
@@ -1652,12 +1844,14 @@ async function loadAll(options = {}) {
 
       // --- cron table ---
       if (cron.length) {
-        let t = '<table><thead><tr><th>Job ID</th><th>Runs</th><th>OK</th><th>Fail</th><th>In</th><th>Out</th><th>Cache</th><th>Cost</th><th>Avg Dur</th><th>Last Run</th></tr></thead><tbody>';
+        let t = '<table><thead><tr><th>Job</th><th>Schedule</th><th>Runs</th><th>Status</th><th>In</th><th>Out</th><th>Cache</th><th>Cost</th><th>Avg Dur</th><th>Last Run</th></tr></thead><tbody>';
         for (const row of cron) {
-          const jid = (row.cron_job_id || '?').substring(0, 20);
-          t += `<tr class="clickable-row" onclick='addDrilldown({cron_job_id:${jsAttr(row.cron_job_id || '')},platform:"cron"})'><td><code>${jid}</code></td><td>${nf(row.runs)}</td><td>${nf(row.ok_runs)}</td><td>${nf(row.failed_runs)}</td><td>${nf(row.tokens_in)}</td><td>${nf(row.tokens_out)}</td><td>${nf(row.cache_read_tokens || 0)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.avg_duration_ms)}</td><td class="text-muted">${fmtLocalTs(row.last_run)}</td></tr>`;
+          const jid = row.cron_job_id || '?';
+          const jobLabel = row.job_name || jid;
+          const status = row.last_status || '—';
+          t += `<tr class="clickable-row" onclick='addDrilldown({cron_job_id:${jsAttr(row.cron_job_id || '')},platform:"cron"})'><td><div style="display:flex;flex-direction:column;gap:3px"><code title="${escHtml(jid)}">${escHtml(jid.substring(0, 20))}</code><span class="text-muted" title="${escHtml(jobLabel)}">${escHtml(jobLabel)}</span></div></td><td class="text-muted">${escHtml(row.schedule_display || '—')}</td><td>${nf(row.runs)}</td><td>${statusBadge(status)}</td><td>${nf(row.tokens_in)}</td><td>${nf(row.tokens_out)}</td><td>${nf(row.cache_read_tokens || 0)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.avg_duration_ms)}</td><td class="text-muted">${fmtLocalTs(row.last_run)}</td></tr>`;
         }
-        t += '</tbody></table><div class="subtle-note">Click a cron job row to inspect sessions from that job.</div>';
+        t += '</tbody></table><div class="subtle-note">Runs now follow Hermes scheduler history, so script-only cron jobs count too. Token and cost columns still show telemetry-backed usage only.</div>';
         html += renderTableCard('cronTable', 'Cron Jobs', t);
       }
 
@@ -1744,6 +1938,12 @@ async function loadAll(options = {}) {
 }
 
 // initial load + configurable auto-refresh
+document.addEventListener('click', (event) => {
+  const menu = document.querySelector('.settings-menu');
+  if (!menu || menu.contains(event.target)) return;
+  closeSettingsMenu();
+});
+initDayBoundaryMode();
 initAutoRefresh();
 loadAll({showShell:true});
 </script>

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -126,6 +126,8 @@ def _sqlite_dashboard_period(value, granularity, tz_name):
     tzinfo, _ = _dashboard_viewer_tz(_normalize_dashboard_tz_name(tz_name))
     dt_local = dt_utc.astimezone(tzinfo)
     granularity = _normalize_granularity(granularity)
+    if granularity == "minute":
+        return dt_local.replace(second=0, microsecond=0).strftime("%Y-%m-%dT%H:%M")
     if granularity == "hour":
         return dt_local.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%dT%H:00")
     if granularity == "day":
@@ -256,7 +258,7 @@ def _since_clause(window_hours, col="started_at"):
 
 def _normalize_granularity(granularity: str | None) -> str:
     g = (granularity or "day").strip().lower()
-    if g not in {"hour", "day", "week", "month"}:
+    if g not in {"minute", "hour", "day", "week", "month"}:
         raise ValueError(f"invalid granularity: {granularity!r}")
     return g
 
@@ -1645,6 +1647,8 @@ def api_daily_token_chart(
         elif granularity == "week":
             monday = (ts - timedelta(days=ts.weekday())).date()
             day = monday.isoformat()
+        elif granularity == "minute":
+            day = ts.replace(second=0, microsecond=0).strftime("%Y-%m-%dT%H:%M")
         elif granularity == "hour":
             day = ts.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%dT%H:00")
         else:

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -166,9 +166,11 @@ def _since_cutoff_epoch(window_hours):
 
 def _parse_cron_output_ts(path: Path) -> datetime | None:
     try:
-        return datetime.strptime(path.stem, "%Y-%m-%d_%H-%M-%S").replace(tzinfo=timezone.utc)
+        naive = datetime.strptime(path.stem, "%Y-%m-%d_%H-%M-%S")
     except ValueError:
         return None
+    local_tz = datetime.now().astimezone().tzinfo or timezone.utc
+    return naive.replace(tzinfo=local_tz).astimezone(timezone.utc)
 
 
 def _cron_scheduler_runs(window_hours=0):
@@ -1625,7 +1627,7 @@ def api_daily_token_chart(
             FROM tool_calls tc
             LEFT JOIN runs r ON r.session_id = tc.session_id
             WHERE {_since_clause(window_hours, "tc.ts")} AND {visible_llm_sql}
-            GROUP BY {_period_label_expr("tc.ts", granularity)}
+            GROUP BY {_period_label_expr("tc.ts", granularity, tz_name)}
             ORDER BY day DESC
             LIMIT ?
         ) d

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -1311,13 +1311,17 @@ def api_daily_tokens(window_hours=24, page=1, per_page=15):
 
 def api_daily_token_chart(window_hours=24, limit_days=90):
     since_clause_ts = _since_clause(window_hours, "ts")
+    since_clause_runs = _since_clause(window_hours, "started_at")
     limit_days = max(1, min(180, int(limit_days)))
-    rows = _rows(
+
+    llm_rows = _rows(
         f"""
         SELECT *
         FROM (
             SELECT
                 DATE(ts) AS day,
+                COUNT(*) AS api_calls,
+                ROUND(COALESCE(SUM(cost_usd), 0), 6) AS cost_usd,
                 COALESCE(SUM(tokens_in), 0) AS tokens_in,
                 COALESCE(SUM(tokens_out), 0) AS tokens_out,
                 COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
@@ -1338,6 +1342,75 @@ def api_daily_token_chart(window_hours=24, limit_days=90):
         """,
         (limit_days,),
     )
+    run_rows = _rows(
+        f"""
+        SELECT *
+        FROM (
+            SELECT
+                DATE(started_at) AS day,
+                COUNT(*) AS request_runs,
+                COALESCE(SUM(tool_calls), 0) AS tool_calls,
+                SUM(CASE WHEN platform = 'cron' THEN 1 ELSE 0 END) AS cron_job_runs
+            FROM runs
+            WHERE {since_clause_runs}
+            GROUP BY DATE(started_at)
+            ORDER BY day DESC
+            LIMIT ?
+        ) d
+        ORDER BY day ASC
+        """,
+        (limit_days,),
+    )
+
+    merged = {}
+    for row in llm_rows:
+        day = row["day"]
+        merged[day] = dict(row)
+    for row in run_rows:
+        day = row["day"]
+        target = merged.setdefault(
+            day,
+            {
+                "day": day,
+                "api_calls": 0,
+                "cost_usd": 0.0,
+                "tokens_in": 0,
+                "tokens_out": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "total_tokens": 0,
+            },
+        )
+        target["request_runs"] = int(row.get("request_runs") or 0)
+        target["tool_calls"] = int(row.get("tool_calls") or 0)
+        target["cron_job_runs"] = int(row.get("cron_job_runs") or 0)
+
+    rows = [merged[day] for day in sorted(merged.keys())][-limit_days:]
+    for row in rows:
+        row.setdefault("request_runs", 0)
+        row.setdefault("tool_calls", 0)
+        row.setdefault("cron_job_runs", 0)
+        row["message_runs"] = max(
+            0, int(row.get("request_runs") or 0) - int(row.get("cron_job_runs") or 0)
+        )
+        billable_tokens = (
+            int(row.get("tokens_in") or 0)
+            + int(row.get("tokens_out") or 0)
+            + int(row.get("cache_write_tokens") or 0)
+            + int(row.get("reasoning_tokens") or 0)
+        )
+        cache_read_tokens = int(row.get("cache_read_tokens") or 0)
+        cost_usd = float(row.get("cost_usd") or 0.0)
+        effective_cost_per_token = (cost_usd / billable_tokens) if billable_tokens > 0 else 0.0
+        estimated_savings_usd = cache_read_tokens * effective_cost_per_token
+        row["estimated_savings_usd"] = round(estimated_savings_usd, 6)
+        total_effective_spend = cost_usd + estimated_savings_usd
+        row["savings_pct"] = (
+            round((estimated_savings_usd / total_effective_spend) * 100, 2)
+            if total_effective_spend > 0
+            else 0.0
+        )
     return rows
 
 

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -126,6 +126,8 @@ def _sqlite_dashboard_period(value, granularity, tz_name):
     tzinfo, _ = _dashboard_viewer_tz(_normalize_dashboard_tz_name(tz_name))
     dt_local = dt_utc.astimezone(tzinfo)
     granularity = _normalize_granularity(granularity)
+    if granularity == "hour":
+        return dt_local.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%dT%H:00")
     if granularity == "day":
         return dt_local.date().isoformat()
     if granularity == "week":
@@ -252,7 +254,7 @@ def _since_clause(window_hours, col="started_at"):
 
 def _normalize_granularity(granularity: str | None) -> str:
     g = (granularity or "day").strip().lower()
-    if g not in {"day", "week", "month"}:
+    if g not in {"hour", "day", "week", "month"}:
         raise ValueError(f"invalid granularity: {granularity!r}")
     return g
 
@@ -1641,6 +1643,8 @@ def api_daily_token_chart(
         elif granularity == "week":
             monday = (ts - timedelta(days=ts.weekday())).date()
             day = monday.isoformat()
+        elif granularity == "hour":
+            day = ts.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%dT%H:00")
         else:
             day = ts.date().isoformat()
         cron_counts[day] = cron_counts.get(day, 0) + 1

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -49,8 +49,16 @@ logger = logging.getLogger("hermes_telemetry.dashboard")
 # ---------------------------------------------------------------------------
 HERMES_HOME = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
 DB_PATH = HERMES_HOME / "telemetry" / "telemetry.db"
+STATE_DB_PATH = HERMES_HOME / "state.db"
+CRON_JOBS_PATH = HERMES_HOME / "cron" / "jobs.json"
+CRON_OUTPUT_DIR = HERMES_HOME / "cron" / "output"
 
 _local = threading.local()
+
+
+def _register_sqlite_functions(conn: sqlite3.Connection):
+    conn.create_function("dashboard_period", 3, _sqlite_dashboard_period)
+    conn.create_function("dashboard_period_start", 3, _sqlite_dashboard_period_start)
 
 
 def _conn():
@@ -58,6 +66,7 @@ def _conn():
         _local.c = sqlite3.connect(str(DB_PATH), isolation_level=None)
         _local.c.row_factory = sqlite3.Row
         _local.c.execute("PRAGMA busy_timeout=5000")
+        _register_sqlite_functions(_local.c)
     return _local.c
 
 
@@ -70,6 +79,155 @@ def _one(sql, params=()):
     return dict(r) if r else {}
 
 
+def _state_rows(sql, params=()):
+    if not STATE_DB_PATH.exists():
+        return []
+    conn = sqlite3.connect(str(STATE_DB_PATH))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=5000")
+    _register_sqlite_functions(conn)
+    try:
+        return [dict(r) for r in conn.execute(sql, params).fetchall()]
+    finally:
+        conn.close()
+
+
+def _normalize_dashboard_tz_name(tz_name: str | None):
+    text = (tz_name or "").strip()
+    if not text or text.lower() == "local":
+        return None
+    if text.upper() == "UTC":
+        return "UTC"
+    return text
+
+
+def _coerce_utc_dt(value):
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    if text == "UTC":
+        return None
+    dt = datetime.fromisoformat(text)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _sqlite_dashboard_period(value, granularity, tz_name):
+    dt_utc = _coerce_utc_dt(value)
+    if dt_utc is None:
+        return None
+    tzinfo, _ = _dashboard_viewer_tz(_normalize_dashboard_tz_name(tz_name))
+    dt_local = dt_utc.astimezone(tzinfo)
+    granularity = _normalize_granularity(granularity)
+    if granularity == "day":
+        return dt_local.date().isoformat()
+    if granularity == "week":
+        monday = (dt_local - timedelta(days=dt_local.weekday())).date()
+        return monday.isoformat()
+    return dt_local.strftime("%Y-%m")
+
+
+def _sqlite_dashboard_period_start(value, granularity, tz_name):
+    label = _sqlite_dashboard_period(value, granularity, tz_name)
+    if not label:
+        return None
+    granularity = _normalize_granularity(granularity)
+    if granularity == "month":
+        return f"{label}-01"
+    return label
+
+
+def _read_cron_jobs():
+    if not CRON_JOBS_PATH.exists():
+        return []
+    try:
+        data = json.loads(CRON_JOBS_PATH.read_text())
+    except Exception:
+        return []
+    jobs = data.get("jobs") if isinstance(data, dict) else None
+    return jobs if isinstance(jobs, list) else []
+
+
+def _since_cutoff_epoch(window_hours):
+    wh = _coerce_window_hours(window_hours)
+    if wh <= 0:
+        return None
+    return datetime.now(timezone.utc).timestamp() - (wh * 3600)
+
+
+def _parse_cron_output_ts(path: Path) -> datetime | None:
+    try:
+        return datetime.strptime(path.stem, "%Y-%m-%d_%H-%M-%S").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _cron_scheduler_runs(window_hours=0):
+    cutoff = None
+    wh = _coerce_window_hours(window_hours)
+    if wh > 0:
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=wh)
+    runs = []
+    for job in _read_cron_jobs():
+        job_id = str(job.get("id") or "").strip()
+        if not job_id:
+            continue
+        job_dir = CRON_OUTPUT_DIR / job_id
+        if not job_dir.exists():
+            continue
+        for path in sorted(job_dir.glob("*.md")):
+            ts = _parse_cron_output_ts(path)
+            if ts is None:
+                continue
+            if cutoff is not None and ts < cutoff:
+                continue
+            runs.append({"cron_job_id": job_id, "ts": ts})
+    return runs
+
+
+def _cron_scheduler_totals(window_hours=0):
+    runs = _cron_scheduler_runs(window_hours)
+    counts = {}
+    last_seen = {}
+    for row in runs:
+        job_id = row["cron_job_id"]
+        counts[job_id] = counts.get(job_id, 0) + 1
+        prev = last_seen.get(job_id)
+        if prev is None or row["ts"] > prev:
+            last_seen[job_id] = row["ts"]
+
+    job_meta = {str(job.get("id") or ""): job for job in _read_cron_jobs() if job.get("id")}
+    rows = []
+    for job_id, job in job_meta.items():
+        runs_count = counts.get(job_id, 0)
+        if _coerce_window_hours(window_hours) <= 0 and isinstance(job.get("repeat"), dict):
+            completed = job["repeat"].get("completed")
+            if isinstance(completed, int):
+                runs_count = max(runs_count, completed)
+        last_run = job.get("last_run_at")
+        if not last_run and last_seen.get(job_id):
+            last_run = last_seen[job_id].isoformat()
+        rows.append(
+            {
+                "cron_job_id": job_id,
+                "job_name": job.get("name") or job_id,
+                "schedule_display": job.get("schedule_display") or "",
+                "runs": runs_count,
+                "last_run": last_run,
+                "last_status": job.get("last_status") or "—",
+                "enabled": bool(job.get("enabled", True)),
+            }
+        )
+    return rows
+
+
 def _since_cutoff_iso(window_hours):
     """UTC ISO cutoff matching the stored timestamp format in telemetry.db.
 
@@ -78,7 +236,7 @@ def _since_cutoff_iso(window_hours):
     format and breaks lexicographic comparisons, so generate the cutoff in the
     same format as the stored data.
     """
-    wh = int(window_hours)
+    wh = _coerce_window_hours(window_hours)
     if wh <= 0:
         return None
     return (datetime.now(timezone.utc) - timedelta(hours=wh)).isoformat()
@@ -99,13 +257,20 @@ def _normalize_granularity(granularity: str | None) -> str:
     return g
 
 
-def _period_label_expr(col: str, granularity: str) -> str:
+def _sql_string_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _period_label_expr(col: str, granularity: str, tz_name: str | None = None) -> str:
     granularity = _normalize_granularity(granularity)
-    if granularity == "day":
-        return f"DATE({col})"
-    if granularity == "week":
-        return f"DATE({col}, '-' || ((CAST(strftime('%w', {col}) AS INTEGER) + 6) % 7) || ' days')"
-    return f"strftime('%Y-%m', {col})"
+    tz_value = _normalize_dashboard_tz_name(tz_name) or "local"
+    return f"dashboard_period({col}, {_sql_string_literal(granularity)}, {_sql_string_literal(tz_value)})"
+
+
+def _period_start_expr(col: str, granularity: str, tz_name: str | None = None) -> str:
+    granularity = _normalize_granularity(granularity)
+    tz_value = _normalize_dashboard_tz_name(tz_name) or "local"
+    return f"dashboard_period_start({col}, {_sql_string_literal(granularity)}, {_sql_string_literal(tz_value)})"
 
 
 def _active_hermes_session_ids():
@@ -181,7 +346,6 @@ def api_summary(window_hours=24):
             SUM(tokens_out) AS tokens_out,
             ROUND(SUM(cost_usd), 6) AS cost_usd,
             AVG(duration_ms) AS avg_duration_ms,
-            SUM(tool_calls) AS tool_calls,
             SUM(estimated_llm_calls) AS estimated_llm_calls
         FROM runs WHERE {since_clause}
     """)
@@ -191,18 +355,28 @@ def api_summary(window_hours=24):
         FROM llm_calls WHERE {since_clause_ts}
     """)
 
+    tool_summary = _one(
+        f"""
+        SELECT COUNT(*) AS tool_calls
+        FROM tool_calls tc
+        LEFT JOIN runs r ON tc.session_id = r.session_id
+        WHERE {_since_clause(window_hours, "r.started_at")}
+        """
+    )
+    runs["tool_calls"] = int(tool_summary.get("tool_calls") or 0)
+
     top_tools = _rows(f"""
         SELECT tool_name, COUNT(*) AS calls,
                SUM(CASE WHEN ok=0 THEN 1 ELSE 0 END) AS failures,
                AVG(latency_ms) AS avg_ms
         FROM tool_calls tc
-        JOIN runs r ON tc.session_id = r.session_id
+        LEFT JOIN runs r ON tc.session_id = r.session_id
         WHERE {_since_clause(window_hours, "r.started_at")}
         GROUP BY tool_name ORDER BY calls DESC LIMIT 10
     """)
 
     # daily cost chart data
-    daily_window = int(window_hours)
+    daily_window = _coerce_window_hours(window_hours)
     if daily_window == 0:
         daily_cost = _rows("""
             SELECT DATE(started_at) AS day,
@@ -228,7 +402,7 @@ def api_summary(window_hours=24):
         )
 
     return {
-        "window_hours": int(window_hours),
+        "window_hours": daily_window,
         "runs": runs,
         "llm": llm,
         "top_tools": top_tools,
@@ -261,7 +435,7 @@ def api_token_breakdown(window_hours=24):
 
 def api_cron(window_hours=168):
     since_clause = _since_clause(window_hours)
-    return _rows(f"""
+    telemetry_rows = _rows(f"""
         SELECT cron_job_id,
                COUNT(*) AS runs,
                SUM(CASE WHEN status='ok' THEN 1 ELSE 0 END) AS ok_runs,
@@ -277,8 +451,68 @@ def api_cron(window_hours=168):
         WHERE cron_job_id IS NOT NULL
           AND {since_clause}
         GROUP BY cron_job_id
-        ORDER BY cost_usd DESC
     """)
+    telemetry_by_job = {row["cron_job_id"]: row for row in telemetry_rows if row.get("cron_job_id")}
+    scheduler_rows = _cron_scheduler_totals(window_hours)
+    merged = []
+    seen = set()
+
+    for row in scheduler_rows:
+        job_id = row["cron_job_id"]
+        tele = telemetry_by_job.get(job_id, {})
+        merged.append(
+            {
+                "cron_job_id": job_id,
+                "job_name": row.get("job_name") or job_id,
+                "schedule_display": row.get("schedule_display") or "",
+                "runs": int(row.get("runs") or 0),
+                "ok_runs": int(tele.get("ok_runs") or 0),
+                "failed_runs": int(tele.get("failed_runs") or 0),
+                "tokens_in": int(tele.get("tokens_in") or 0),
+                "tokens_out": int(tele.get("tokens_out") or 0),
+                "cache_read_tokens": int(tele.get("cache_read_tokens") or 0),
+                "cache_write_tokens": int(tele.get("cache_write_tokens") or 0),
+                "cost_usd": float(tele.get("cost_usd") or 0.0),
+                "avg_duration_ms": tele.get("avg_duration_ms"),
+                "last_run": row.get("last_run") or tele.get("last_run"),
+                "last_status": row.get("last_status") or "—",
+                "enabled": bool(row.get("enabled", True)),
+            }
+        )
+        seen.add(job_id)
+
+    for row in telemetry_rows:
+        job_id = row.get("cron_job_id")
+        if not job_id or job_id in seen:
+            continue
+        merged.append(
+            {
+                "cron_job_id": job_id,
+                "job_name": job_id,
+                "schedule_display": "",
+                "runs": int(row.get("runs") or 0),
+                "ok_runs": int(row.get("ok_runs") or 0),
+                "failed_runs": int(row.get("failed_runs") or 0),
+                "tokens_in": int(row.get("tokens_in") or 0),
+                "tokens_out": int(row.get("tokens_out") or 0),
+                "cache_read_tokens": int(row.get("cache_read_tokens") or 0),
+                "cache_write_tokens": int(row.get("cache_write_tokens") or 0),
+                "cost_usd": float(row.get("cost_usd") or 0.0),
+                "avg_duration_ms": row.get("avg_duration_ms"),
+                "last_run": row.get("last_run"),
+                "last_status": "—",
+                "enabled": True,
+            }
+        )
+
+    return sorted(
+        merged,
+        key=lambda row: (
+            row.get("last_run") or "",
+            int(row.get("runs") or 0),
+        ),
+        reverse=True,
+    )
 
 
 def api_providers(window_hours=24):
@@ -308,7 +542,8 @@ def api_providers(window_hours=24):
 
 
 def api_provider_health(window_hours=24):
-    effective_window = int(window_hours) if int(window_hours) > 0 else 24
+    requested_window = _coerce_window_hours(window_hours)
+    effective_window = requested_window if requested_window > 0 else 24
     now = datetime.now(timezone.utc)
     current_start = (now - timedelta(hours=effective_window)).isoformat()
     previous_start = (now - timedelta(hours=effective_window * 2)).isoformat()
@@ -535,7 +770,7 @@ def api_runs(
     raw_total_runs = int(raw_total_row.get("total_runs") or 0)
     return {
         "filters": {
-            "hours": int(window_hours),
+            "hours": _coerce_window_hours(window_hours),
             "day": day,
             "model": model,
             "provider": provider,
@@ -666,7 +901,7 @@ def api_requests(
     raw_total_requests = int(raw_total_row.get("total_requests") or 0)
     return {
         "filters": {
-            "hours": int(window_hours),
+            "hours": _coerce_window_hours(window_hours),
             "day": day,
             "model": model,
             "provider": provider,
@@ -1254,8 +1489,9 @@ def api_model_tokens(window_hours=24, limit=100):
     )
 
 
-def api_daily_tokens(window_hours=24, page=1, per_page=15):
+def api_daily_tokens(window_hours=24, page=1, per_page=15, tz_name: str | None = None):
     since_clause_ts = _since_clause(window_hours, "ts")
+    period_expr = _period_label_expr("ts", "day", tz_name)
     page = max(1, int(page))
     per_page = max(1, min(15, int(per_page)))
 
@@ -1263,10 +1499,10 @@ def api_daily_tokens(window_hours=24, page=1, per_page=15):
         f"""
         SELECT COUNT(*) AS total_days
         FROM (
-            SELECT DATE(ts) AS day
+            SELECT {period_expr} AS day
             FROM llm_calls
             WHERE {since_clause_ts}
-            GROUP BY DATE(ts)
+            GROUP BY {period_expr}
         ) d
         """
     )
@@ -1278,7 +1514,7 @@ def api_daily_tokens(window_hours=24, page=1, per_page=15):
     rows = _rows(
         f"""
         SELECT
-            DATE(ts) AS day,
+            {period_expr} AS day,
             COUNT(*) AS api_calls,
             COALESCE(SUM(tokens_in), 0) AS tokens_in,
             COALESCE(SUM(tokens_out), 0) AS tokens_out,
@@ -1293,7 +1529,7 @@ def api_daily_tokens(window_hours=24, page=1, per_page=15):
                 + COALESCE(SUM(reasoning_tokens), 0) AS total_tokens
         FROM llm_calls
         WHERE {since_clause_ts}
-        GROUP BY DATE(ts)
+        GROUP BY {period_expr}
         ORDER BY day DESC
         LIMIT ? OFFSET ?
         """,
@@ -1309,57 +1545,124 @@ def api_daily_tokens(window_hours=24, page=1, per_page=15):
     }
 
 
-def api_daily_token_chart(window_hours=24, limit_days=90):
-    since_clause_ts = _since_clause(window_hours, "ts")
+def api_daily_token_chart(
+    window_hours=24,
+    limit_days=90,
+    include_deleted=False,
+    granularity="day",
+    tz_name: str | None = None,
+):
+    since_clause_ts = _since_clause(window_hours, "lc.ts")
     since_clause_runs = _since_clause(window_hours, "started_at")
-    limit_days = max(1, min(180, int(limit_days)))
+    since_epoch = _since_cutoff_epoch(window_hours)
+    granularity = _normalize_granularity(granularity)
+    llm_period_expr = _period_label_expr("lc.ts", granularity, tz_name)
+    runs_period_expr = _period_label_expr("started_at", granularity, tz_name)
+    state_period_expr = _period_label_expr("datetime(timestamp, 'unixepoch')", granularity, tz_name)
+    limit_days = max(1, min(3650, int(limit_days)))
+    visible_llm_sql, visible_llm_params = _visible_sessions_clause(
+        "r.session_id", include_deleted=include_deleted
+    )
+    visible_runs_sql, visible_runs_params = _visible_sessions_clause(
+        "session_id", include_deleted=include_deleted
+    )
 
     llm_rows = _rows(
         f"""
         SELECT *
         FROM (
             SELECT
-                DATE(ts) AS day,
+                {llm_period_expr} AS day,
                 COUNT(*) AS api_calls,
-                ROUND(COALESCE(SUM(cost_usd), 0), 6) AS cost_usd,
-                COALESCE(SUM(tokens_in), 0) AS tokens_in,
-                COALESCE(SUM(tokens_out), 0) AS tokens_out,
-                COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
-                COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
-                COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
-                COALESCE(SUM(tokens_in), 0)
-                    + COALESCE(SUM(tokens_out), 0)
-                    + COALESCE(SUM(cache_read_tokens), 0)
-                    + COALESCE(SUM(cache_write_tokens), 0)
-                    + COALESCE(SUM(reasoning_tokens), 0) AS total_tokens
-            FROM llm_calls
-            WHERE {since_clause_ts}
-            GROUP BY DATE(ts)
+                ROUND(COALESCE(SUM(lc.cost_usd), 0), 6) AS cost_usd,
+                COALESCE(SUM(lc.tokens_in), 0) AS tokens_in,
+                COALESCE(SUM(lc.tokens_out), 0) AS tokens_out,
+                COALESCE(SUM(lc.cache_read_tokens), 0) AS cache_read_tokens,
+                COALESCE(SUM(lc.cache_write_tokens), 0) AS cache_write_tokens,
+                COALESCE(SUM(lc.reasoning_tokens), 0) AS reasoning_tokens,
+                COALESCE(SUM(lc.tokens_in), 0)
+                    + COALESCE(SUM(lc.tokens_out), 0)
+                    + COALESCE(SUM(lc.cache_read_tokens), 0)
+                    + COALESCE(SUM(lc.cache_write_tokens), 0)
+                    + COALESCE(SUM(lc.reasoning_tokens), 0) AS total_tokens
+            FROM llm_calls lc
+            LEFT JOIN runs r ON r.session_id = lc.session_id
+            WHERE {since_clause_ts} AND {visible_llm_sql}
+            GROUP BY {llm_period_expr}
             ORDER BY day DESC
             LIMIT ?
         ) d
         ORDER BY day ASC
         """,
-        (limit_days,),
+        (*visible_llm_params, limit_days),
     )
     run_rows = _rows(
         f"""
         SELECT *
         FROM (
             SELECT
-                DATE(started_at) AS day,
-                COUNT(*) AS request_runs,
-                COALESCE(SUM(tool_calls), 0) AS tool_calls,
-                SUM(CASE WHEN platform = 'cron' THEN 1 ELSE 0 END) AS cron_job_runs
+                {runs_period_expr} AS day,
+                COUNT(*) AS request_runs
             FROM runs
-            WHERE {since_clause_runs}
-            GROUP BY DATE(started_at)
+            WHERE {since_clause_runs} AND {visible_runs_sql}
+            GROUP BY {runs_period_expr}
             ORDER BY day DESC
             LIMIT ?
         ) d
         ORDER BY day ASC
         """,
-        (limit_days,),
+        (*visible_runs_params, limit_days),
+    )
+    tool_rows = _rows(
+        f"""
+        SELECT *
+        FROM (
+            SELECT
+                {_period_label_expr("tc.ts", granularity, tz_name)} AS day,
+                COUNT(*) AS tool_calls
+            FROM tool_calls tc
+            LEFT JOIN runs r ON r.session_id = tc.session_id
+            WHERE {_since_clause(window_hours, "tc.ts")} AND {visible_llm_sql}
+            GROUP BY {_period_label_expr("tc.ts", granularity)}
+            ORDER BY day DESC
+            LIMIT ?
+        ) d
+        ORDER BY day ASC
+        """,
+        (*visible_llm_params, limit_days),
+    )
+    cron_rows = _cron_scheduler_runs(window_hours)
+    cron_counts = {}
+    cron_tzinfo, _ = _dashboard_viewer_tz(_normalize_dashboard_tz_name(tz_name))
+    for row in cron_rows:
+        ts = row["ts"].astimezone(cron_tzinfo)
+        if granularity == "month":
+            day = ts.strftime("%Y-%m")
+        elif granularity == "week":
+            monday = (ts - timedelta(days=ts.weekday())).date()
+            day = monday.isoformat()
+        else:
+            day = ts.date().isoformat()
+        cron_counts[day] = cron_counts.get(day, 0) + 1
+    state_where = "role IN ('user','assistant')"
+    state_params = []
+    if since_epoch is not None:
+        state_where += " AND timestamp >= ?"
+        state_params.append(since_epoch)
+    message_rows = _state_rows(
+        f"""
+        SELECT
+            {state_period_expr} AS day,
+            SUM(CASE WHEN role = 'user' AND TRIM(COALESCE(content, '')) != '' THEN 1 ELSE 0 END) AS user_messages,
+            SUM(CASE WHEN role = 'assistant' AND TRIM(COALESCE(content, '')) != '' THEN 1 ELSE 0 END) AS assistant_messages,
+            SUM(CASE WHEN role = 'user' AND TRIM(COALESCE(content, '')) != '' THEN 1 ELSE 0 END)
+                + SUM(CASE WHEN role = 'assistant' AND TRIM(COALESCE(content, '')) != '' THEN 1 ELSE 0 END) AS message_runs
+        FROM messages
+        WHERE {state_where}
+        GROUP BY {state_period_expr}
+        ORDER BY day ASC
+        """,
+        tuple(state_params),
     )
 
     merged = {}
@@ -1383,17 +1686,67 @@ def api_daily_token_chart(window_hours=24, limit_days=90):
             },
         )
         target["request_runs"] = int(row.get("request_runs") or 0)
+    for row in tool_rows:
+        day = row["day"]
+        target = merged.setdefault(
+            day,
+            {
+                "day": day,
+                "api_calls": 0,
+                "cost_usd": 0.0,
+                "tokens_in": 0,
+                "tokens_out": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "total_tokens": 0,
+            },
+        )
         target["tool_calls"] = int(row.get("tool_calls") or 0)
-        target["cron_job_runs"] = int(row.get("cron_job_runs") or 0)
+    for day, count in cron_counts.items():
+        target = merged.setdefault(
+            day,
+            {
+                "day": day,
+                "api_calls": 0,
+                "cost_usd": 0.0,
+                "tokens_in": 0,
+                "tokens_out": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "total_tokens": 0,
+            },
+        )
+        target["cron_job_runs"] = int(count)
+    for row in message_rows:
+        day = row["day"]
+        target = merged.setdefault(
+            day,
+            {
+                "day": day,
+                "api_calls": 0,
+                "cost_usd": 0.0,
+                "tokens_in": 0,
+                "tokens_out": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "total_tokens": 0,
+            },
+        )
+        target["message_runs"] = int(row.get("message_runs") or 0)
+        target["user_messages"] = int(row.get("user_messages") or 0)
+        target["assistant_messages"] = int(row.get("assistant_messages") or 0)
 
     rows = [merged[day] for day in sorted(merged.keys())][-limit_days:]
     for row in rows:
         row.setdefault("request_runs", 0)
         row.setdefault("tool_calls", 0)
         row.setdefault("cron_job_runs", 0)
-        row["message_runs"] = max(
-            0, int(row.get("request_runs") or 0) - int(row.get("cron_job_runs") or 0)
-        )
+        row.setdefault("message_runs", 0)
+        row.setdefault("user_messages", 0)
+        row.setdefault("assistant_messages", 0)
         billable_tokens = (
             int(row.get("tokens_in") or 0)
             + int(row.get("tokens_out") or 0)
@@ -1414,26 +1767,33 @@ def api_daily_token_chart(window_hours=24, limit_days=90):
     return rows
 
 
-def api_daily_model_chart(window_hours=24, limit_days=90, top_n=5):
+def api_daily_model_chart(
+    window_hours=24, limit_days=90, top_n=5, include_deleted=False, tz_name: str | None = None
+):
     since_clause_ts = _since_clause(window_hours, "ts")
-    limit_days = max(1, min(180, int(limit_days)))
+    day_expr = _period_label_expr("lc.ts", "day", tz_name)
+    limit_days = max(1, min(3650, int(limit_days)))
     top_n = max(1, min(8, int(top_n)))
+    visible_sql, visible_params = _visible_sessions_clause(
+        "r.session_id", include_deleted=include_deleted
+    )
 
     top_models = _rows(
         f"""
-        SELECT COALESCE(model, '—') AS model,
-               COALESCE(SUM(tokens_in), 0)
-                   + COALESCE(SUM(tokens_out), 0)
-                   + COALESCE(SUM(cache_read_tokens), 0)
-                   + COALESCE(SUM(cache_write_tokens), 0)
-                   + COALESCE(SUM(reasoning_tokens), 0) AS total_tokens
-        FROM llm_calls
-        WHERE {since_clause_ts}
-        GROUP BY COALESCE(model, '—')
+        SELECT COALESCE(lc.model, '—') AS model,
+               COALESCE(SUM(lc.tokens_in), 0)
+                   + COALESCE(SUM(lc.tokens_out), 0)
+                   + COALESCE(SUM(lc.cache_read_tokens), 0)
+                   + COALESCE(SUM(lc.cache_write_tokens), 0)
+                   + COALESCE(SUM(lc.reasoning_tokens), 0) AS total_tokens
+        FROM llm_calls lc
+        LEFT JOIN runs r ON r.session_id = lc.session_id
+        WHERE {since_clause_ts} AND {visible_sql}
+        GROUP BY COALESCE(lc.model, '—')
         ORDER BY total_tokens DESC
         LIMIT ?
         """,
-        (top_n,),
+        (*visible_params, top_n),
     )
     model_names = [r["model"] for r in top_models]
 
@@ -1442,21 +1802,23 @@ def api_daily_model_chart(window_hours=24, limit_days=90, top_n=5):
         SELECT *
         FROM (
             SELECT
-                DATE(ts) AS day,
-                COALESCE(model, '—') AS model,
-                COALESCE(SUM(tokens_in), 0)
-                    + COALESCE(SUM(tokens_out), 0)
-                    + COALESCE(SUM(cache_read_tokens), 0)
-                    + COALESCE(SUM(cache_write_tokens), 0)
-                    + COALESCE(SUM(reasoning_tokens), 0) AS total_tokens
-            FROM llm_calls
-            WHERE {since_clause_ts}
-            GROUP BY DATE(ts), COALESCE(model, '—')
+                {day_expr} AS day,
+                COALESCE(lc.model, '—') AS model,
+                COALESCE(SUM(lc.tokens_in), 0)
+                    + COALESCE(SUM(lc.tokens_out), 0)
+                    + COALESCE(SUM(lc.cache_read_tokens), 0)
+                    + COALESCE(SUM(lc.cache_write_tokens), 0)
+                    + COALESCE(SUM(lc.reasoning_tokens), 0) AS total_tokens
+            FROM llm_calls lc
+            LEFT JOIN runs r ON r.session_id = lc.session_id
+            WHERE {since_clause_ts} AND {visible_sql}
+            GROUP BY {day_expr}, COALESCE(lc.model, '—')
             ORDER BY day DESC
             LIMIT 100000
         ) d
         ORDER BY day ASC
-        """
+        """,
+        tuple(visible_params),
     )
 
     day_order = []
@@ -1481,7 +1843,12 @@ def api_daily_model_chart(window_hours=24, limit_days=90, top_n=5):
 
 
 def api_model_period_trends(
-    window_hours=24, granularity="day", metric="tokens", top_n=6, limit_periods=24
+    window_hours=24,
+    granularity="day",
+    metric="tokens",
+    top_n=6,
+    limit_periods=24,
+    tz_name: str | None = None,
 ):
     granularity = _normalize_granularity(granularity)
     metric = (metric or "tokens").strip().lower()
@@ -1490,7 +1857,7 @@ def api_model_period_trends(
     top_n = max(1, min(8, int(top_n)))
     limit_periods = max(1, min(36, int(limit_periods)))
     since_clause_ts = _since_clause(window_hours, "ts")
-    period_expr = _period_label_expr("ts", granularity)
+    period_expr = _period_label_expr("ts", granularity, tz_name)
 
     metric_expr = {
         "tokens": "COALESCE(SUM(tokens_in), 0) + COALESCE(SUM(tokens_out), 0) + COALESCE(SUM(cache_read_tokens), 0) + COALESCE(SUM(cache_write_tokens), 0) + COALESCE(SUM(reasoning_tokens), 0)",
@@ -1516,7 +1883,7 @@ def api_model_period_trends(
     period_rows = _rows(
         f"""
         SELECT {period_expr} AS period,
-               MIN(DATE(ts)) AS period_start,
+               MIN({_period_start_expr("ts", granularity, tz_name)}) AS period_start,
                COALESCE(model, '—') AS model,
                COUNT(*) AS api_calls,
                COALESCE(SUM(tokens_in), 0) AS tokens_in,
@@ -1576,15 +1943,17 @@ def api_model_period_trends(
     }
 
 
-def api_model_share_comparison(window_hours=24, granularity="day", limit=12):
+def api_model_share_comparison(
+    window_hours=24, granularity="day", limit=12, tz_name: str | None = None
+):
     granularity = _normalize_granularity(granularity)
     limit = max(1, min(20, int(limit)))
     since_clause_ts = _since_clause(window_hours, "ts")
-    period_expr = _period_label_expr("ts", granularity)
+    period_expr = _period_label_expr("ts", granularity, tz_name)
     rows = _rows(
         f"""
         SELECT {period_expr} AS period,
-               MIN(DATE(ts)) AS period_start,
+               MIN({_period_start_expr("ts", granularity, tz_name)}) AS period_start,
                COALESCE(model, '—') AS model,
                COUNT(*) AS api_calls,
                ROUND(COALESCE(SUM(cost_usd), 0), 6) AS cost_usd,
@@ -1961,6 +2330,20 @@ def _parse_int(value, name: str) -> int:
         raise ValueError(f"invalid {name}: {value!r}") from None
 
 
+def _coerce_window_hours(window_hours) -> float:
+    try:
+        return float(window_hours)
+    except (TypeError, ValueError):
+        raise ValueError(f"invalid hours: {window_hours!r}") from None
+
+
+def _parse_window_hours(value, name: str = "hours") -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"invalid {name}: {value!r}") from None
+
+
 # Allowed values for budget config — prevents YAML key injection
 ALLOWED_SCOPES = {"global", "per_cron_job", "per_sender"}
 ALLOWED_WINDOWS = {"daily", "monthly"}
@@ -2102,26 +2485,30 @@ class Handler(SimpleHTTPRequestHandler):
             # API routes
             if path == "/api/summary":
                 qs = parse_qs(parsed.query)
-                return self._json(api_summary(_parse_int(qs.get("hours", [24])[0], "hours")))
+                return self._json(
+                    api_summary(_parse_window_hours(qs.get("hours", [24])[0], "hours"))
+                )
 
             if path == "/api/cron":
                 qs = parse_qs(parsed.query)
-                return self._json(api_cron(_parse_int(qs.get("hours", [168])[0], "hours")))
+                return self._json(api_cron(_parse_window_hours(qs.get("hours", [168])[0], "hours")))
 
             if path == "/api/providers":
                 qs = parse_qs(parsed.query)
-                return self._json(api_providers(_parse_int(qs.get("hours", [24])[0], "hours")))
+                return self._json(
+                    api_providers(_parse_window_hours(qs.get("hours", [24])[0], "hours"))
+                )
 
             if path == "/api/provider-health":
                 qs = parse_qs(parsed.query)
                 return self._json(
-                    api_provider_health(_parse_int(qs.get("hours", [24])[0], "hours"))
+                    api_provider_health(_parse_window_hours(qs.get("hours", [24])[0], "hours"))
                 )
 
             if path == "/api/cache-efficiency":
                 qs = parse_qs(parsed.query)
                 return self._json(
-                    api_cache_efficiency(_parse_int(qs.get("hours", [24])[0], "hours"))
+                    api_cache_efficiency(_parse_window_hours(qs.get("hours", [24])[0], "hours"))
                 )
 
             if path == "/api/runs":
@@ -2129,7 +2516,7 @@ class Handler(SimpleHTTPRequestHandler):
                 return self._json(
                     api_runs(
                         _parse_int(qs.get("limit", [50])[0], "limit"),
-                        _parse_int(qs.get("hours", [0])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [0])[0], "hours"),
                         qs.get("day", [None])[0],
                         qs.get("model", [None])[0],
                         qs.get("provider", [None])[0],
@@ -2148,7 +2535,7 @@ class Handler(SimpleHTTPRequestHandler):
                 return self._json(
                     api_requests(
                         _parse_int(qs.get("limit", [100])[0], "limit"),
-                        _parse_int(qs.get("hours", [0])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [0])[0], "hours"),
                         qs.get("day", [None])[0],
                         qs.get("model", [None])[0],
                         qs.get("provider", [None])[0],
@@ -2174,7 +2561,7 @@ class Handler(SimpleHTTPRequestHandler):
                 qs = parse_qs(parsed.query)
                 return self._json(
                     api_tool_analytics(
-                        _parse_int(qs.get("hours", [0])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [0])[0], "hours"),
                         qs.get("day", [None])[0],
                         qs.get("model", [None])[0],
                         qs.get("provider", [None])[0],
@@ -2192,7 +2579,7 @@ class Handler(SimpleHTTPRequestHandler):
                 qs = parse_qs(parsed.query)
                 return self._json(
                     api_error_center(
-                        _parse_int(qs.get("hours", [0])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [0])[0], "hours"),
                         qs.get("day", [None])[0],
                         qs.get("model", [None])[0],
                         qs.get("provider", [None])[0],
@@ -2210,7 +2597,7 @@ class Handler(SimpleHTTPRequestHandler):
                 qs = parse_qs(parsed.query)
                 return self._json(
                     api_model_tokens(
-                        _parse_int(qs.get("hours", [24])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [24])[0], "hours"),
                         _parse_int(qs.get("limit", [100])[0], "limit"),
                     )
                 )
@@ -2219,7 +2606,7 @@ class Handler(SimpleHTTPRequestHandler):
                 qs = parse_qs(parsed.query)
                 return self._json(
                     api_model_efficiency(
-                        _parse_int(qs.get("hours", [0])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [0])[0], "hours"),
                         _parse_int(qs.get("limit", [50])[0], "limit"),
                         qs.get("include_deleted", ["0"])[0] in {"1", "true", "yes"},
                     )
@@ -2229,7 +2616,7 @@ class Handler(SimpleHTTPRequestHandler):
                 qs = parse_qs(parsed.query)
                 return self._json(
                     api_tool_failure_heatmap(
-                        _parse_int(qs.get("hours", [0])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [0])[0], "hours"),
                         _parse_int(qs.get("limit", [80])[0], "limit"),
                         qs.get("include_deleted", ["0"])[0] in {"1", "true", "yes"},
                     )
@@ -2239,7 +2626,7 @@ class Handler(SimpleHTTPRequestHandler):
                 qs = parse_qs(parsed.query)
                 return self._json(
                     api_cron_failure_waste(
-                        _parse_int(qs.get("hours", [0])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [0])[0], "hours"),
                         _parse_int(qs.get("limit", [50])[0], "limit"),
                         qs.get("include_deleted", ["0"])[0] in {"1", "true", "yes"},
                     )
@@ -2247,52 +2634,65 @@ class Handler(SimpleHTTPRequestHandler):
 
             if path == "/api/daily-tokens":
                 qs = parse_qs(parsed.query)
+                tz_name = qs.get("tz", [None])[0]
                 return self._json(
                     api_daily_tokens(
-                        _parse_int(qs.get("hours", [24])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [24])[0], "hours"),
                         _parse_int(qs.get("page", [1])[0], "page"),
                         _parse_int(qs.get("per_page", [15])[0], "per_page"),
+                        tz_name,
                     )
                 )
 
             if path == "/api/daily-token-chart":
                 qs = parse_qs(parsed.query)
+                tz_name = qs.get("tz", [None])[0]
                 return self._json(
                     api_daily_token_chart(
-                        _parse_int(qs.get("hours", [24])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [24])[0], "hours"),
                         _parse_int(qs.get("limit_days", [90])[0], "limit_days"),
+                        qs.get("include_deleted", ["0"])[0] in {"1", "true", "yes"},
+                        qs.get("granularity", ["day"])[0],
+                        tz_name,
                     )
                 )
 
             if path == "/api/daily-model-chart":
                 qs = parse_qs(parsed.query)
+                tz_name = qs.get("tz", [None])[0]
                 return self._json(
                     api_daily_model_chart(
-                        _parse_int(qs.get("hours", [24])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [24])[0], "hours"),
                         _parse_int(qs.get("limit_days", [90])[0], "limit_days"),
                         _parse_int(qs.get("top_n", [5])[0], "top_n"),
+                        qs.get("include_deleted", ["0"])[0] in {"1", "true", "yes"},
+                        tz_name,
                     )
                 )
 
             if path == "/api/model-period-trends":
                 qs = parse_qs(parsed.query)
+                tz_name = qs.get("tz", [None])[0]
                 return self._json(
                     api_model_period_trends(
-                        _parse_int(qs.get("hours", [24])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [24])[0], "hours"),
                         qs.get("granularity", ["day"])[0],
                         qs.get("metric", ["tokens"])[0],
                         _parse_int(qs.get("top_n", [6])[0], "top_n"),
                         _parse_int(qs.get("limit_periods", [24])[0], "limit_periods"),
+                        tz_name,
                     )
                 )
 
             if path == "/api/model-share-comparison":
                 qs = parse_qs(parsed.query)
+                tz_name = qs.get("tz", [None])[0]
                 return self._json(
                     api_model_share_comparison(
-                        _parse_int(qs.get("hours", [24])[0], "hours"),
+                        _parse_window_hours(qs.get("hours", [24])[0], "hours"),
                         qs.get("granularity", ["day"])[0],
                         _parse_int(qs.get("limit", [12])[0], "limit"),
+                        tz_name,
                     )
                 )
 
@@ -2311,7 +2711,7 @@ class Handler(SimpleHTTPRequestHandler):
             if path == "/api/token-breakdown":
                 qs = parse_qs(parsed.query)
                 return self._json(
-                    api_token_breakdown(_parse_int(qs.get("hours", [24])[0], "hours"))
+                    api_token_breakdown(_parse_window_hours(qs.get("hours", [24])[0], "hours"))
                 )
         except ValueError as e:
             return self._json({"error": str(e)}, 400)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import sqlite3
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,11 +18,16 @@ _SERVE_PATH = Path(__file__).resolve().parents[1] / "dashboard" / "serve.py"
 
 
 @pytest.fixture
-def serve_module():
+def serve_module(tmp_path):
     spec = importlib.util.spec_from_file_location("dashboard_serve", _SERVE_PATH)
     module = importlib.util.module_from_spec(spec)
     sys.modules["dashboard_serve"] = module
     spec.loader.exec_module(module)
+    cron_root = tmp_path / "cron"
+    cron_root.mkdir()
+    module.CRON_JOBS_PATH = cron_root / "jobs.json"
+    module.CRON_OUTPUT_DIR = cron_root / "output"
+    module.CRON_OUTPUT_DIR.mkdir()
     yield module
     sys.modules.pop("dashboard_serve", None)
 
@@ -33,6 +40,42 @@ def isolated_dashboard_db():
     if conn:
         conn.close()
         db._local.conn = None
+
+
+def _seed_state_db(path: Path, rows: list[tuple[float, str, str]]):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id INTEGER,
+            role TEXT,
+            content TEXT,
+            tool_call_id TEXT,
+            tool_calls TEXT,
+            tool_name TEXT,
+            timestamp REAL,
+            token_count INTEGER,
+            finish_reason TEXT,
+            reasoning TEXT,
+            reasoning_content TEXT
+        )
+        """
+    )
+    conn.executemany(
+        "INSERT INTO messages (timestamp, role, content) VALUES (?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_cron_history(serve_module, jobs: list[dict], output_runs: list[tuple[str, str]]):
+    serve_module.CRON_JOBS_PATH.write_text(json.dumps({"jobs": jobs}))
+    for job_id, ts in output_runs:
+        job_dir = serve_module.CRON_OUTPUT_DIR / job_id
+        job_dir.mkdir(parents=True, exist_ok=True)
+        (job_dir / f"{ts}.md").write_text("ok\n")
 
 
 # ---------------------------------------------------------------------------
@@ -419,12 +462,88 @@ def test_budget_detail_restores_default_thresholds(serve_module, tmp_path):
     assert detail["on_estimated_mode"] == "warn_only"
 
 
-def test_daily_token_chart_includes_requests_cost_and_savings(serve_module, monkeypatch):
-    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-10T10:00:00+00:00")
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="zoneinfo requires Python 3.9+")
+def test_dashboard_period_helper_respects_viewer_timezone(serve_module):
+    assert (
+        serve_module._sqlite_dashboard_period("2026-06-13T18:30:00+00:00", "day", "Asia/Dhaka")
+        == "2026-06-14"
+    )
+    assert (
+        serve_module._sqlite_dashboard_period("2026-06-13T18:30:00+00:00", "day", "UTC")
+        == "2026-06-13"
+    )
 
-    db.start_run("trend-a", model="gpt-5.4", platform="cli")
-    db.record_tool_call("trend-a", "2026-06-10T10:05:00+00:00", "read_file", True, 20)
-    db.record_tool_call("trend-a", "2026-06-10T10:06:00+00:00", "terminal", True, 30)
+
+def test_parse_window_hours_supports_subhour_ranges(serve_module):
+    assert serve_module._parse_window_hours("0.25") == 0.25
+    assert serve_module._parse_window_hours("0") == 0.0
+
+
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="zoneinfo requires Python 3.9+")
+def test_daily_token_chart_groups_by_viewer_timezone_day(serve_module, monkeypatch, tmp_path):
+    state_db = tmp_path / "state.db"
+    _seed_state_db(state_db, [])
+    monkeypatch.setattr(serve_module, "STATE_DB_PATH", state_db)
+
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-13T17:00:00+00:00")
+    db.start_run("tz-a", model="gpt-5.4", platform="discord")
+    db.record_llm_call(
+        "tz-a", "2026-06-13T17:30:00+00:00", "gpt-5.4", "openai-codex", 100, 10, 0.01, 50
+    )
+    db.end_run("tz-a", "ok", ended_at="2026-06-13T17:35:00+00:00")
+
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-13T18:00:00+00:00")
+    db.start_run("tz-b", model="gpt-5.4", platform="discord")
+    db.record_llm_call(
+        "tz-b", "2026-06-13T18:30:00+00:00", "gpt-5.4", "openai-codex", 200, 20, 0.02, 50
+    )
+    db.end_run("tz-b", "ok", ended_at="2026-06-13T18:35:00+00:00")
+
+    utc_rows = serve_module.api_daily_token_chart(window_hours=0, limit_days=10, tz_name="UTC")
+    dhaka_rows = serve_module.api_daily_token_chart(
+        window_hours=0, limit_days=10, tz_name="Asia/Dhaka"
+    )
+
+    assert [row["day"] for row in utc_rows] == ["2026-06-13"]
+    assert utc_rows[0]["api_calls"] == 2
+    assert [row["day"] for row in dhaka_rows] == ["2026-06-13", "2026-06-14"]
+    assert dhaka_rows[0]["api_calls"] == 1
+    assert dhaka_rows[1]["api_calls"] == 1
+
+
+def test_daily_token_chart_includes_requests_cost_savings_and_messages(
+    serve_module, monkeypatch, tmp_path
+):
+    _seed_cron_history(
+        serve_module,
+        [
+            {
+                "id": "trend-cron",
+                "name": "Trend Cron",
+                "schedule_display": "0 * * * *",
+                "repeat": {"completed": 1},
+                "last_run_at": "2026-06-10T11:10:00+00:00",
+                "last_status": "ok",
+                "enabled": True,
+            }
+        ],
+        [("trend-cron", "2026-06-10_11-10-00")],
+    )
+    state_db = tmp_path / "state.db"
+    _seed_state_db(
+        state_db,
+        [
+            (datetime(2026, 6, 10, 10, 1, tzinfo=timezone.utc).timestamp(), "user", "hello"),
+            (datetime(2026, 6, 10, 10, 2, tzinfo=timezone.utc).timestamp(), "assistant", "hi"),
+            (datetime(2026, 6, 10, 10, 3, tzinfo=timezone.utc).timestamp(), "assistant", ""),
+        ],
+    )
+    monkeypatch.setattr(serve_module, "STATE_DB_PATH", state_db)
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-10T09:50:00+00:00")
+
+    db.start_run("trend-a", model="gpt-5.4", platform="discord")
+    db.record_tool_call("trend-a", "2026-06-10T10:05:00+00:00", "search_files", True, 15)
+    db.record_tool_call("trend-a", "2026-06-10T10:06:00+00:00", "read_file", True, 20)
     db.record_llm_call(
         "trend-a",
         "2026-06-10T10:00:00+00:00",
@@ -453,8 +572,256 @@ def test_daily_token_chart_includes_requests_cost_and_savings(serve_module, monk
     assert row["request_runs"] == 2
     assert row["tool_calls"] == 3
     assert row["cron_job_runs"] == 1
-    assert row["message_runs"] == 1
+    assert row["message_runs"] == 2
+    assert row["user_messages"] == 1
+    assert row["assistant_messages"] == 1
     assert row["cost_usd"] == pytest.approx(0.03, abs=1e-6)
     assert row["total_tokens"] == 330
     assert row["estimated_savings_usd"] == pytest.approx(0.025, abs=1e-6)
     assert row["savings_pct"] == pytest.approx(45.45, abs=0.01)
+
+
+def test_daily_token_chart_hides_deleted_sessions_like_dashboard_tables(
+    serve_module, monkeypatch, tmp_path
+):
+    _seed_cron_history(
+        serve_module,
+        [
+            {
+                "id": "alpha",
+                "name": "Cron Alpha",
+                "schedule_display": "0 * * * *",
+                "repeat": {"completed": 1},
+                "last_run_at": "2026-06-10T12:10:00+00:00",
+                "last_status": "ok",
+                "enabled": True,
+            }
+        ],
+        [("alpha", "2026-06-10_12-10-00")],
+    )
+    state_db = tmp_path / "state.db"
+    _seed_state_db(
+        state_db,
+        [
+            (datetime(2026, 6, 10, 10, 1, tzinfo=timezone.utc).timestamp(), "user", "visible user"),
+            (
+                datetime(2026, 6, 10, 10, 2, tzinfo=timezone.utc).timestamp(),
+                "assistant",
+                "visible assistant",
+            ),
+        ],
+    )
+    monkeypatch.setattr(serve_module, "STATE_DB_PATH", state_db)
+    monkeypatch.setattr(
+        serve_module, "_active_hermes_session_ids", lambda: ({"sess-visible"}, True)
+    )
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-10T09:55:00+00:00")
+
+    db.start_run("sess-visible", model="gpt-5.4", platform="discord")
+    db.record_llm_call(
+        "sess-visible", "2026-06-10T10:00:00+00:00", "gpt-5.4", "openai-codex", 100, 50, 0.03, 120
+    )
+    db.end_run("sess-visible", "ok", ended_at="2026-06-10T10:10:00+00:00")
+
+    db.start_run("sess-hidden", model="gpt-5.4", platform="discord")
+    db.record_llm_call(
+        "sess-hidden", "2026-06-10T11:00:00+00:00", "gpt-5.4", "openai-codex", 200, 75, 0.05, 100
+    )
+    db.end_run("sess-hidden", "ok", ended_at="2026-06-10T11:10:00+00:00")
+
+    db.start_run("cron_alpha", model="gpt-5.4", platform="cron")
+    db.record_llm_call(
+        "cron_alpha", "2026-06-10T12:00:00+00:00", "gpt-5.4", "openai-codex", 80, 20, 0.01, 90
+    )
+    db.end_run("cron_alpha", "ok", ended_at="2026-06-10T12:10:00+00:00")
+
+    rows = serve_module.api_daily_token_chart(window_hours=0, limit_days=10)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["api_calls"] == 2
+    assert row["request_runs"] == 2
+    assert row["cron_job_runs"] == 1
+    assert row["message_runs"] == 2
+    assert row["user_messages"] == 1
+    assert row["assistant_messages"] == 1
+    assert row["tokens_in"] == 180
+    assert row["tokens_out"] == 70
+
+
+def test_daily_token_chart_include_deleted_restores_archived_sessions(
+    serve_module, monkeypatch, tmp_path
+):
+    state_db = tmp_path / "state.db"
+    _seed_state_db(
+        state_db,
+        [
+            (datetime(2026, 6, 10, 10, 1, tzinfo=timezone.utc).timestamp(), "user", "first user"),
+            (
+                datetime(2026, 6, 10, 10, 2, tzinfo=timezone.utc).timestamp(),
+                "assistant",
+                "first assistant",
+            ),
+            (datetime(2026, 6, 10, 11, 1, tzinfo=timezone.utc).timestamp(), "user", "second user"),
+            (
+                datetime(2026, 6, 10, 11, 2, tzinfo=timezone.utc).timestamp(),
+                "assistant",
+                "second assistant",
+            ),
+        ],
+    )
+    monkeypatch.setattr(serve_module, "STATE_DB_PATH", state_db)
+    monkeypatch.setattr(
+        serve_module, "_active_hermes_session_ids", lambda: ({"sess-visible"}, True)
+    )
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-10T09:55:00+00:00")
+
+    db.start_run("sess-visible", model="gpt-5.4", platform="discord")
+    db.record_llm_call(
+        "sess-visible", "2026-06-10T10:00:00+00:00", "gpt-5.4", "openai-codex", 100, 50, 0.03, 120
+    )
+    db.end_run("sess-visible", "ok", ended_at="2026-06-10T10:10:00+00:00")
+
+    db.start_run("sess-hidden", model="gpt-5.4", platform="discord")
+    db.record_llm_call(
+        "sess-hidden", "2026-06-10T11:00:00+00:00", "gpt-5.4", "openai-codex", 200, 75, 0.05, 100
+    )
+    db.end_run("sess-hidden", "ok", ended_at="2026-06-10T11:10:00+00:00")
+
+    rows = serve_module.api_daily_token_chart(window_hours=0, limit_days=10, include_deleted=True)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["api_calls"] == 2
+    assert row["request_runs"] == 2
+    assert row["message_runs"] == 4
+    assert row["user_messages"] == 2
+    assert row["assistant_messages"] == 2
+    assert row["tokens_in"] == 300
+    assert row["tokens_out"] == 125
+
+
+def test_daily_token_chart_supports_weekly_granularity(serve_module, monkeypatch, tmp_path):
+    _seed_cron_history(
+        serve_module,
+        [
+            {
+                "id": "week-b",
+                "name": "Week B",
+                "schedule_display": "0 * * * *",
+                "repeat": {"completed": 1},
+                "last_run_at": "2026-06-12T09:10:00+00:00",
+                "last_status": "ok",
+                "enabled": True,
+            }
+        ],
+        [("week-b", "2026-06-12_09-10-00")],
+    )
+    state_db = tmp_path / "state.db"
+    _seed_state_db(
+        state_db,
+        [
+            (datetime(2026, 6, 10, 10, 1, tzinfo=timezone.utc).timestamp(), "user", "u1"),
+            (datetime(2026, 6, 10, 10, 2, tzinfo=timezone.utc).timestamp(), "assistant", "a1"),
+            (datetime(2026, 6, 12, 9, 0, tzinfo=timezone.utc).timestamp(), "user", "u2"),
+            (datetime(2026, 6, 12, 9, 1, tzinfo=timezone.utc).timestamp(), "assistant", "a2"),
+        ],
+    )
+    monkeypatch.setattr(serve_module, "STATE_DB_PATH", state_db)
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-10T08:00:00+00:00")
+
+    db.start_run("week-a", model="gpt-5.4", platform="discord")
+    db.record_llm_call(
+        "week-a", "2026-06-10T10:00:00+00:00", "gpt-5.4", "openai-codex", 100, 50, 0.03, 100
+    )
+    db.end_run("week-a", "ok", ended_at="2026-06-10T10:10:00+00:00")
+
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-12T08:00:00+00:00")
+    db.start_run("week-b", model="gpt-5.4", platform="cron")
+    db.record_llm_call(
+        "week-b", "2026-06-12T09:00:00+00:00", "gpt-5.4", "openai-codex", 200, 75, 0.05, 100
+    )
+    db.end_run("week-b", "ok", ended_at="2026-06-12T09:10:00+00:00")
+
+    rows = serve_module.api_daily_token_chart(window_hours=0, limit_days=10, granularity="week")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["day"] == "2026-06-08"
+    assert row["api_calls"] == 2
+    assert row["request_runs"] == 2
+    assert row["cron_job_runs"] == 1
+    assert row["message_runs"] == 4
+    assert row["tokens_in"] == 300
+    assert row["tokens_out"] == 125
+
+
+def test_api_summary_uses_tool_call_events_not_run_aggregate(serve_module, monkeypatch):
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-10T09:55:00+00:00")
+    db.start_run("summary-tools", model="gpt-5.4", platform="discord")
+    db.record_tool_call("summary-tools", "2026-06-10T10:00:00+00:00", "read_file", True, 10)
+    db.record_tool_call("summary-tools", "2026-06-10T10:00:01+00:00", "search_files", True, 12)
+    db.end_run("summary-tools", "ok", ended_at="2026-06-10T10:01:00+00:00")
+
+    conn = sqlite3.connect(serve_module.DB_PATH)
+    conn.execute("UPDATE runs SET tool_calls = 1 WHERE session_id = 'summary-tools'")
+    conn.commit()
+    conn.close()
+
+    summary = serve_module.api_summary(window_hours=0)
+    assert summary["runs"]["tool_calls"] == 2
+
+
+def test_api_cron_includes_scheduler_runs_without_telemetry(serve_module, monkeypatch):
+    _seed_cron_history(
+        serve_module,
+        [
+            {
+                "id": "script-only",
+                "name": "Script Only",
+                "schedule_display": "every 15m",
+                "repeat": {"completed": 3},
+                "last_run_at": "2026-06-10T12:30:00+00:00",
+                "last_status": "ok",
+                "enabled": True,
+            },
+            {
+                "id": "telemetry-job",
+                "name": "Telemetry Job",
+                "schedule_display": "0 * * * *",
+                "repeat": {"completed": 2},
+                "last_run_at": "2026-06-10T11:00:00+00:00",
+                "last_status": "ok",
+                "enabled": True,
+            },
+        ],
+        [
+            ("script-only", "2026-06-10_12-00-00"),
+            ("script-only", "2026-06-10_12-15-00"),
+            ("script-only", "2026-06-10_12-30-00"),
+            ("telemetry-job", "2026-06-10_11-00-00"),
+        ],
+    )
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-10T10:55:00+00:00")
+    db.start_run(
+        "cron_telemetry-job_20260610_110000",
+        model="gpt-5.4",
+        platform="cron",
+        cron_job_id="telemetry-job",
+    )
+    db.record_llm_call(
+        "cron_telemetry-job_20260610_110000",
+        "2026-06-10T11:00:00+00:00",
+        "gpt-5.4",
+        "openai-codex",
+        50,
+        10,
+        0.01,
+        80,
+    )
+    db.end_run("cron_telemetry-job_20260610_110000", "ok", ended_at="2026-06-10T11:05:00+00:00")
+
+    rows = serve_module.api_cron(window_hours=0)
+    by_job = {row["cron_job_id"]: row for row in rows}
+    assert by_job["script-only"]["runs"] == 3
+    assert by_job["script-only"]["tokens_in"] == 0
+    assert by_job["script-only"]["last_status"] == "ok"
+    assert by_job["telemetry-job"]["runs"] == 2
+    assert by_job["telemetry-job"]["tokens_in"] == 50

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -554,6 +554,53 @@ def test_daily_token_chart_supports_hourly_granularity(serve_module, monkeypatch
     assert rows[2]["api_calls"] == 1
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="zoneinfo requires Python 3.9+")
+def test_daily_token_chart_supports_minute_granularity(serve_module, monkeypatch, tmp_path):
+    state_db = tmp_path / "state.db"
+    _seed_state_db(
+        state_db,
+        [
+            (datetime(2026, 6, 13, 10, 15, tzinfo=timezone.utc).timestamp(), "user", "u1"),
+            (datetime(2026, 6, 13, 10, 15, tzinfo=timezone.utc).timestamp(), "assistant", "a1"),
+            (datetime(2026, 6, 13, 10, 17, tzinfo=timezone.utc).timestamp(), "user", "u2"),
+        ],
+    )
+    monkeypatch.setattr(serve_module, "STATE_DB_PATH", state_db)
+
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-13T10:10:00+00:00")
+    db.start_run("minute-a", model="gpt-5.4", platform="discord")
+    db.record_llm_call(
+        "minute-a", "2026-06-13T10:15:20+00:00", "gpt-5.4", "openai-codex", 100, 20, 0.01, 50
+    )
+    db.record_tool_call("minute-a", "2026-06-13T10:15:30+00:00", "read_file", True, 10)
+    db.end_run("minute-a", "ok", ended_at="2026-06-13T10:15:40+00:00")
+
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-13T10:16:00+00:00")
+    db.start_run("minute-b", model="gpt-5.4", platform="cron")
+    db.record_llm_call(
+        "minute-b", "2026-06-13T10:17:10+00:00", "gpt-5.4", "openai-codex", 200, 30, 0.02, 50
+    )
+    db.end_run("minute-b", "ok", ended_at="2026-06-13T10:17:20+00:00")
+
+    rows = serve_module.api_daily_token_chart(
+        window_hours=0, limit_days=20, granularity="minute", tz_name="UTC"
+    )
+
+    by_day = {row["day"]: row for row in rows}
+    assert set(by_day) == {
+        "2026-06-13T10:10",
+        "2026-06-13T10:15",
+        "2026-06-13T10:16",
+        "2026-06-13T10:17",
+    }
+    assert by_day["2026-06-13T10:10"]["request_runs"] == 1
+    assert by_day["2026-06-13T10:15"]["api_calls"] == 1
+    assert by_day["2026-06-13T10:15"]["tool_calls"] == 1
+    assert by_day["2026-06-13T10:15"]["message_runs"] == 2
+    assert by_day["2026-06-13T10:16"]["request_runs"] == 1
+    assert by_day["2026-06-13T10:17"]["api_calls"] == 1
+
+
 def test_daily_token_chart_includes_requests_cost_savings_and_messages(
     serve_module, monkeypatch, tmp_path
 ):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -511,6 +511,49 @@ def test_daily_token_chart_groups_by_viewer_timezone_day(serve_module, monkeypat
     assert dhaka_rows[1]["api_calls"] == 1
 
 
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="zoneinfo requires Python 3.9+")
+def test_daily_token_chart_supports_hourly_granularity(serve_module, monkeypatch, tmp_path):
+    state_db = tmp_path / "state.db"
+    _seed_state_db(
+        state_db,
+        [
+            (datetime(2026, 6, 13, 10, 5, tzinfo=timezone.utc).timestamp(), "user", "u1"),
+            (datetime(2026, 6, 13, 10, 6, tzinfo=timezone.utc).timestamp(), "assistant", "a1"),
+            (datetime(2026, 6, 13, 11, 5, tzinfo=timezone.utc).timestamp(), "user", "u2"),
+            (datetime(2026, 6, 13, 11, 6, tzinfo=timezone.utc).timestamp(), "assistant", "a2"),
+        ],
+    )
+    monkeypatch.setattr(serve_module, "STATE_DB_PATH", state_db)
+
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-13T09:55:00+00:00")
+    db.start_run("hour-a", model="gpt-5.4", platform="discord")
+    db.record_llm_call(
+        "hour-a", "2026-06-13T10:15:00+00:00", "gpt-5.4", "openai-codex", 100, 20, 0.01, 50
+    )
+    db.end_run("hour-a", "ok", ended_at="2026-06-13T10:20:00+00:00")
+
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-13T10:55:00+00:00")
+    db.start_run("hour-b", model="gpt-5.4", platform="cron")
+    db.record_llm_call(
+        "hour-b", "2026-06-13T11:25:00+00:00", "gpt-5.4", "openai-codex", 200, 30, 0.02, 50
+    )
+    db.end_run("hour-b", "ok", ended_at="2026-06-13T11:30:00+00:00")
+
+    rows = serve_module.api_daily_token_chart(
+        window_hours=0, limit_days=48, granularity="hour", tz_name="UTC"
+    )
+
+    assert [row["day"] for row in rows] == [
+        "2026-06-13T09:00",
+        "2026-06-13T10:00",
+        "2026-06-13T11:00",
+    ]
+    assert rows[0]["request_runs"] == 1
+    assert rows[1]["api_calls"] == 1
+    assert rows[1]["message_runs"] == 2
+    assert rows[2]["api_calls"] == 1
+
+
 def test_daily_token_chart_includes_requests_cost_savings_and_messages(
     serve_module, monkeypatch, tmp_path
 ):

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -417,3 +417,44 @@ def test_budget_detail_restores_default_thresholds(serve_module, tmp_path):
     assert detail["soft_pct"] == 0.8
     assert detail["hard_pct"] == 1.0
     assert detail["on_estimated_mode"] == "warn_only"
+
+
+def test_daily_token_chart_includes_requests_cost_and_savings(serve_module, monkeypatch):
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-10T10:00:00+00:00")
+
+    db.start_run("trend-a", model="gpt-5.4", platform="cli")
+    db.record_tool_call("trend-a", "2026-06-10T10:05:00+00:00", "read_file", True, 20)
+    db.record_tool_call("trend-a", "2026-06-10T10:06:00+00:00", "terminal", True, 30)
+    db.record_llm_call(
+        "trend-a",
+        "2026-06-10T10:00:00+00:00",
+        "gpt-5.4",
+        "openai-codex",
+        100,
+        50,
+        0.03,
+        120,
+        cache_read_tokens=150,
+        cache_write_tokens=20,
+        reasoning_tokens=10,
+    )
+    db.end_run("trend-a", "ok", ended_at="2026-06-10T10:10:00+00:00")
+
+    monkeypatch.setattr(db, "_utcnow", lambda: "2026-06-10T11:00:00+00:00")
+    db.start_run("trend-cron", model="gpt-5.4", platform="cron")
+    db.record_tool_call("trend-cron", "2026-06-10T11:05:00+00:00", "browser_navigate", True, 25)
+    db.end_run("trend-cron", "ok", ended_at="2026-06-10T11:10:00+00:00")
+
+    rows = serve_module.api_daily_token_chart(window_hours=0, limit_days=10)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["day"] == "2026-06-10"
+    assert row["api_calls"] == 1
+    assert row["request_runs"] == 2
+    assert row["tool_calls"] == 3
+    assert row["cron_job_runs"] == 1
+    assert row["message_runs"] == 1
+    assert row["cost_usd"] == pytest.approx(0.03, abs=1e-6)
+    assert row["total_tokens"] == 330
+    assert row["estimated_savings_usd"] == pytest.approx(0.025, abs=1e-6)
+    assert row["savings_pct"] == pytest.approx(45.45, abs=0.01)


### PR DESCRIPTION
## Summary

This PR refreshes the home dashboard telemetry experience with a more polished chart surface, clearer homepage metrics, and a settings flow that makes time windows and daily grouping easier to control.

## What changed

- rebuilt the home metric trend visualization around Chart.js with token-first multi-series rendering
- improved homepage metric semantics and trend cards for LLM calls, sessions, messages, tool calls, cron job runs, cost, savings, and token usage
- restored scheduler-backed cron run counting so homepage cron totals can reflect scheduler executions even without tokenized LLM work
- added timezone-aware day-boundary control (`Local time` / `UTC`) for daily chart grouping
- added richer view-time options, including sub-hour ranges and longer historical windows, while keeping `All time` as the default
- moved home controls into a more polished gear/settings panel and reordered header actions to `Loaded · Refresh · Gear`
- tightened responsive layout, typography, tooltip styling, legend readability, and chart spacing on the home surface
- expanded dashboard test coverage for timezone grouping, sub-hour windows, tool-call aggregation, and cron scheduler totals

## Why

The homepage had diverged from upstream in a few important ways:

- local chart work needed to be carried forward onto newer upstream code
- daily grouping needed an operator-friendly local-vs-UTC choice instead of a hardcoded backend day boundary
- cron counts and homepage telemetry cards needed to better reflect what operators actually expect to see
- the settings and chart presentation still felt cramped relative to the richer data now shown on the home view

## Validation

- `uvx ruff format --check .`
- `uvx ruff check .`
- `PYTHONPATH=. uv run --no-project --with pytest --with watchdog pytest tests/ -v --tb=short`

All checks passed locally (`262 passed`).

## Notes

- `Today`, `This week`, and `This month` currently map to rolling time windows (`24h`, `168h`, `720h`) rather than strict calendar-boundary buckets.
- The homepage chart/settings work in this PR includes the previously local chart carry-forward work plus the subsequent telemetry/settings polish.
