### PR TITLE
Fix free-tier pricing and id-change transition detection (issue #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Free→paid transition detection now handles the **id-change** case (issue #32):
+  when a provider drops a `:free` suffix (or renames a promo to its paid base)
+  so the paid call arrives under a different model id than the recorded `:free`
+  row. `db.is_free_tier_transition(model, provider)` matches a stored
+  `<id>:free` row both for the bare rename (`nemotron-3-ultra:free` →
+  `nemotron-3-ultra`) and for a suffixed paid id at a token boundary
+  (`nemotron-3-ultra-550b-a55b`). Wired into `post_api_request` alongside the
+  existing `is_known_free_model` check.
+- `nvidia/nemotron-3-ultra` paid seed in `_DEFAULT_PRICING` (OpenRouter rate
+  pending NIM-direct confirmation). Covers both the bare id and the suffixed
+  `…-550b-a55b` form via prefix, so cost becomes non-zero once the `:free`
+  promo ends 2026-06-18 — which is what fires the transition alert.
+
+### Notes
+- **Free Nemotron Ultra users**: declare `nvidia/nemotron-3-ultra:free` at `$0`
+  with `_subscription: true` in `pricing.yaml` before 2026-06-18. This both
+  silences the estimated-price warning and seeds the model as known-free so the
+  free→paid alert fires when billing starts. See the README **PLEASE READ**
+  notice. A built-in default price cannot suppress the estimated-price warning —
+  only the manual `_subscription` flag can.
+
 ## [0.5.0] - 2026-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,18 +16,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `nemotron-3-ultra`) and for a suffixed paid id at a token boundary
   (`nemotron-3-ultra-550b-a55b`). Wired into `post_api_request` alongside the
   existing `is_known_free_model` check.
+- **`:free` suffix pricing rule** (issue #32): any model id ending in `:free`
+  (the OpenRouter free-tier convention, e.g.
+  `nvidia/nemotron-3-ultra-550b-a55b:free`) now resolves to an explicit `$0` in
+  `pricing._lookup_form`, **before** the prefix scan. This means a `:free` id is
+  recorded as known-free (no estimated-price warning) and seeds the free→paid
+  alert automatically — no manual `pricing.yaml` entry required. A user's
+  explicit `:free` entry still overrides the rule.
 - `nvidia/nemotron-3-ultra` paid seed in `_DEFAULT_PRICING` (OpenRouter rate
   pending NIM-direct confirmation). Covers both the bare id and the suffixed
   `…-550b-a55b` form via prefix, so cost becomes non-zero once the `:free`
   promo ends 2026-06-18 — which is what fires the transition alert.
 
+### Fixed
+- `:free` promo variants of any **seeded** model were billed at the seeded
+  **paid** price via prefix match instead of `$0` (issue #32). Pre-fix,
+  `nvidia/nemotron-3-super-120b-a12b:free` resolved to the paid `$0.09/$0.45`
+  rate, and adding the `nvidia/nemotron-3-ultra` seed (above) regressed
+  `nvidia/nemotron-3-ultra-550b-a55b:free` from `$0` to the paid rate. The new
+  `:free` suffix rule short-circuits before the prefix scan, so free-tier calls
+  correctly cost `$0` during the promo. Corrects the earlier (0.4.1) claim that
+  `:free` variants "resolve to $0 via the unknown-model fallback" — they did not
+  for any model with a seeded paid base.
+
 ### Notes
-- **Free Nemotron Ultra users**: declare `nvidia/nemotron-3-ultra:free` at `$0`
-  with `_subscription: true` in `pricing.yaml` before 2026-06-18. This both
-  silences the estimated-price warning and seeds the model as known-free so the
-  free→paid alert fires when billing starts. See the README **PLEASE READ**
-  notice. A built-in default price cannot suppress the estimated-price warning —
-  only the manual `_subscription` flag can.
+- **Free Nemotron Ultra users**: no action required. Calls under any
+  `…nemotron-3-ultra…:free` id resolve to `$0` automatically and seed the
+  free→paid alert, which fires when the `:free` promo ends 2026-06-18 and the
+  gateway starts billing the bare/suffixed paid id. A manual `_subscription`
+  `$0` entry in `pricing.yaml` is still honored (and overrides the rule) but is
+  no longer needed.
 
 ## [0.5.0] - 2026-06-15
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -62,8 +62,8 @@ hermes-telemetry/
 │                          per-thread connections, WAL mode, write API and
 │                          read/budget query API.
 ├── pricing.py           ← Cost estimation engine. Priority-chain lookup
-│                          (custom YAML → built-in → prefix match). All 5 token
-│                          components. Google-symmetric normalization.
+│                          (custom YAML → built-in → `:free`→$0 → prefix match).
+│                          All 5 token components. Google-symmetric normalization.
 ├── pricing_refresh.py   ← Auto-refresh from remote pricing APIs. PricingSource
 │                          ABC, OpenRouterSource, GoogleAISource. Merge strategy
 │                          preserves manual overrides.
@@ -402,9 +402,22 @@ already uses `INSERT OR IGNORE`).
 
 1. **Custom YAML** (`~/.hermes/telemetry/pricing.yaml`, `models:` section) — exact match, case-insensitive
 2. **Built-in table** (`_DEFAULT_PRICING`) — exact match
-3. **Prefix fallback** — scans all of the above plus `_PREFIX_PRICING`, **longest prefix wins**
-4. **Google symmetric form** — if the above misses, tries `gemini-X` ↔ `google/gemini-X`
-5. **Unknown** → returns `$0.00`, logs a one-time WARNING
+3. **`:free` suffix rule** — any id ending in `:free` resolves to an explicit `$0`
+   (`{"input": 0.0, "output": 0.0}`), **before** the prefix fallback. See below.
+4. **Prefix fallback** — scans all of the above plus `_PREFIX_PRICING`, **longest prefix wins**
+5. **Google symmetric form** — if the above misses, tries `gemini-X` ↔ `google/gemini-X`
+6. **Unknown** → returns `$0.00`, logs a one-time WARNING
+
+**`:free` suffix rule (issue #32):** OpenRouter advertises free-tier variants with
+a `:free` suffix (e.g. `nvidia/nemotron-3-ultra-550b-a55b:free`). These are `$0` by
+definition. The rule sits in `_lookup_form` **after** the two exact-match steps but
+**before** the prefix scan, for two reasons: (1) otherwise a suffixed free id
+inherits its paid base's price via prefix — the `nvidia/nemotron-3-ultra` seed would
+price `…-550b-a55b:free` at the paid rate, billing a free call as paid; (2) returning
+an explicit zero dict (not the unknown-model `None`) makes the call resolve as
+known-free — no estimated-price warning, and it's recorded in `known_free_models` so
+the free→paid alert fires when the gateway later drops the `:free` suffix. A user's
+explicit `:free` entry (step 1) still overrides the rule.
 
 Every candidate is first filtered by the **provider-aware guard** (below), so a
 source-ineligible entry is skipped and the chain falls through to the next one.
@@ -446,8 +459,11 @@ same-id collision, the OpenRouter entry in `models:` is excluded for a
 `provider="nvidia"` call, and the lookup falls through to the source-neutral
 seed in `_DEFAULT_PRICING`. Keeping seeds in code also makes them immune to an
 OpenRouter sync overwriting the shared key. The `:free` promo variants
-(`nvidia/...:free`) carry no seed — they resolve to `$0.00` via the
-unknown-model fallback (issue #12).
+(`nvidia/...:free`) carry no seed — they resolve to `$0.00` via the **`:free`
+suffix rule** above (issues #12/#32). (Before that rule existed, a `:free` variant
+of any *seeded* model was mis-priced at the seed's paid rate via prefix match — the
+earlier "resolve to $0 via the unknown-model fallback" claim only held for models
+with no seeded paid base.)
 
 ### Pricing metadata tags (`_`-prefixed)
 
@@ -670,10 +686,17 @@ either:
 on the `cost > 0.0` branch. The concrete case: the `nvidia/nemotron-3-ultra:free`
 promo ends 2026-06-18 and bills as `nvidia/nemotron-3-ultra`; the paid price is
 seeded in `_DEFAULT_PRICING` so `cost > 0` once billing starts, and the reverse
-lookup connects the paid id back to the user's recorded `:free` row to fire the
-alert. See the README **PLEASE READ** notice for the required user-side config
-(`_subscription: true` on the `:free` entry — needed to suppress the
-estimated-price warning, which a default price cannot do).
+lookup connects the paid id back to the recorded `:free` row to fire the alert.
+
+**No user-side config is required** (changed by issue #32): while the promo is
+live, the `:free` id resolves to `$0` via the `:free` suffix rule and is recorded
+as known-free automatically — so the `:free` row exists for the reverse lookup to
+match, with no `_subscription` entry needed. This holds for whichever free form
+the gateway sends: the short `nvidia/nemotron-3-ultra:free` (matched on the paid
+side by **bare rename**) and the OpenRouter long form
+`nvidia/nemotron-3-ultra-550b-a55b:free` (matched by **bare rename** of its own
+suffix-dropped paid id `…-550b-a55b`). An explicit `_subscription` entry is still
+honored and overrides the rule, but is no longer necessary.
 
 ---
 
@@ -908,17 +931,21 @@ with `pytest --basetemp=DIR`.
   stored `<id>:free` row when a provider moves a model to paid under a *different*
   id (dropped `:free` suffix or suffixed paid id at a token boundary). Wired into
   `post_api_request` as `is_known_free_model(...) OR is_free_tier_transition(...)`.
+- **`:free` suffix → $0 rule** in `_lookup_form`: any `…:free` id resolves to an
+  explicit `$0` before the prefix scan (see *Lookup priority chain*). This both
+  (a) stops a seeded model's `:free` variant from being mis-billed at its paid rate
+  via prefix, and (b) records the `:free` id as known-free with no estimated-price
+  warning — so the transition alert seeds itself with **no user config**. This
+  *replaced* the earlier design's manual-`_subscription` requirement. It also
+  surfaced and fixed a latent bug: `nvidia/nemotron-3-super-120b-a12b:free` (a
+  pre-existing 0.4.1 seed) had been resolving to the paid `$0.09/$0.45` rate.
 - **`nvidia/nemotron-3-ultra` paid seed** in `_DEFAULT_PRICING` (OpenRouter rate,
   NIM-direct pending). Catches the bare id (exact) and the `…-550b-a55b` form
   (prefix), making `cost > 0` after the 2026-06-18 promo end — which fires the
-  alert. **Known trade-off**: the paid prefix also matches `…-ultra:free`, so a
-  user *without* the manual `_subscription` $0 entry sees the free tier priced at
-  the paid rate before 2026-06-18. Mitigated by the README **PLEASE READ** notice;
-  the manual entry both fixes the collision (exact match wins) and suppresses the
-  estimated-price warning (which a default price cannot do).
-- **262 tests** (was 253): `test_db.py` gained 7 `is_free_tier_transition` cases;
-  `test_pricing.py` gained the ultra paid-seed + `:free` collision/`_subscription`
-  cases.
+  alert. The free `…:free` forms are unaffected (handled by the suffix rule above).
+- **263 tests** (was 253): `test_db.py` gained 7 `is_free_tier_transition` cases;
+  `test_pricing.py` gained the ultra paid-seed + `:free`-suffix → $0 (bare and
+  OpenRouter-long-form), `super:free` regression, and explicit-override cases.
 
 ---
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -80,7 +80,7 @@ hermes-telemetry/
 │   └── serve.py         ← stdlib HTTP server, port 8765, --host flag.
 ├── tests/
 │   ├── conftest.py      ← Autouse HERMES_HOME isolation (see Test Isolation).
-│   └── test_*.py        ← 253 tests. All in-memory SQLite, no live gateway.
+│   └── test_*.py        ← 262 tests. All in-memory SQLite, no live gateway.
 ├── config.example.yaml  ← Annotated pricing.yaml example.
 └── budget.example.yaml  ← Annotated budget.yaml example.
 ```
@@ -647,6 +647,34 @@ that fell through to the `$0.00` unknown-model fallback. Without this guard, any
 unrecognized model would be recorded as "free" and trigger spurious alerts when
 the pricing table is later populated.
 
+### Id-change transitions (`is_free_tier_transition`, issue #32)
+
+A `known_free_models` row is keyed on the model id seen at $0. But some providers
+move a model from free to paid by **changing the id** — dropping a `:free` suffix
+(or renaming the promo to its paid base) — so the first paid call arrives under a
+different id than the recorded `:free` row, and a plain `is_known_free_model`
+lookup misses.
+
+`is_free_tier_transition(model, provider)` in `db.py` bridges that gap. For an
+incoming paid `model` it returns `True` if a stored `<id>:free` row matches via
+either:
+
+1. **Bare rename** — `model + ":free"` is a known-free row
+   (`nvidia/nemotron-3-ultra` ← `nvidia/nemotron-3-ultra:free`).
+2. **Suffixed paid id** — a stored `<base>:free` whose `<base>` is a prefix of
+   `model` at a token boundary (`-`, `:`, `/`, `_`), so
+   `nvidia/nemotron-3-ultra-550b-a55b` ← `nvidia/nemotron-3-ultra:free` but an
+   unrelated `…-ultrablend` does not false-positive.
+
+`post_api_request` checks `is_known_free_model(...) OR is_free_tier_transition(...)`
+on the `cost > 0.0` branch. The concrete case: the `nvidia/nemotron-3-ultra:free`
+promo ends 2026-06-18 and bills as `nvidia/nemotron-3-ultra`; the paid price is
+seeded in `_DEFAULT_PRICING` so `cost > 0` once billing starts, and the reverse
+lookup connects the paid id back to the user's recorded `:free` row to fire the
+alert. See the README **PLEASE READ** notice for the required user-side config
+(`_subscription: true` on the `:free` entry — needed to suppress the
+estimated-price warning, which a default price cannot do).
+
 ---
 
 ## Pricing Auto-Refresh
@@ -873,6 +901,24 @@ with `pytest --basetemp=DIR`.
 - **253 tests** (was 233): `test_init.py` gained free→paid detection, queueing,
   injection, and backfill tests; `test_db.py` and `test_pricing.py` gained
   corresponding unit tests.
+
+### Unreleased — Free→paid id-change handling (issue #32)
+
+- **`is_free_tier_transition(model, provider)`** in `db.py`: reverse-looks-up a
+  stored `<id>:free` row when a provider moves a model to paid under a *different*
+  id (dropped `:free` suffix or suffixed paid id at a token boundary). Wired into
+  `post_api_request` as `is_known_free_model(...) OR is_free_tier_transition(...)`.
+- **`nvidia/nemotron-3-ultra` paid seed** in `_DEFAULT_PRICING` (OpenRouter rate,
+  NIM-direct pending). Catches the bare id (exact) and the `…-550b-a55b` form
+  (prefix), making `cost > 0` after the 2026-06-18 promo end — which fires the
+  alert. **Known trade-off**: the paid prefix also matches `…-ultra:free`, so a
+  user *without* the manual `_subscription` $0 entry sees the free tier priced at
+  the paid rate before 2026-06-18. Mitigated by the README **PLEASE READ** notice;
+  the manual entry both fixes the collision (exact match wins) and suppresses the
+  estimated-price warning (which a default price cannot do).
+- **262 tests** (was 253): `test_db.py` gained 7 `is_free_tier_transition` cases;
+  `test_pricing.py` gained the ultra paid-seed + `:free` collision/`_subscription`
+  cases.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A comprehensive telemetry plugin that captures real usage data, enforces budget 
 
 [![Hermes Agent](https://raw.githubusercontent.com/NousResearch/hermes-agent/HEAD/assets/banner.png)](https://raw.githubusercontent.com/NousResearch/hermes-agent/HEAD/assets/banner.png)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://camo.githubusercontent.com/08cef40a9105b6526ca22088bc514fbfdbc9aac1ddbf8d4e6c750e3a88a44dca/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4c6963656e73652d4d49542d626c75652e737667) [![Tests: 253 passing](https://img.shields.io/badge/Tests-253%20passing-green.svg)](https://img.shields.io/badge/Tests-253%20passing-green.svg) [![Provider Support](https://img.shields.io/badge/Providers-OpenRouter-orange.svg)](https://img.shields.io/badge/Providers-OpenRouter-orange.svg) [![Challenge Entry](https://img.shields.io/badge/Hermes%20Agent-Challenge%20Entry-purple.svg)](https://camo.githubusercontent.com/d0c993fdf35127e435629279025d4b1892e351f5e04ce1547329686aa4223366/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4865726d65732532304167656e742d4368616c6c656e6765253230456e7472792d707572706c652e737667)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://camo.githubusercontent.com/08cef40a9105b6526ca22088bc514fbfdbc9aac1ddbf8d4e6c750e3a88a44dca/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4c6963656e73652d4d49542d626c75652e737667) [![Tests: 262 passing](https://img.shields.io/badge/Tests-262%20passing-green.svg)](https://img.shields.io/badge/Tests-262%20passing-green.svg) [![Provider Support](https://img.shields.io/badge/Providers-OpenRouter-orange.svg)](https://img.shields.io/badge/Providers-OpenRouter-orange.svg) [![Challenge Entry](https://img.shields.io/badge/Hermes%20Agent-Challenge%20Entry-purple.svg)](https://camo.githubusercontent.com/d0c993fdf35127e435629279025d4b1892e351f5e04ce1547329686aa4223366/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4865726d65732532304167656e742d4368616c6c656e6765253230456e7472792d707572706c652e737667)
 
 -----
 
@@ -562,6 +562,26 @@ models:
     _subscription: true  # declared $0 — survives every OpenRouter refresh
 ```
 
+> ### ⚠️ PLEASE READ — if you use free Nemotron Ultra before June 18, 2026
+>
+> The `nvidia/nemotron-3-ultra:free` promo **ends June 18, 2026**, after which the
+> model bills as `nvidia/nemotron-3-ultra`. To get the free→paid alert *and* avoid
+> a spurious estimated-price warning, you **must** declare the free tier manually
+> in `pricing.yaml` — no exception:
+>
+> ```yaml
+> models:
+>   nvidia/nemotron-3-ultra:free:
+>     input: 0.0
+>     output: 0.0
+>     _subscription: true   # REQUIRED: silences the estimated-price warning
+> ```
+>
+> Then restart Hermes. This seeds the model as known-free so that, once the promo
+> ends, hermes-telemetry detects the jump to paid (even though the id changes) and
+> warns you in-context. The `_subscription: true` flag is what keeps `/budget` from
+> flagging it as an estimated-price model — a built-in default price cannot do this.
+
 ### `budget.yaml`
 
 Configure spend guardrails. No file → budgets disabled.
@@ -619,7 +639,7 @@ The plugin can automatically fetch model pricing from OpenRouter’s public API,
   - Previously auto-fetched models are updated when prices change
   - Models are tagged with `_auto: true` and `_source: openrouter` — the `_source` tag is load-bearing: it drives the provider-aware guard above
 
-> **NVIDIA NIM** (`build.nvidia.com`) is supported out of the box: the Nemotron lineup ships as built-in seed prices, so NIM-served calls cost correctly even though NIM has no auto-refresh source. The seeds are immune to OpenRouter syncs, and a NIM call never borrows OpenRouter's rate for a colliding model id. `nvidia/...:free` promo variants resolve to `$0.00`.
+> **NVIDIA NIM** (`build.nvidia.com`) is supported out of the box: the Nemotron lineup ships as built-in seed prices, so NIM-served calls cost correctly even though NIM has no auto-refresh source. The seeds are immune to OpenRouter syncs, and a NIM call never borrows OpenRouter's rate for a colliding model id. Most `nvidia/...:free` promo variants resolve to `$0.00`; the `nemotron-3-ultra:free` promo ends 2026-06-18 (see the **PLEASE READ** notice above).
 
 ### Estimated-Price Models
 
@@ -904,7 +924,7 @@ global    $0.1812 / $2.00    9%  [daily]
 |Pricing auto-refresh (OpenRouter API)|✅ 320 models fetched, manual overrides preserved   |
 |Estimated-price model handling       |✅ Negative prices → $0.00, budget degradation      |
 |Dashboard (HTML, auto-refresh 30s)   |✅ Charts, tables, budget bar, provider distribution|
-|253 tests pass                       |✅                                                  |
+|262 tests pass                       |✅                                                  |
 
 -----
 
@@ -931,19 +951,19 @@ pip install pytest pyyaml
 pytest tests/ -v
 ```
 
-**Test suite (253 tests):**
+**Test suite (262 tests):**
 
 |File                             |Tests|Coverage                                                                                                                       |
 |---------------------------------|-----|-------------------------------------------------------------------------------------------------------------------------------|
-|`test_pricing.py`                |57   |Cache/reasoning split, no double-counting of `prompt_tokens`, YAML overrides, prefix matching, provider-aware source guard, NIM seeds, subscription tag, unknown model handling, `is_explicitly_priced`, `get_known_free_models`|
+|`test_pricing.py`                |60   |Cache/reasoning split, no double-counting of `prompt_tokens`, YAML overrides, prefix matching, provider-aware source guard, NIM seeds (incl. `nemotron-3-ultra` paid + `:free` collision), subscription tag, unknown model handling, `is_explicitly_priced`, `get_known_free_models`|
 |`test_telemetry_cli.py`          |32   |CLI subcommands (stats/budget), all window variants, text + `--json` output, entry point smoke test                            |
-|`test_db.py`                     |38   |Schema v1→v5 migrations, CRUD, aggregations, concurrent WAL writes (10 threads × 5 writes), `known_free_models` CRUD, `backfill_known_free_models`|
+|`test_db.py`                     |45   |Schema v1→v5 migrations, CRUD, aggregations, concurrent WAL writes (10 threads × 5 writes), `known_free_models` CRUD, `backfill_known_free_models`, `is_free_tier_transition` (id-change detection)|
 |`test_setup.py`                  |21   |First-time setup wizard, pricing/budget file generation, interactive + non-interactive paths                                   |
 |`test_dashboard.py`              |21   |HTML dashboard rendering, auto-refresh, chart data endpoints, viewer-timezone budget windows                                   |
 |`test_budget.py`                 |20   |ok/soft/hard verdicts, estimated-to-soft degradation, anti-spam ledger, cron pause, per-scope routing, `/budget set` hot-reload|
 |`test_stats_providers.py`        |14   |Real vs estimated per provider, `/stats providers` output format, Nous warning dedup                                           |
 |`test_pricing_refresh.py`        |14   |Auto-refresh from OpenRouter API, change detection, manual override preservation, subscription-model metadata                  |
-|`test_init.py`                   |23   |Cron session ID regex, tool success/failure parsing, free→paid transition alert (detection, queueing, injection, backfill)     |
+|`test_init.py`                   |13   |Cron session ID regex, tool success/failure parsing, free→paid transition alert (detection, queueing, injection, backfill)     |
 |`test_subagent_reconciliation.py`|9    |Parent + child hook sequence, token reconciliation, no double-counting                                                         |
 |`test_stats_models.py`           |8    |Per-model breakdown, `/stats models` output format                                                                             |
 |`test_pricing_hot_reload.py`     |3    |In-process cache invalidation on pricing update                                                                                |

--- a/README.md
+++ b/README.md
@@ -48,6 +48,34 @@ LLM provider
 
 -----
 
+> ### ℹ️ Free Nemotron Ultra before June 18, 2026 — no action needed
+>
+> The `nvidia/nemotron-3-ultra:free` promo **ends June 18, 2026**, after which the
+> model bills as `nvidia/nemotron-3-ultra` (and the OpenRouter long form
+> `nvidia/nemotron-3-ultra-550b-a55b`). You no longer need to declare anything in
+> `pricing.yaml`: **any model id ending in `:free` resolves to `$0` automatically**
+> (the OpenRouter free-tier convention) and is recorded as known-free, with no
+> estimated-price warning. This covers every form the gateway might send —
+> `nvidia/nemotron-3-ultra:free` and `nvidia/nemotron-3-ultra-550b-a55b:free`
+> alike.
+>
+> When the promo ends and the `:free` suffix is dropped, the model starts
+> incurring cost and hermes-telemetry detects the free→paid jump — even though the
+> id changes — and warns you in-context. (Pricing details: [`pricing.yaml`](#pricingyaml).)
+>
+> You may still pin an explicit price for a `:free` id if you ever need to (an
+> explicit `pricing.yaml` entry overrides the automatic `$0`):
+>
+> ```yaml
+> models:
+>   nvidia/nemotron-3-ultra:free:
+>     input: 0.0
+>     output: 0.0
+>     _subscription: true
+> ```
+
+-----
+
 ## Table of Contents
 
 - [Screenshots](#screenshots)
@@ -561,32 +589,6 @@ models:
     output: 0.0
     _subscription: true  # declared $0 — survives every OpenRouter refresh
 ```
-
-> ### ℹ️ Free Nemotron Ultra before June 18, 2026 — no action needed
->
-> The `nvidia/nemotron-3-ultra:free` promo **ends June 18, 2026**, after which the
-> model bills as `nvidia/nemotron-3-ultra` (and the OpenRouter long form
-> `nvidia/nemotron-3-ultra-550b-a55b`). You no longer need to declare anything in
-> `pricing.yaml`: **any model id ending in `:free` resolves to `$0` automatically**
-> (the OpenRouter free-tier convention) and is recorded as known-free, with no
-> estimated-price warning. This covers every form the gateway might send —
-> `nvidia/nemotron-3-ultra:free` and `nvidia/nemotron-3-ultra-550b-a55b:free`
-> alike.
->
-> When the promo ends and the `:free` suffix is dropped, the model starts
-> incurring cost and hermes-telemetry detects the free→paid jump — even though the
-> id changes — and warns you in-context.
->
-> You may still pin an explicit price for a `:free` id if you ever need to (an
-> explicit `pricing.yaml` entry overrides the automatic `$0`):
->
-> ```yaml
-> models:
->   nvidia/nemotron-3-ultra:free:
->     input: 0.0
->     output: 0.0
->     _subscription: true
-> ```
 
 ### `budget.yaml`
 

--- a/README.md
+++ b/README.md
@@ -562,25 +562,31 @@ models:
     _subscription: true  # declared $0 — survives every OpenRouter refresh
 ```
 
-> ### ⚠️ PLEASE READ — if you use free Nemotron Ultra before June 18, 2026
+> ### ℹ️ Free Nemotron Ultra before June 18, 2026 — no action needed
 >
 > The `nvidia/nemotron-3-ultra:free` promo **ends June 18, 2026**, after which the
-> model bills as `nvidia/nemotron-3-ultra`. To get the free→paid alert *and* avoid
-> a spurious estimated-price warning, you **must** declare the free tier manually
-> in `pricing.yaml` — no exception:
+> model bills as `nvidia/nemotron-3-ultra` (and the OpenRouter long form
+> `nvidia/nemotron-3-ultra-550b-a55b`). You no longer need to declare anything in
+> `pricing.yaml`: **any model id ending in `:free` resolves to `$0` automatically**
+> (the OpenRouter free-tier convention) and is recorded as known-free, with no
+> estimated-price warning. This covers every form the gateway might send —
+> `nvidia/nemotron-3-ultra:free` and `nvidia/nemotron-3-ultra-550b-a55b:free`
+> alike.
+>
+> When the promo ends and the `:free` suffix is dropped, the model starts
+> incurring cost and hermes-telemetry detects the free→paid jump — even though the
+> id changes — and warns you in-context.
+>
+> You may still pin an explicit price for a `:free` id if you ever need to (an
+> explicit `pricing.yaml` entry overrides the automatic `$0`):
 >
 > ```yaml
 > models:
 >   nvidia/nemotron-3-ultra:free:
 >     input: 0.0
 >     output: 0.0
->     _subscription: true   # REQUIRED: silences the estimated-price warning
+>     _subscription: true
 > ```
->
-> Then restart Hermes. This seeds the model as known-free so that, once the promo
-> ends, hermes-telemetry detects the jump to paid (even though the id changes) and
-> warns you in-context. The `_subscription: true` flag is what keeps `/budget` from
-> flagging it as an estimated-price model — a built-in default price cannot do this.
 
 ### `budget.yaml`
 
@@ -639,7 +645,7 @@ The plugin can automatically fetch model pricing from OpenRouter’s public API,
   - Previously auto-fetched models are updated when prices change
   - Models are tagged with `_auto: true` and `_source: openrouter` — the `_source` tag is load-bearing: it drives the provider-aware guard above
 
-> **NVIDIA NIM** (`build.nvidia.com`) is supported out of the box: the Nemotron lineup ships as built-in seed prices, so NIM-served calls cost correctly even though NIM has no auto-refresh source. The seeds are immune to OpenRouter syncs, and a NIM call never borrows OpenRouter's rate for a colliding model id. Most `nvidia/...:free` promo variants resolve to `$0.00`; the `nemotron-3-ultra:free` promo ends 2026-06-18 (see the **PLEASE READ** notice above).
+> **NVIDIA NIM** (`build.nvidia.com`) is supported out of the box: the Nemotron lineup ships as built-in seed prices, so NIM-served calls cost correctly even though NIM has no auto-refresh source. The seeds are immune to OpenRouter syncs, and a NIM call never borrows OpenRouter's rate for a colliding model id. Any `…:free` id resolves to `$0.00` via the free-tier suffix rule (so a seeded model's `:free` variant is never mis-billed at its paid rate); the `nemotron-3-ultra:free` promo ends 2026-06-18 (see the notice above).
 
 ### Estimated-Price Models
 
@@ -951,11 +957,11 @@ pip install pytest pyyaml
 pytest tests/ -v
 ```
 
-**Test suite (262 tests):**
+**Test suite (263 tests):**
 
 |File                             |Tests|Coverage                                                                                                                       |
 |---------------------------------|-----|-------------------------------------------------------------------------------------------------------------------------------|
-|`test_pricing.py`                |60   |Cache/reasoning split, no double-counting of `prompt_tokens`, YAML overrides, prefix matching, provider-aware source guard, NIM seeds (incl. `nemotron-3-ultra` paid + `:free` collision), subscription tag, unknown model handling, `is_explicitly_priced`, `get_known_free_models`|
+|`test_pricing.py`                |61   |Cache/reasoning split, no double-counting of `prompt_tokens`, YAML overrides, prefix matching, provider-aware source guard, NIM seeds (incl. `nemotron-3-ultra` paid + `:free` suffix → $0 rule), subscription tag, unknown model handling, `is_explicitly_priced`, `get_known_free_models`|
 |`test_telemetry_cli.py`          |32   |CLI subcommands (stats/budget), all window variants, text + `--json` output, entry point smoke test                            |
 |`test_db.py`                     |45   |Schema v1→v5 migrations, CRUD, aggregations, concurrent WAL writes (10 threads × 5 writes), `known_free_models` CRUD, `backfill_known_free_models`, `is_free_tier_transition` (id-change detection)|
 |`test_setup.py`                  |21   |First-time setup wizard, pricing/budget file generation, interactive + non-interactive paths                                   |

--- a/__init__.py
+++ b/__init__.py
@@ -285,13 +285,20 @@ def register(ctx) -> None:  # noqa: ANN001
             cost = pricing.estimate_cost(full_usage, effective_model, provider)
             latency_ms = int(api_duration * 1000)
 
-            # Free→paid transition detection (issue #16).
+            # Free→paid transition detection (issues #16/#32).
             # Only models with explicit pricing (not unknown-model fallback) are
             # tracked: an unknown model at $0 is not "free by design" and should
             # not trigger a false alert when it later gets a real price entry.
+            # is_free_tier_transition also catches the id-change case, where a
+            # provider drops a `:free` suffix (or renames the promo to its paid
+            # base) so the paid call arrives under a different model id than the
+            # `:free` row we recorded — e.g. nemotron-3-ultra:free → nemotron-3-ultra.
             if cost == 0.0 and pricing.is_explicitly_priced(effective_model, provider):
                 db.record_free_model(effective_model, provider)
-            elif cost > 0.0 and db.is_known_free_model(effective_model, provider):
+            elif cost > 0.0 and (
+                db.is_known_free_model(effective_model, provider)
+                or db.is_free_tier_transition(effective_model, provider)
+            ):
                 with _pending_free_paid_lock:
                     if session_id not in _pending_free_paid_alerts:
                         _pending_free_paid_alerts[session_id] = (effective_model, cost)

--- a/db.py
+++ b/db.py
@@ -791,6 +791,43 @@ def is_known_free_model(model: str, provider: str = "") -> bool:
     return row is not None
 
 
+def is_free_tier_transition(model: str, provider: str = "") -> bool:
+    """Return True if *model* looks like the paid successor of a known-free
+    ``:free`` variant — i.e. a provider dropped the ``:free`` suffix (or renamed
+    the promo id to its paid base) and started charging.
+
+    Two ways a stored ``X:free`` row matches an incoming paid ``model``:
+      1. Exact: ``model + ":free"`` is a known-free row — the bare-id rename,
+         e.g. ``nvidia/nemotron-3-ultra`` ← ``nvidia/nemotron-3-ultra:free``.
+      2. Prefix: a stored ``<base>:free`` whose ``<base>`` is a prefix of
+         ``model`` at a token boundary — the suffixed paid id, e.g.
+         ``nvidia/nemotron-3-ultra-550b-a55b`` ← ``nvidia/nemotron-3-ultra:free``.
+
+    Matches the same provider or the wildcard ``provider=''`` backfill sentinel.
+    """
+    conn = _get_conn()
+    # Check 1: incoming model is exactly a stored "<model>:free".
+    row = conn.execute(
+        "SELECT 1 FROM known_free_models WHERE model = ? AND (provider = ? OR provider = '')",
+        (model + ":free", provider),
+    ).fetchone()
+    if row is not None:
+        return True
+    # Check 2: a stored "<base>:free" whose <base> is a prefix of model. Require
+    # the char after <base> to be a separator so "…-3-ultra" matches the
+    # "…-3-ultra-550b" variant but never an unrelated "…-3-ultraX" model.
+    rows = conn.execute(
+        "SELECT model FROM known_free_models"
+        " WHERE (provider = ? OR provider = '') AND model LIKE '%:free'",
+        (provider,),
+    ).fetchall()
+    for (free_model,) in rows:
+        base = free_model[: -len(":free")]
+        if base and model.startswith(base) and model[len(base) : len(base) + 1] in "-:/_":
+            return True
+    return False
+
+
 def backfill_known_free_models(models: list) -> int:
     """Insert known-free models with provider='' (wildcard) for backward compat.
 

--- a/poc_free_tier_id_change.py
+++ b/poc_free_tier_id_change.py
@@ -1,0 +1,254 @@
+"""Manual test battery: :free suffix pricing + free->paid id-change alert (#32).
+
+Exercises the REAL plugin lifecycle (register() + the actual hook closures
+Hermes would call) against an isolated HERMES_HOME, the same pattern as
+poc_setup.py / poc_setup_cmd.py. Not a substitute for pytest — this is the
+end-to-end sanity check that the unit tests can't show: hooks wired together,
+in hook-firing order, exactly as Hermes would drive them.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).parent
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+tmp = tempfile.mkdtemp(prefix="hermes_poc_free32_")
+os.environ["HERMES_HOME"] = tmp
+os.environ["HERMES_TELEMETRY_NO_SETUP"] = "1"  # skip auto pricing/budget generation
+print(f"[PoC] HERMES_HOME = {tmp}\n")
+
+import importlib.util  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "hermes_telemetry", REPO / "__init__.py", submodule_search_locations=[str(REPO)]
+)
+plugin_mod = importlib.util.module_from_spec(_spec)
+sys.modules["hermes_telemetry"] = plugin_mod
+_spec.loader.exec_module(plugin_mod)
+
+from hermes_telemetry import db, pricing  # noqa: E402
+
+
+class FakeCtx:
+    """Minimal stand-in for Hermes' PluginContext: just records hooks."""
+
+    def __init__(self):
+        self.hooks: dict[str, list] = {}
+        self.commands: dict[str, object] = {}
+
+    def register_hook(self, name, fn):
+        self.hooks.setdefault(name, []).append(fn)
+
+    def register_command(self, name, fn, **_kw):
+        self.commands[name] = fn
+
+    # register_cli_command intentionally NOT defined: register() catches
+    # AttributeError/TypeError for Hermes versions without this API.
+
+
+def fire(ctx, hook_name, **kwargs):
+    results = []
+    for fn in ctx.hooks.get(hook_name, []):
+        results.append(fn(**kwargs))
+    return results
+
+
+ok = True
+
+
+def check(label, cond):
+    global ok
+    mark = "✅" if cond else "❌"
+    print(f"  {mark} {label}")
+    if not cond:
+        ok = False
+
+
+print("=" * 70)
+print("register() — wiring hooks against isolated HERMES_HOME")
+print("=" * 70)
+ctx = FakeCtx()
+plugin_mod.register(ctx)
+for h in ("on_session_start", "post_api_request", "pre_llm_call"):
+    check(f"hook registered: {h}", h in ctx.hooks)
+print()
+
+SESSION = "sess-free32-001"
+PROVIDER_OR = "openrouter"
+PROVIDER_NIM = "nvidia"
+
+print("=" * 70)
+print("Phase 1 — promo live: short :free id (NIM-style) costs $0")
+print("=" * 70)
+fire(
+    ctx,
+    "on_session_start",
+    session_id=SESSION,
+    model="nvidia/nemotron-3-ultra:free",
+    platform="cli",
+)
+fire(
+    ctx,
+    "post_api_request",
+    session_id=SESSION,
+    model="nvidia/nemotron-3-ultra:free",
+    provider=PROVIDER_NIM,
+    api_duration=1.2,
+    usage={"input_tokens": 1_000_000, "output_tokens": 500_000},
+    api_call_count=1,
+)
+run = db.get_run(SESSION)
+check("session cost after free call == 0.0", run["cost_usd"] == 0.0)
+check(
+    "nvidia/nemotron-3-ultra:free recorded as known-free",
+    db.is_known_free_model("nvidia/nemotron-3-ultra:free", PROVIDER_NIM),
+)
+alerts = fire(ctx, "pre_llm_call", session_id=SESSION)
+check("no free->paid alert injected while still free", all(a is None for a in alerts))
+print()
+
+print("=" * 70)
+print("Phase 2 — promo live: OpenRouter LONG :free id ALSO costs $0")
+print("(this is the exact case the user found on openrouter.ai)")
+print("=" * 70)
+SESSION2 = "sess-free32-002"
+LONG_FREE = "nvidia/nemotron-3-ultra-550b-a55b:free"
+fire(ctx, "on_session_start", session_id=SESSION2, model=LONG_FREE, platform="cli")
+fire(
+    ctx,
+    "post_api_request",
+    session_id=SESSION2,
+    model=LONG_FREE,
+    provider=PROVIDER_OR,
+    api_duration=0.8,
+    usage={"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    api_call_count=1,
+)
+run2 = db.get_run(SESSION2)
+check(f"{LONG_FREE} costs $0.00 (was $3.00 before the fix)", run2["cost_usd"] == 0.0)
+check("recorded as known-free", db.is_known_free_model(LONG_FREE, PROVIDER_OR))
+print()
+
+print("=" * 70)
+print("Phase 3 — promo ENDS: gateway drops :free, bills the bare id")
+print("=" * 70)
+fire(
+    ctx,
+    "post_api_request",
+    session_id=SESSION,
+    model="nvidia/nemotron-3-ultra",
+    provider=PROVIDER_NIM,
+    api_duration=1.0,
+    usage={"input_tokens": 1_000_000, "output_tokens": 500_000},
+    api_call_count=2,
+)
+run = db.get_run(SESSION)
+check("bare paid id now costs > $0", run["cost_usd"] > 0.0)
+alerts = fire(ctx, "pre_llm_call", session_id=SESSION)
+injected = [a for a in alerts if a]
+check("free->paid alert injected this turn", len(injected) == 1)
+if injected:
+    ctx_text = injected[0]["context"]
+    print(f"    context: {ctx_text.splitlines()[0][:90]}...")
+    check("alert mentions the model id", "nemotron-3-ultra" in ctx_text)
+alerts_again = fire(ctx, "pre_llm_call", session_id=SESSION)
+check("alert does NOT repeat next turn (one-shot)", all(a is None for a in alerts_again))
+print()
+
+print("=" * 70)
+print("Phase 4 — promo ENDS: gateway bills the OpenRouter LONG suffixed id")
+print("(id-change case: never seen as paid before, :free row had the long id)")
+print("=" * 70)
+fire(
+    ctx,
+    "post_api_request",
+    session_id=SESSION2,
+    model="nvidia/nemotron-3-ultra-550b-a55b",
+    provider=PROVIDER_OR,
+    api_duration=0.9,
+    usage={"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    api_call_count=2,
+)
+run2 = db.get_run(SESSION2)
+check("suffixed paid id now costs > $0", run2["cost_usd"] > 0.0)
+alerts2 = fire(ctx, "pre_llm_call", session_id=SESSION2)
+injected2 = [a for a in alerts2 if a]
+check("free->paid alert injected for the long-form id change", len(injected2) == 1)
+print()
+
+print("=" * 70)
+print("Phase 5 — regression check: pre-existing super:free seed")
+print("=" * 70)
+SESSION3 = "sess-free32-003"
+SUPER_FREE = "nvidia/nemotron-3-super-120b-a12b:free"
+fire(ctx, "on_session_start", session_id=SESSION3, model=SUPER_FREE, platform="cli")
+fire(
+    ctx,
+    "post_api_request",
+    session_id=SESSION3,
+    model=SUPER_FREE,
+    provider=PROVIDER_OR,
+    api_duration=0.5,
+    usage={"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    api_call_count=1,
+)
+run3 = db.get_run(SESSION3)
+check(f"{SUPER_FREE} costs $0.00 (was $0.60 before the fix)", run3["cost_usd"] == 0.0)
+print()
+
+print("=" * 70)
+print("Phase 6 — unrelated unknown model: still warns, never known-free")
+print("=" * 70)
+SESSION4 = "sess-free32-004"
+UNKNOWN = "totally-unrelated-unknown-model"
+fire(ctx, "on_session_start", session_id=SESSION4, model=UNKNOWN, platform="cli")
+fire(
+    ctx,
+    "post_api_request",
+    session_id=SESSION4,
+    model=UNKNOWN,
+    provider="",
+    api_duration=0.3,
+    usage={"input_tokens": 1000, "output_tokens": 1000},
+    api_call_count=1,
+)
+check("unknown model is NOT known-free", not db.is_known_free_model(UNKNOWN, ""))
+print()
+
+print("=" * 70)
+print("Phase 7 — explicit pricing.yaml entry still overrides the :free rule")
+print("=" * 70)
+pricing_file = Path(tmp) / "telemetry" / "pricing.yaml"
+pricing_file.parent.mkdir(parents=True, exist_ok=True)
+pricing_file.write_text(
+    'models:\n  "some-vendor/special:free":\n    input: 9.99\n    output: 0.0\n'
+)
+pricing.reload_custom_pricing()
+cost = pricing.estimate_cost({"input_tokens": 1_000_000}, "some-vendor/special:free")
+check("explicit :free entry overrides the built-in $0 rule", abs(cost - 9.99) < 1e-9)
+print()
+
+print("=" * 70)
+print("Phase 8 — /stats reflects everything end-to-end")
+print("=" * 70)
+from hermes_telemetry import stats  # noqa: E402
+
+out = stats.handle("")
+print(out)
+check("/stats runs without error", isinstance(out, str) and len(out) > 0)
+print()
+
+shutil.rmtree(tmp, ignore_errors=True)
+print(f"[PoC] Cleaned up {tmp}\n")
+
+print("=" * 70)
+if ok:
+    print("ALL CHECKS PASSED ✅ — issue #32 :free suffix fix verified end-to-end")
+else:
+    print("SOME CHECKS FAILED ❌ — see ❌ markers above")
+    sys.exit(1)

--- a/pricing.py
+++ b/pricing.py
@@ -68,14 +68,21 @@ _DEFAULT_PRICING: dict[str, dict] = {
     # nemotron normalize to it). Seeds live here, source-neutral and in code, so
     # they (1) survive an OpenRouter sync untouched and (2) are selected when the
     # provider-aware guard excludes a same-id OpenRouter entry for a NIM call.
-    # Prices per build.nvidia.com, verified 2026-06. The `:free` promo variants
-    # (e.g. nemotron-3-ultra:free) resolve to $0 via the unknown-model fallback
+    # Prices per build.nvidia.com, verified 2026-06. Most `:free` promo variants
+    # (e.g. nemotron-3-super:free) resolve to $0 via the unknown-model fallback
     # and need no entry — see issue #12.
     "nvidia/nemotron-3-super-120b-a12b": dict(input=0.10, output=0.50),
     "nvidia/nemotron-super-49b": dict(input=0.10, output=0.40),
     "nvidia/nemotron-70b-instruct": dict(input=1.20, output=1.20),
     "nvidia/nemotron-nano-12b-vl": dict(input=0.20, output=0.60),
     "nvidia/nemotron-nano-9b": dict(input=0.04, output=0.16),
+    # nemotron-3-ultra: the `:free` promo ends 2026-06-18, after which the
+    # gateway drops the `:free` suffix and bills `nvidia/nemotron-3-ultra` (and
+    # the suffixed `…-550b-a55b` form, caught by prefix match). Seeding the paid
+    # price here makes cost>0 once the promo ends, which is what fires the
+    # free→paid transition alert (issues #16/#32). Price is the OpenRouter rate
+    # pending confirmation of the NIM-direct figure.
+    "nvidia/nemotron-3-ultra": dict(input=0.50, output=2.50),
     # ── Meta (via OpenRouter / providers) ───────────────────────────────────
     "meta-llama/llama-3.1-405b-instruct": dict(input=2.70, output=2.70),
     "meta-llama/llama-3.1-70b-instruct": dict(input=0.52, output=0.75),

--- a/pricing.py
+++ b/pricing.py
@@ -68,9 +68,9 @@ _DEFAULT_PRICING: dict[str, dict] = {
     # nemotron normalize to it). Seeds live here, source-neutral and in code, so
     # they (1) survive an OpenRouter sync untouched and (2) are selected when the
     # provider-aware guard excludes a same-id OpenRouter entry for a NIM call.
-    # Prices per build.nvidia.com, verified 2026-06. Most `:free` promo variants
-    # (e.g. nemotron-3-super:free) resolve to $0 via the unknown-model fallback
-    # and need no entry — see issue #12.
+    # Prices per build.nvidia.com, verified 2026-06. `:free` promo variants
+    # (e.g. nemotron-3-super-120b-a12b:free) resolve to $0 via the ":free"
+    # suffix rule in `_lookup_form` and need no entry — see issue #12.
     "nvidia/nemotron-3-super-120b-a12b": dict(input=0.10, output=0.50),
     "nvidia/nemotron-super-49b": dict(input=0.10, output=0.40),
     "nvidia/nemotron-70b-instruct": dict(input=1.20, output=1.20),
@@ -78,10 +78,11 @@ _DEFAULT_PRICING: dict[str, dict] = {
     "nvidia/nemotron-nano-9b": dict(input=0.04, output=0.16),
     # nemotron-3-ultra: the `:free` promo ends 2026-06-18, after which the
     # gateway drops the `:free` suffix and bills `nvidia/nemotron-3-ultra` (and
-    # the suffixed `…-550b-a55b` form, caught by prefix match). Seeding the paid
-    # price here makes cost>0 once the promo ends, which is what fires the
-    # free→paid transition alert (issues #16/#32). Price is the OpenRouter rate
-    # pending confirmation of the NIM-direct figure.
+    # the suffixed `…-550b-a55b` form, caught by prefix match). While the promo
+    # is live, the `…:free` ids resolve to $0 via the ":free" suffix rule (not
+    # this seed). Seeding the paid price here makes cost>0 once the promo ends,
+    # which is what fires the free→paid transition alert (issues #16/#32). Price
+    # is the OpenRouter rate pending confirmation of the NIM-direct figure.
     "nvidia/nemotron-3-ultra": dict(input=0.50, output=2.50),
     # ── Meta (via OpenRouter / providers) ───────────────────────────────────
     "meta-llama/llama-3.1-405b-instruct": dict(input=2.70, output=2.70),
@@ -275,6 +276,20 @@ def _lookup_form(model_lc: str, provider: str = "") -> dict | None:
         return custom_models[model_lc]
     if model_lc in _DEFAULT_PRICING:
         return _DEFAULT_PRICING[model_lc]
+    # Free-tier suffix: OpenRouter (and similar gateways) advertise free variants
+    # with a ":free" suffix, e.g. "nvidia/nemotron-3-ultra-550b-a55b:free". These
+    # are $0 by definition. Short-circuit to an explicit zero price BEFORE the
+    # prefix scan, for two reasons:
+    #   1. Otherwise the suffixed free id inherits its paid base price via prefix
+    #      (e.g. the "nvidia/nemotron-3-ultra" seed would price "…-550b-a55b:free"
+    #      at $0.50/$2.50 — billing a free call as paid).
+    #   2. Returning an explicit zero dict (not the unknown-model None) makes the
+    #      call resolve as known-free: no estimated-price warning, and recorded in
+    #      known_free_models so the free→paid alert fires when the gateway later
+    #      drops the ":free" suffix and starts charging (issues #16/#32).
+    # A user's explicit ":free" entry (matched above) still wins over this rule.
+    if model_lc.endswith(":free"):
+        return {"input": 0.0, "output": 0.0}
     # Prefix fallback: scan ALL known keys — custom (auto-refreshed + user) and
     # default exact keys, plus the curated family-prefix table — longest prefix
     # wins. This lets an auto-refreshed key like 'google/gemini-3-flash-preview'

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -702,3 +702,52 @@ def test_backfill_does_not_overwrite_specific_provider_row():
     ).fetchall()
     providers = {r[0] for r in rows}
     assert providers == {"nous", ""}
+
+
+# ---------------------------------------------------------------------------
+# is_free_tier_transition — id-change detection (issue #32)
+# ---------------------------------------------------------------------------
+
+
+def test_free_tier_transition_bare_id_rename():
+    """Paid call under the bare id matches the stored `<id>:free` row."""
+    db.record_free_model("nvidia/nemotron-3-ultra:free", "nvidia")
+    # `:free` suffix dropped — paid call arrives as the bare id
+    assert db.is_free_tier_transition("nvidia/nemotron-3-ultra", "nvidia")
+
+
+def test_free_tier_transition_suffixed_paid_id():
+    """Paid call under a `<base>-…` suffixed id matches the stored `<base>:free`."""
+    db.record_free_model("nvidia/nemotron-3-ultra:free", "nvidia")
+    assert db.is_free_tier_transition("nvidia/nemotron-3-ultra-550b-a55b", "nvidia")
+
+
+def test_free_tier_transition_matches_wildcard_provider():
+    """Backfilled provider='' rows match a transition under any provider."""
+    db.backfill_known_free_models(["nvidia/nemotron-3-ultra:free"])
+    assert db.is_free_tier_transition("nvidia/nemotron-3-ultra", "nvidia")
+    assert db.is_free_tier_transition("nvidia/nemotron-3-ultra-550b-a55b", "openrouter")
+
+
+def test_free_tier_transition_ignores_unrelated_model():
+    """An unrelated paid model does not false-positive off a `:free` row."""
+    db.record_free_model("nvidia/nemotron-3-ultra:free", "nvidia")
+    assert not db.is_free_tier_transition("nvidia/nemotron-super-49b", "nvidia")
+
+
+def test_free_tier_transition_requires_token_boundary():
+    """Prefix match only at a separator — `…-ultraX` must not match `…-ultra:free`."""
+    db.record_free_model("nvidia/nemotron-3-ultra:free", "nvidia")
+    # No separator after the base → not a transition
+    assert not db.is_free_tier_transition("nvidia/nemotron-3-ultrablend", "nvidia")
+
+
+def test_free_tier_transition_false_without_free_row():
+    """No `:free` row recorded → never a transition."""
+    assert not db.is_free_tier_transition("nvidia/nemotron-3-ultra", "nvidia")
+
+
+def test_free_tier_transition_provider_scoped():
+    """A specific-provider `:free` row does not match a different provider."""
+    db.record_free_model("nvidia/nemotron-3-ultra:free", "nvidia")
+    assert not db.is_free_tier_transition("nvidia/nemotron-3-ultra", "openrouter")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -150,9 +150,9 @@ def test_unknown_model_does_not_queue_free_to_paid_alert(tmp_path, monkeypatch):
     db.close_thread_conn()
     pricing.reload_custom_pricing()
 
-    # Genuinely unknown id (no exact entry, no prefix seed). Note:
-    # nvidia/nemotron-3-ultra:free is no longer unknown — it resolves via the
-    # paid nemotron-3-ultra prefix (issue #32).
+    # Genuinely unknown id (no exact entry, no prefix seed, no ":free" suffix).
+    # Note: any "…:free" id is NOT unknown — it resolves to $0 via the ":free"
+    # suffix rule and is recorded as known-free (issue #32).
     model = "nvidia/totally-unknown-model"
     provider = "nvidia"
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -148,8 +148,12 @@ def test_unknown_model_does_not_queue_free_to_paid_alert(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / "telemetry").mkdir()
     db.close_thread_conn()
+    pricing.reload_custom_pricing()
 
-    model = "nvidia/nemotron-3-ultra:free"
+    # Genuinely unknown id (no exact entry, no prefix seed). Note:
+    # nvidia/nemotron-3-ultra:free is no longer unknown — it resolves via the
+    # paid nemotron-3-ultra prefix (issue #32).
+    model = "nvidia/totally-unknown-model"
     provider = "nvidia"
 
     # Unknown model: is_explicitly_priced returns False → should NOT be recorded

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -793,34 +793,54 @@ def test_nim_openrouter_collision_excluded_for_nvidia(tmp_path, monkeypatch):
     assert abs(cost_or - (0.09 + 0.45)) < 1e-9
 
 
-def test_nim_ultra_free_without_config_hits_paid_prefix():
-    """After seeding the paid `nemotron-3-ultra`, a bare `:free` call with NO
-    manual pricing entry resolves to the PAID price via prefix match. This is the
-    documented collision the README's PLEASE-READ notice tells users to avoid by
-    declaring the free tier manually before 2026-06-18 (issue #32)."""
-    cost = pricing.estimate_cost(
+def test_nim_ultra_free_suffix_resolves_zero():
+    """A `:free` call resolves to $0 via the ":free" suffix rule, NOT the paid
+    `nemotron-3-ultra` prefix — no manual pricing entry needed. Covers both the
+    bare-id free form and the OpenRouter-style suffixed free form (issue #32)."""
+    bare_free = pricing.estimate_cost(
         {"input_tokens": 1_000_000}, "nvidia/nemotron-3-ultra:free", provider="nvidia"
     )
-    assert abs(cost - 0.50) < 1e-9
+    suffixed_free = pricing.estimate_cost(
+        {"input_tokens": 1_000_000},
+        "nvidia/nemotron-3-ultra-550b-a55b:free",
+        provider="openrouter",
+    )
+    assert bare_free == 0.0
+    assert suffixed_free == 0.0
+    # And both are explicitly priced → recorded as known-free → transition-capable.
+    assert pricing.is_explicitly_priced("nvidia/nemotron-3-ultra:free", "nvidia")
+    assert pricing.is_explicitly_priced("nvidia/nemotron-3-ultra-550b-a55b:free", "openrouter")
 
 
-def test_nim_ultra_free_with_subscription_resolves_zero(tmp_path, monkeypatch):
-    """With the manual `_subscription` $0 entry, the exact match wins over the
-    paid prefix and the free tier correctly costs $0 (issue #32)."""
+def test_nim_super_free_suffix_resolves_zero():
+    """Regression: a seeded model's `:free` variant must resolve to $0, not the
+    seeded paid price via prefix. Pre-fix, `…-super-120b-a12b:free` billed at the
+    paid $0.09/$0.45 rate via prefix match (issue #32)."""
+    cost = pricing.estimate_cost(
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        "nvidia/nemotron-3-super-120b-a12b:free",
+        provider="openrouter",
+    )
+    assert cost == 0.0
+
+
+def test_free_suffix_overridable_by_explicit_entry(tmp_path, monkeypatch):
+    """An explicit custom `:free` entry still wins over the built-in $0 rule, so
+    users can pin a different price for a `:free` id if a gateway ever charges
+    for one (issue #32)."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / "telemetry").mkdir()
+    # Pin a NONZERO price to the `:free` id: if the built-in $0 rule fired first
+    # this call would cost $0, so a nonzero result proves the explicit custom
+    # entry takes precedence over the suffix rule.
     (tmp_path / "telemetry" / "pricing.yaml").write_text(
-        "models:\n"
-        '  "nvidia/nemotron-3-ultra:free":\n'
-        "    input: 0.0\n"
-        "    output: 0.0\n"
-        "    _subscription: true\n"
+        'models:\n  "nvidia/nemotron-3-ultra:free":\n    input: 1.23\n    output: 0.0\n'
     )
     pricing.reload_custom_pricing()
     cost = pricing.estimate_cost(
         {"input_tokens": 1_000_000}, "nvidia/nemotron-3-ultra:free", provider="nvidia"
     )
-    assert cost == 0.0
+    assert abs(cost - 1.23) < 1e-9
     pricing.reload_custom_pricing()
 
 
@@ -864,9 +884,9 @@ def test_is_explicitly_priced_zero_price_model():
 
 def test_is_explicitly_priced_unknown_model():
     assert pricing.is_explicitly_priced("completely-unknown-xyz-model") is False
-    # A genuinely unknown nvidia id (no prefix seed) stays unpriced. Note:
-    # `nvidia/nemotron-3-ultra:free` is NO LONGER unknown — it now resolves via
-    # the paid `nemotron-3-ultra` prefix (issue #32), covered by the NIM tests.
+    # A genuinely unknown nvidia id (no prefix seed, no ":free") stays unpriced.
+    # Note: any `…:free` id IS explicitly priced ($0 via the suffix rule, issue
+    # #32) — that path is covered by the NIM free-suffix tests above.
     assert pricing.is_explicitly_priced("nvidia/totally-unknown-model") is False
 
 

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -793,12 +793,48 @@ def test_nim_openrouter_collision_excluded_for_nvidia(tmp_path, monkeypatch):
     assert abs(cost_or - (0.09 + 0.45)) < 1e-9
 
 
-def test_nim_free_variant_resolves_zero(caplog):
-    """A :free promo variant is unpriced → $0.00 (handled by zero-cost fallback)."""
+def test_nim_ultra_free_without_config_hits_paid_prefix():
+    """After seeding the paid `nemotron-3-ultra`, a bare `:free` call with NO
+    manual pricing entry resolves to the PAID price via prefix match. This is the
+    documented collision the README's PLEASE-READ notice tells users to avoid by
+    declaring the free tier manually before 2026-06-18 (issue #32)."""
+    cost = pricing.estimate_cost(
+        {"input_tokens": 1_000_000}, "nvidia/nemotron-3-ultra:free", provider="nvidia"
+    )
+    assert abs(cost - 0.50) < 1e-9
+
+
+def test_nim_ultra_free_with_subscription_resolves_zero(tmp_path, monkeypatch):
+    """With the manual `_subscription` $0 entry, the exact match wins over the
+    paid prefix and the free tier correctly costs $0 (issue #32)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "telemetry").mkdir()
+    (tmp_path / "telemetry" / "pricing.yaml").write_text(
+        "models:\n"
+        '  "nvidia/nemotron-3-ultra:free":\n'
+        "    input: 0.0\n"
+        "    output: 0.0\n"
+        "    _subscription: true\n"
+    )
+    pricing.reload_custom_pricing()
     cost = pricing.estimate_cost(
         {"input_tokens": 1_000_000}, "nvidia/nemotron-3-ultra:free", provider="nvidia"
     )
     assert cost == 0.0
+    pricing.reload_custom_pricing()
+
+
+def test_nim_ultra_paid_resolves_bare_and_suffixed():
+    """The paid seed answers both the bare id and the OpenRouter-style suffixed
+    id (via prefix), so cost>0 once the promo ends — what fires the alert."""
+    bare = pricing.estimate_cost(
+        {"input_tokens": 1_000_000}, "nvidia/nemotron-3-ultra", provider="nvidia"
+    )
+    suffixed = pricing.estimate_cost(
+        {"input_tokens": 1_000_000}, "nvidia/nemotron-3-ultra-550b-a55b", provider="nvidia"
+    )
+    assert abs(bare - 0.50) < 1e-9
+    assert abs(suffixed - 0.50) < 1e-9
 
 
 def test_nim_seed_survives_simulated_refresh():
@@ -828,7 +864,10 @@ def test_is_explicitly_priced_zero_price_model():
 
 def test_is_explicitly_priced_unknown_model():
     assert pricing.is_explicitly_priced("completely-unknown-xyz-model") is False
-    assert pricing.is_explicitly_priced("nvidia/nemotron-3-ultra:free") is False
+    # A genuinely unknown nvidia id (no prefix seed) stays unpriced. Note:
+    # `nvidia/nemotron-3-ultra:free` is NO LONGER unknown — it now resolves via
+    # the paid `nemotron-3-ultra` prefix (issue #32), covered by the NIM tests.
+    assert pricing.is_explicitly_priced("nvidia/totally-unknown-model") is False
 
 
 def test_is_explicitly_priced_subscription_model(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes two related issues with free-tier model pricing and transition detection:

1. **`:free` suffix pricing rule** — Any model id ending in `:free` (OpenRouter's free-tier convention) now resolves to an explicit `$0` in the pricing lookup chain, **before** the prefix scan. This prevents seeded models' `:free` variants from being mis-billed at their paid rate via prefix match (e.g., `nvidia/nemotron-3-ultra-550b-a55b:free` was incorrectly priced at the paid rate instead of `$0`).

2. **Free→paid id-change detection** — Adds `db.is_free_tier_transition(model, provider)` to detect when a provider drops a `:free` suffix or renames a promo to its paid base, so the paid call arrives under a different id than the recorded `:free` row. Matches both the bare-id rename (`nvidia/nemotron-3-ultra:free` → `nvidia/nemotron-3-ultra`) and suffixed paid ids at token boundaries (`nvidia/nemotron-3-ultra-550b-a55b` ← `nvidia/nemotron-3-ultra:free`).

Concrete case: the `nvidia/nemotron-3-ultra:free` promo ends 2026-06-18. While live, any `:free` form resolves to `$0` automatically and is recorded as known-free. When the promo ends and the gateway drops the `:free` suffix, the model starts incurring cost and the transition alert fires — even though the id changed.

## Type of change
- [x] fix — bug fix
- [x] feat — new feature

## Changes

### Core logic
- **`pricing.py`**: Added `:free` suffix rule in `_lookup_form()` (step 3 of lookup chain, before prefix scan). Returns explicit `{"input": 0.0, "output": 0.0}` for any `…:free` id. Added `nvidia/nemotron-3-ultra` paid seed to `_DEFAULT_PRICING` (OpenRouter rate) so cost becomes non-zero once the promo ends.
- **`db.py`**: Added `is_free_tier_transition(model, provider)` function with two-part matching: (1) exact match on `model + ":free"`, (2) prefix match on stored `<base>:free` at token boundaries (`-`, `:`, `/`, `_`).
- **`__init__.py`**: Wired `is_free_tier_transition()` into `post_api_request` alongside existing `is_known_free_model()` check for the `cost > 0.0` branch.

### Documentation
- **`ONBOARDING.md`**: Updated lookup priority chain (now 6 steps), added detailed explanation of `:free` suffix rule and id-change transitions, clarified that `:free` variants no longer need manual `_subscription` entries.
- **`CHANGELOG.md`**: Added comprehensive unreleased section documenting the fix, new features, and user-facing notes for Nemotron Ultra users.
- **`README.md`**: Added info box for free Nemotron Ultra users explaining the promo end date and automatic handling.

### Testing
- **`tests/test_pricing.py`**: 
  - Renamed `test_nim_free_variant_resolves_zero` to `test_nim_ultra_free_suffix_resolves_zero` with expanded coverage for both bare and suffixed free forms.
  - Added `test_nim_super_free_suffix_resolves_zero` (regression test for seeded model's `:free` variant).
  - Added `test_free_suffix_overridable_by_explicit_entry` (explicit custom entry overrides the rule).
  - Added `test_nim_ultra_paid_resolves_bare_and_suffixed` (paid seed answers both forms).
  - Updated `test_is_explicitly_priced_unknown_model` to clarify that `:free` ids ARE explicitly priced.
- **`tests/test_db.py`**: Added 6 new tests for

https://claude.ai/code/session_019CrA4wSfpisJ99kP7ZiF5n