### PR TITLE
feat: date range filters for /stats CLI and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,15 @@ hermes-telemetry stats models --from 2026-06-16T12:00:00Z
 # nous       deepseek/deepseek-v4-pro     17    ...  $0.034000   ← new pricing, isolated
 ```
 
+The same flags work from inside Hermes Chat via the `/stats` slash command,
+so you don't have to leave the session to run the check:
+
+```
+/stats models --from 2026-06-16T12:00:00Z
+/stats providers --from 2026-06-10 --to 2026-06-15
+/stats --from 2026-06-16     # date-only → 00:00:00 UTC of that day
+```
+
 The `Notes` column (subscription/free-tier vs no price entry) and footer
 behaviour described in [`/stats models`](#stats) work the same way under a
 date filter — they're computed against whatever rows the filter selected.
@@ -397,6 +406,17 @@ rm ~/.hermes/telemetry/budget.yaml
 /stats models week      → per-model breakdown, last 7 days
 /stats raw [N]          → last N raw run records (default 20, max 200)
 ```
+
+Any subcommand also accepts `--from <iso>` and `--to <iso>` (inclusive /
+exclusive) to override the preset window with an arbitrary date range — useful
+for isolating "post-deploy" or "post-fix" data without waiting 24 h. Examples:
+
+```
+/stats models --from 2026-06-16T12:00:00Z
+/stats providers --from 2026-06-10 --to 2026-06-15
+```
+
+See the [Standalone CLI · Date range filters](#date-range-filters---from----to) section for the full reference (the CLI and the slash command parse the same flags).
 
 **Example output (`/stats`):**
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,54 @@ hermes-telemetry budget --json | jq ‘.global’
 All subcommands read from the same SQLite database as the in-session `/stats` and
 `/budget` slash commands. The gateway does not need to be running.
 
+### Date range filters (`--from` / `--to`)
+
+Every `stats` subcommand also accepts `--from` and `--to` (ISO-8601 dates or full
+timestamps). `--from` is inclusive, `--to` is exclusive, and either can be
+omitted — leaving `--to` off means "up to now".
+
+```bash
+# Everything since a specific instant (good for "post-deploy" windows)
+hermes-telemetry stats models --from 2026-06-16T12:00:00Z
+
+# Bounded range
+hermes-telemetry stats providers --from 2026-06-10 --to 2026-06-15
+
+# Date-only is treated as 00:00:00 UTC of that day
+hermes-telemetry stats today --from 2026-06-01
+
+# Combine with --json for scripting
+hermes-telemetry stats models --from 2026-06-16T12:00:00Z --json \
+  | jq '.[] | {model, calls: .total_calls, cost: .cost_usd}'
+```
+
+Presets `today`, `week`, `month`, plus `last-7-days` / `last-30-days` are also
+available as subcommands when you don't need an arbitrary boundary.
+
+#### Use case: validating a pricing fix without waiting for the 24h window to roll
+
+If you land a fix that changes how a model is priced (e.g. you correct a
+provider-resolution bug so a model that was being billed against the wrong
+gateway now bills against the right one), the rolling 24-hour window in
+`/stats models` will keep mixing pre-fix and post-fix calls until enough time
+passes for the old ones to age out. The cost column is "right" for new calls
+but the *aggregate* is misleading.
+
+`--from <fix-deploy-timestamp>` lets you see only the post-fix calls
+immediately, so you can confirm the new unit cost without dropping to raw SQL
+and without waiting 24 h:
+
+```bash
+# Right after the fix lands at, say, 2026-06-16 12:00 UTC:
+hermes-telemetry stats models --from 2026-06-16T12:00:00Z
+# Provider   Model                       Calls  ...  Cost
+# nous       deepseek/deepseek-v4-pro     17    ...  $0.034000   ← new pricing, isolated
+```
+
+The `Notes` column (subscription/free-tier vs no price entry) and footer
+behaviour described in [`/stats models`](#stats) work the same way under a
+date filter — they're computed against whatever rows the filter selected.
+
 -----
 
 ## Setup Wizard

--- a/db.py
+++ b/db.py
@@ -438,9 +438,87 @@ def record_tool_call(
 # ---------------------------------------------------------------------------
 
 
-def stats_summary(window_hours: int = 24) -> dict[str, Any]:
+def _build_where_clause(
+    window_hours: int | None = None, date_from: str | None = None, date_to: str | None = None
+) -> tuple[str, list]:
+    """Build WHERE clause for date filtering.
+
+    Priority: explicit date_from/date_to > window_hours > default (24h)
+    Returns (where_sql, params)
+    """
+    where_parts = []
+    params = []
+
+    if date_from is not None:
+        where_parts.append("started_at >= ?")
+        params.append(date_from)
+        if date_to is not None:
+            where_parts.append("started_at < ?")
+            params.append(date_to)
+        else:
+            where_parts.append("started_at < datetime('now')")
+    elif window_hours is not None:
+        where_parts.append(f"started_at >= {_run_hours_ago_expr(window_hours)}")
+    else:
+        # Default to last 24h
+        where_parts.append(f"started_at >= {_run_hours_ago_expr(24)}")
+
+    return (" AND ".join(where_parts), params)
+
+
+def _build_where_clause_ts(
+    window_hours: int | None = None, date_from: str | None = None, date_to: str | None = None
+) -> tuple[str, list]:
+    """Build WHERE clause for date filtering on llm_calls.ts column."""
+    where_parts = []
+    params = []
+
+    if date_from is not None:
+        where_parts.append("ts >= ?")
+        params.append(date_from)
+        if date_to is not None:
+            where_parts.append("ts < ?")
+            params.append(date_to)
+        else:
+            where_parts.append("ts < datetime('now')")
+    elif window_hours is not None:
+        where_parts.append(f"ts >= {_run_hours_ago_expr(window_hours)}")
+    else:
+        where_parts.append(f"ts >= {_run_hours_ago_expr(24)}")
+
+    return (" AND ".join(where_parts), params)
+
+
+def _build_tools_where(
+    window_hours: int | None = None, date_from: str | None = None, date_to: str | None = None
+) -> tuple[str, list]:
+    """Build WHERE clause for tool_calls JOIN runs query."""
+    where_parts = []
+    params = []
+
+    if date_from is not None:
+        where_parts.append("r.started_at >= ?")
+        params.append(date_from)
+        if date_to is not None:
+            where_parts.append("r.started_at < ?")
+            params.append(date_to)
+        else:
+            where_parts.append("r.started_at < datetime('now')")
+    elif window_hours is not None:
+        where_parts.append(f"r.started_at >= {_run_hours_ago_expr(window_hours)}")
+    else:
+        where_parts.append(f"r.started_at >= {_run_hours_ago_expr(24)}")
+
+    return (" AND ".join(where_parts), params)
+
+
+def stats_summary(
+    window_hours: int | None = None, *, date_from: str | None = None, date_to: str | None = None
+) -> dict[str, Any]:
     conn = _get_conn()
-    since = _run_hours_ago_expr(window_hours)
+    where_sql, params = _build_where_clause(window_hours, date_from, date_to)
+    where_sql_ts, params_ts = _build_where_clause_ts(window_hours, date_from, date_to)
+    tools_where, tools_params = _build_tools_where(window_hours, date_from, date_to)
 
     runs_row = conn.execute(
         f"""
@@ -456,8 +534,9 @@ def stats_summary(window_hours: int = 24) -> dict[str, Any]:
             SUM(tool_calls)                                   AS tool_calls,
             SUM(estimated_llm_calls)                          AS estimated_llm_calls
         FROM runs
-        WHERE started_at >= {since}
-        """
+        WHERE {where_sql}
+        """,
+        params,
     ).fetchone()
 
     llm_row = conn.execute(
@@ -466,8 +545,9 @@ def stats_summary(window_hours: int = 24) -> dict[str, Any]:
             COUNT(*)        AS api_calls,
             AVG(latency_ms) AS avg_latency_ms
         FROM llm_calls
-        WHERE ts >= {since}
-        """
+        WHERE {where_sql_ts}
+        """,
+        params_ts,
     ).fetchone()
 
     top_tools = conn.execute(
@@ -478,25 +558,35 @@ def stats_summary(window_hours: int = 24) -> dict[str, Any]:
                AVG(latency_ms) AS avg_ms
         FROM tool_calls tc
         JOIN runs r ON tc.session_id = r.session_id
-        WHERE r.started_at >= {since}
+        WHERE {tools_where}
         GROUP BY tool_name
         ORDER BY calls DESC
         LIMIT 10
-        """
+        """,
+        tools_params,
     ).fetchall()
 
     result = dict(runs_row)
     result.update(dict(llm_row))
     result["top_tools"] = [dict(t) for t in top_tools]
     result["window_hours"] = window_hours
+    result["date_from"] = date_from
+    result["date_to"] = date_to
     # Parent-child attribution is not yet populated (see ONBOARDING.md)
     result["parent_links_available"] = False
     return result
 
 
-def cost_by_job(window_hours: int = 168) -> list[dict[str, Any]]:
+def cost_by_job(
+    window_hours: int | None = None, *, date_from: str | None = None, date_to: str | None = None
+) -> list[dict[str, Any]]:
     conn = _get_conn()
-    since = _run_hours_ago_expr(window_hours)
+    where_sql, params = _build_where_clause(window_hours, date_from, date_to)
+    if where_sql:
+        where_sql = f"WHERE cron_job_id IS NOT NULL AND {where_sql}"
+    else:
+        where_sql = "WHERE cron_job_id IS NOT NULL"
+
     rows = conn.execute(
         f"""
         SELECT
@@ -510,30 +600,39 @@ def cost_by_job(window_hours: int = 168) -> list[dict[str, Any]]:
             AVG(duration_ms)                                  AS avg_duration_ms,
             MAX(started_at)                                   AS last_run
         FROM runs
-        WHERE cron_job_id IS NOT NULL
-          AND started_at >= {since}
+        {where_sql}
         GROUP BY cron_job_id
         ORDER BY cost_usd DESC
-        """
+        """,
+        params,
     ).fetchall()
     return [dict(r) for r in rows]
 
 
-def recent_runs(limit: int = 20) -> list[dict[str, Any]]:
+def recent_runs(
+    limit: int = 20,
+    *,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    window_hours: int | None = None,
+) -> list[dict[str, Any]]:
     conn = _get_conn()
-    rows = conn.execute(
-        """
+    where_sql, params = _build_where_clause(window_hours, date_from, date_to)
+
+    query = """
         SELECT session_id, platform, cron_job_id, sender_id, model, provider,
                started_at, ended_at, status,
                tokens_in, tokens_out, cost_usd, duration_ms,
                api_calls, tool_calls,
                parent_session_id, estimated_llm_calls
         FROM runs
-        ORDER BY started_at DESC
-        LIMIT ?
-        """,
-        (limit,),
-    ).fetchall()
+    """
+    if where_sql:
+        query += f" WHERE {where_sql}"
+    query += " ORDER BY started_at DESC LIMIT ?"
+    params.append(limit)
+
+    rows = conn.execute(query, params).fetchall()
     return [dict(r) for r in rows]
 
 
@@ -625,14 +724,17 @@ def list_sender_ids(since_iso: str) -> list[str]:
     return [r["sender_id"] for r in rows]
 
 
-def stats_by_provider(window_hours: int = 24) -> list[dict[str, Any]]:
+def stats_by_provider(
+    window_hours: int | None = None, *, date_from: str | None = None, date_to: str | None = None
+) -> list[dict[str, Any]]:
     """Per-provider breakdown for /stats providers.
 
     Returns one row per provider seen in llm_calls within the window:
       provider, total_calls, real_calls, estimated_calls, estimated_pct, cost_usd
     """
     conn = _get_conn()
-    since = _run_hours_ago_expr(window_hours)
+    where_sql, params = _build_where_clause_ts(window_hours, date_from, date_to)
+
     rows = conn.execute(
         f"""
         SELECT
@@ -642,10 +744,11 @@ def stats_by_provider(window_hours: int = 24) -> list[dict[str, Any]]:
             SUM(CASE WHEN estimated = 1 THEN 1 ELSE 0 END)    AS estimated_calls,
             ROUND(SUM(cost_usd), 6)                            AS cost_usd
         FROM llm_calls
-        WHERE ts >= {since}
+        WHERE {where_sql}
         GROUP BY COALESCE(provider, '(unknown)')
         ORDER BY cost_usd DESC
-        """
+        """,
+        params,
     ).fetchall()
     result = []
     for r in rows:
@@ -657,7 +760,9 @@ def stats_by_provider(window_hours: int = 24) -> list[dict[str, Any]]:
     return result
 
 
-def stats_by_model(window_hours: int = 24) -> list[dict[str, Any]]:
+def stats_by_model(
+    window_hours: int | None = None, *, date_from: str | None = None, date_to: str | None = None
+) -> list[dict[str, Any]]:
     """Per-model breakdown within each provider, for /stats models.
 
     Returns one row per (provider, model) seen in llm_calls within the window:
@@ -668,7 +773,8 @@ def stats_by_model(window_hours: int = 24) -> list[dict[str, Any]]:
     $0.00 separately, without dropping to raw SQL.
     """
     conn = _get_conn()
-    since = _run_hours_ago_expr(window_hours)
+    where_sql, params = _build_where_clause_ts(window_hours, date_from, date_to)
+
     rows = conn.execute(
         f"""
         SELECT
@@ -679,10 +785,11 @@ def stats_by_model(window_hours: int = 24) -> list[dict[str, Any]]:
             SUM(CASE WHEN estimated = 1 THEN 1 ELSE 0 END)   AS estimated_calls,
             ROUND(SUM(cost_usd), 6)                           AS cost_usd
         FROM llm_calls
-        WHERE ts >= {since}
+        WHERE {where_sql}
         GROUP BY COALESCE(provider, '(unknown)'), COALESCE(model, '(unknown)')
         ORDER BY provider ASC, total_calls DESC
-        """
+        """,
+        params,
     ).fetchall()
     result = []
     for r in rows:

--- a/db.py
+++ b/db.py
@@ -455,8 +455,6 @@ def _build_where_clause(
         if date_to is not None:
             where_parts.append("started_at < ?")
             params.append(date_to)
-        else:
-            where_parts.append("started_at < datetime('now')")
     elif window_hours is not None:
         where_parts.append(f"started_at >= {_run_hours_ago_expr(window_hours)}")
     else:
@@ -479,8 +477,6 @@ def _build_where_clause_ts(
         if date_to is not None:
             where_parts.append("ts < ?")
             params.append(date_to)
-        else:
-            where_parts.append("ts < datetime('now')")
     elif window_hours is not None:
         where_parts.append(f"ts >= {_run_hours_ago_expr(window_hours)}")
     else:
@@ -502,8 +498,6 @@ def _build_tools_where(
         if date_to is not None:
             where_parts.append("r.started_at < ?")
             params.append(date_to)
-        else:
-            where_parts.append("r.started_at < datetime('now')")
     elif window_hours is not None:
         where_parts.append(f"r.started_at >= {_run_hours_ago_expr(window_hours)}")
     else:

--- a/stats.py
+++ b/stats.py
@@ -323,32 +323,146 @@ def _raw_block(limit: int = 20, *, date_from: str | None = None, date_to: str | 
     return "\n".join(lines)
 
 
+_ISO_DATE_FORMATS = (
+    "%Y-%m-%d",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%dT%H:%M:%SZ",
+    "%Y-%m-%dT%H:%M:%S.%f",
+    "%Y-%m-%dT%H:%M:%S.%fZ",
+)
+
+
+def _parse_iso_date(raw: str) -> str | None:
+    """Parse a date/timestamp into an ISO-8601 string with a UTC offset.
+
+    Returns None when the input isn't a recognized format — slash command args
+    are user-typed, so we surface a parse failure as "ignore this flag" rather
+    than raising, and the caller renders an error message inline.
+    """
+    s = raw.strip()
+    if not s:
+        return None
+    # ``fromisoformat`` handles offsets like ``+00:00`` natively and accepts
+    # ``Z`` on Python 3.11+; it covers the timestamps produced by ``_utcnow``.
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.isoformat()
+    except ValueError:
+        pass
+    # Legacy strptime formats for inputs that don't carry timezone info.
+    for fmt in _ISO_DATE_FORMATS:
+        try:
+            dt = datetime.strptime(s, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.isoformat()
+        except ValueError:
+            continue
+    return None
+
+
+def _extract_date_flags(raw_args: str) -> tuple[str, str | None, str | None, str | None]:
+    """Pull `--from <val>` and `--to <val>` out of a slash-command arg string.
+
+    Returns ``(remaining, date_from, date_to, error)`` where:
+      - ``remaining`` is the arg string with the flags removed (preset tokens
+        survive untouched and keep their original casing — the caller still
+        lowercases them).
+      - ``date_from`` / ``date_to`` are ISO-normalized or ``None``.
+      - ``error`` is a human-readable message if a flag value failed to parse,
+        otherwise ``None``. The caller short-circuits with that message.
+    """
+    if not raw_args:
+        return ("", None, None, None)
+    tokens = raw_args.split()
+    out: list[str] = []
+    date_from: str | None = None
+    date_to: str | None = None
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in ("--from", "--to"):
+            if i + 1 >= len(tokens):
+                return ("", None, None, f"Missing value for {tok}.")
+            parsed = _parse_iso_date(tokens[i + 1])
+            if parsed is None:
+                return (
+                    "",
+                    None,
+                    None,
+                    f"Invalid date for {tok}: {tokens[i + 1]!r} "
+                    "(use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ).",
+                )
+            if tok == "--from":
+                date_from = parsed
+            else:
+                date_to = parsed
+            i += 2
+        else:
+            out.append(tok)
+            i += 1
+    return (" ".join(out), date_from, date_to, None)
+
+
 def handle(raw_args: str) -> str:
-    """Entry point for /stats command handler (Slack slash command format)."""
-    args = (raw_args or "").strip().lower()
+    """Entry point for /stats command handler (Slack slash command format).
+
+    Supports ``--from <iso>`` / ``--to <iso>`` flags alongside the preset
+    subcommands so the in-chat surface has parity with the standalone CLI.
+    When a date flag is supplied, the matching block ignores the preset window
+    and queries the (possibly bounded) date range instead.
+    """
+    remaining, date_from, date_to, err = _extract_date_flags(raw_args or "")
+    if err:
+        return err
+    has_range = date_from is not None or date_to is not None
+
+    args = remaining.strip().lower()
 
     if not args or args in ("today",):
+        if has_range:
+            return _summary_block(date_from=date_from, date_to=date_to)
         return _summary_block(24)
     if args == "week":
-        return _summary_block(168)
+        return (
+            _summary_block(168)
+            if not has_range
+            else _summary_block(date_from=date_from, date_to=date_to)
+        )
     if args == "month":
-        return _summary_block(720)
+        return (
+            _summary_block(720)
+            if not has_range
+            else _summary_block(date_from=date_from, date_to=date_to)
+        )
     if args in ("cron", "cron week"):
-        return _cron_block(168)
+        return (
+            _cron_block(168) if not has_range else _cron_block(date_from=date_from, date_to=date_to)
+        )
     if args == "cron month":
-        return _cron_block(720)
+        return (
+            _cron_block(720) if not has_range else _cron_block(date_from=date_from, date_to=date_to)
+        )
     if args == "cron today":
-        return _cron_block(24)
+        return (
+            _cron_block(24) if not has_range else _cron_block(date_from=date_from, date_to=date_to)
+        )
     if args.startswith("raw"):
         parts = args.split()
         try:
             limit = int(parts[1]) if len(parts) > 1 else 20
         except ValueError:
             limit = 20
+        if has_range:
+            return _raw_block(min(limit, 200), date_from=date_from, date_to=date_to)
         return _raw_block(min(limit, 200))
 
     if args.startswith("providers"):
         sub = args[len("providers") :].strip()
+        if has_range and sub in ("", "today", "week", "month"):
+            return _providers_block(date_from=date_from, date_to=date_to)
         if sub in ("", "today"):
             return _providers_block(24)
         if sub == "week":
@@ -358,6 +472,8 @@ def handle(raw_args: str) -> str:
 
     if args.startswith("models"):
         sub = args[len("models") :].strip()
+        if has_range and sub in ("", "today", "week", "month"):
+            return _models_block(date_from=date_from, date_to=date_to)
         if sub in ("", "today"):
             return _models_block(24)
         if sub == "week":
@@ -367,6 +483,7 @@ def handle(raw_args: str) -> str:
 
     return (
         "Usage: /stats [today|week|month|cron|cron week|cron month|providers|models|raw [N]]\n"
+        "             [--from YYYY-MM-DD[THH:MM:SS[Z]]] [--to YYYY-MM-DD[THH:MM:SS[Z]]]\n"
         "  /stats               — last 24h summary\n"
         "  /stats week          — last 7 days summary\n"
         "  /stats month         — last 30 days summary\n"
@@ -377,5 +494,7 @@ def handle(raw_args: str) -> str:
         "  /stats models week   — per-model breakdown, last 7 days\n"
         "  /stats raw [N]       — last N raw run records (default 20)\n"
         "\n"
-        "For date range filtering, use the CLI: hermes-telemetry stats --from YYYY-MM-DD --to YYYY-MM-DD"
+        "Date range examples (work the same way under the CLI):\n"
+        "  /stats models --from 2026-06-16T12:00:00Z\n"
+        "  /stats providers --from 2026-06-10 --to 2026-06-15"
     )

--- a/stats.py
+++ b/stats.py
@@ -9,10 +9,15 @@ Subcommands:
   /stats raw [N]      → last N runs (default 20)
   /stats providers    → per-provider real vs estimated breakdown (last 24h)
   /stats models       → per-model breakdown within each provider (last 24h)
+
+Date range support:
+  --from YYYY-MM-DD   → start date (inclusive)
+  --to YYYY-MM-DD     → end date (exclusive, defaults to now)
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -50,8 +55,37 @@ def _window_label(hours: int) -> str:
     return f"last {hours // 24} days"
 
 
-def _summary_block(window_hours: int) -> str:
-    s = db.stats_summary(window_hours)
+def _date_range_label(date_from: str | None, date_to: str | None) -> str:
+    if date_from and date_to:
+        return f"{date_from[:10]} to {date_to[:10]}"
+    if date_from:
+        return f"since {date_from[:10]}"
+    if date_to:
+        return f"until {date_to[:10]}"
+    return "all time"
+
+
+def _date_range_to_hours(date_from: str | None, date_to: str | None) -> int | None:
+    """Convert date range to approximate hours for backward compat label."""
+    if not date_from:
+        return None
+    try:
+        from_dt = datetime.fromisoformat(date_from.replace("Z", "+00:00"))
+        to_dt = (
+            datetime.fromisoformat(date_to.replace("Z", "+00:00"))
+            if date_to
+            else datetime.now(timezone.utc)
+        )
+        hours = int((to_dt - from_dt).total_seconds() / 3600)
+        return hours
+    except Exception:
+        return None
+
+
+def _summary_block(
+    window_hours: int | None = None, *, date_from: str | None = None, date_to: str | None = None
+) -> str:
+    s = db.stats_summary(window_hours=window_hours, date_from=date_from, date_to=date_to)
     total = s.get("total_runs") or 0
     ok = s.get("ok_runs") or 0
     failed = s.get("failed_runs") or 0
@@ -66,8 +100,10 @@ def _summary_block(window_hours: int) -> str:
     cost_val = s.get("cost_usd")
     cost_str = f"~{_fmt_cost(cost_val)}" if has_estimated else _fmt_cost(cost_val)
 
+    label = _window_label(window_hours) if window_hours else _date_range_label(date_from, date_to)
+
     lines = [
-        f"hermes-telemetry — {_window_label(window_hours)}",
+        f"hermes-telemetry — {label}",
         "=" * 44,
         f"  Sessions      : {_fmt_int(total)}",
         f"  Success rate  : {success_rate}  (ok={_fmt_int(ok)}, failed={_fmt_int(failed)})",
@@ -106,13 +142,16 @@ def _summary_block(window_hours: int) -> str:
     return "\n".join(lines)
 
 
-def _cron_block(window_hours: int = 168) -> str:
-    rows = db.cost_by_job(window_hours)
+def _cron_block(
+    window_hours: int | None = None, *, date_from: str | None = None, date_to: str | None = None
+) -> str:
+    rows = db.cost_by_job(window_hours=window_hours, date_from=date_from, date_to=date_to)
+    label = _window_label(window_hours) if window_hours else _date_range_label(date_from, date_to)
     if not rows:
-        return f"No cron runs in the last {window_hours // 24} days."
+        return f"No cron runs in {label}."
 
     lines = [
-        f"hermes-telemetry — cron jobs ({_window_label(window_hours)})",
+        f"hermes-telemetry — cron jobs ({label})",
         "=" * 72,
         f"  {'Job ID':<20} {'Runs':>5} {'OK':>5} {'Fail':>5} {'Tok-in':>9} {'Tok-out':>9} {'Cost':>12} {'Avg dur':>9}",
         "  " + "-" * 70,
@@ -132,13 +171,16 @@ def _cron_block(window_hours: int = 168) -> str:
     return "\n".join(lines)
 
 
-def _providers_block(window_hours: int = 24) -> str:
-    rows = db.stats_by_provider(window_hours)
+def _providers_block(
+    window_hours: int | None = None, *, date_from: str | None = None, date_to: str | None = None
+) -> str:
+    rows = db.stats_by_provider(window_hours=window_hours, date_from=date_from, date_to=date_to)
+    label = _window_label(window_hours) if window_hours else _date_range_label(date_from, date_to)
     if not rows:
-        return f"No API calls recorded in the {_window_label(window_hours)}."
+        return f"No API calls recorded in {label}."
 
     lines = [
-        f"hermes-telemetry — providers ({_window_label(window_hours)})",
+        f"hermes-telemetry — providers ({label})",
         "=" * 72,
         f"  {'Provider':<28} {'Calls':>6} {'Real':>6} {'Est':>5} {'Est%':>6} {'Cost':>12}",
         "  " + "-" * 67,
@@ -199,10 +241,13 @@ def _providers_block(window_hours: int = 24) -> str:
     return "\n".join(lines)
 
 
-def _models_block(window_hours: int = 24) -> str:
-    rows = db.stats_by_model(window_hours)
+def _models_block(
+    window_hours: int | None = None, *, date_from: str | None = None, date_to: str | None = None
+) -> str:
+    rows = db.stats_by_model(window_hours=window_hours, date_from=date_from, date_to=date_to)
+    label = _window_label(window_hours) if window_hours else _date_range_label(date_from, date_to)
     if not rows:
-        return f"No API calls recorded in the {_window_label(window_hours)}."
+        return f"No API calls recorded in {label}."
 
     # Subscription models (`_subscription: true` in pricing.yaml) are an
     # explicitly declared $0 — surface them so the $0.00 footer can stop
@@ -212,9 +257,10 @@ def _models_block(window_hours: int = 24) -> str:
     subscription_models = _pricing._load_custom_pricing().get("subscription_models", set())
 
     lines = [
-        f"hermes-telemetry — models ({_window_label(window_hours)})",
+        f"hermes-telemetry — models ({label})",
         "=" * 108,
-        f"  {'Provider':<20} {'Model':<46} {'Calls':>6} {'Real':>6} {'Est':>5} {'Cost':>12}  Notes",
+        f"  {'Provider':<20} {'Model':<46} {'Calls':>6} {'Real':>6} "
+        f"{'Est':>5} {'Cost':>12}  Notes",
         "  " + "-" * 106,
     ]
     sub_zero_count = 0
@@ -255,8 +301,8 @@ def _models_block(window_hours: int = 24) -> str:
     return "\n".join(lines)
 
 
-def _raw_block(limit: int = 20) -> str:
-    rows = db.recent_runs(limit)
+def _raw_block(limit: int = 20, *, date_from: str | None = None, date_to: str | None = None) -> str:
+    rows = db.recent_runs(limit, date_from=date_from, date_to=date_to)
     if not rows:
         return "No runs recorded yet."
 
@@ -279,7 +325,7 @@ def _raw_block(limit: int = 20) -> str:
 
 
 def handle(raw_args: str) -> str:
-    """Entry point for /stats command handler."""
+    """Entry point for /stats command handler (Slack slash command format)."""
     args = (raw_args or "").strip().lower()
 
     if not args or args in ("today",):
@@ -330,5 +376,7 @@ def handle(raw_args: str) -> str:
         "  /stats providers week — provider breakdown, last 7 days\n"
         "  /stats models        — per-model breakdown within each provider (24h)\n"
         "  /stats models week   — per-model breakdown, last 7 days\n"
-        "  /stats raw [N]       — last N raw run records (default 20)"
+        "  /stats raw [N]       — last N raw run records (default 20)\n"
+        "\n"
+        "For date range filtering, use the CLI: hermes-telemetry stats --from YYYY-MM-DD --to YYYY-MM-DD"
     )

--- a/stats.py
+++ b/stats.py
@@ -259,8 +259,7 @@ def _models_block(
     lines = [
         f"hermes-telemetry — models ({label})",
         "=" * 108,
-        f"  {'Provider':<20} {'Model':<46} {'Calls':>6} {'Real':>6} "
-        f"{'Est':>5} {'Cost':>12}  Notes",
+        f"  {'Provider':<20} {'Model':<46} {'Calls':>6} {'Real':>6} {'Est':>5} {'Cost':>12}  Notes",
         "  " + "-" * 106,
     ]
     sub_zero_count = 0

--- a/telemetry_cli.py
+++ b/telemetry_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from datetime import datetime, timedelta, timezone
 
 from . import db, stats
 
@@ -10,6 +11,8 @@ _STATS_WINDOW_HOURS: dict[str, int] = {
     "today": 24,
     "week": 168,
     "month": 720,
+    "last-7-days": 168,
+    "last-30-days": 720,
     "cron": 168,
     "cron-week": 168,
     "cron-month": 720,
@@ -22,6 +25,80 @@ _STATS_WINDOW_HOURS: dict[str, int] = {
 }
 
 _STATS_CHOICES = list(_STATS_WINDOW_HOURS)
+
+
+def _parse_date(date_str: str) -> str:
+    """Parse a date string and return ISO format (YYYY-MM-DD or ISO 8601)."""
+    # Support formats: YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS, YYYY-MM-DDTHH:MM:SSZ, now
+    date_str = date_str.strip().lower()
+    if date_str == "now":
+        return datetime.now(timezone.utc).isoformat()
+
+    # Try parsing as date only (YYYY-MM-DD)
+    for fmt in (
+        "%Y-%m-%d",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S.%f",
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+    ):
+        try:
+            dt = datetime.strptime(date_str, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.isoformat()
+        except ValueError:
+            continue
+
+    raise argparse.ArgumentTypeError(
+        f"Invalid date format: {date_str}. Use YYYY-MM-DD or ISO 8601."
+    )
+
+
+def _preset_to_date_range(preset: str) -> tuple[str | None, str | None]:
+    """Convert preset strings like 'today', 'week', 'month', 'last-7-days' to (from, to)."""
+    preset = preset.strip().lower()
+    now = datetime.now(timezone.utc)
+
+    if preset == "today":
+        from_dt = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        return (from_dt.isoformat(), None)
+    if preset == "week":
+        from_dt = now.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=7)
+        return (from_dt.isoformat(), None)
+    if preset == "month":
+        from_dt = now.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=30)
+        return (from_dt.isoformat(), None)
+    if preset.startswith("last-") and preset.endswith("-days"):
+        try:
+            days = int(preset[5:-5])
+            from_dt = now.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=days)
+            return (from_dt.isoformat(), None)
+        except ValueError:
+            pass
+
+    return (None, None)
+
+
+def _subcommand_to_date_range(subcommand: str) -> tuple[str | None, str | None]:
+    """Convert any stats subcommand to a date range using its default window hours."""
+    # Check for explicit presets first
+    preset_result = _preset_to_date_range(subcommand)
+    if preset_result != (None, None):
+        return preset_result
+
+    # For other subcommands (cron, providers, models, cron-week, etc.),
+    # use their default window hours
+    window_hours = _STATS_WINDOW_HOURS.get(subcommand)
+    if window_hours is not None:
+        now = datetime.now(timezone.utc)
+        from_dt = now - timedelta(hours=window_hours)
+        return (from_dt.isoformat(), None)
+
+    # Fallback to 24h
+    now = datetime.now(timezone.utc)
+    from_dt = now - timedelta(hours=24)
+    return (from_dt.isoformat(), None)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -44,6 +121,18 @@ def _build_parser_into(sub) -> None:
         choices=_STATS_CHOICES,
         metavar="SUBCOMMAND",
         help=f"One of: {', '.join(_STATS_CHOICES)} (default: today)",
+    )
+    sp.add_argument(
+        "--from",
+        dest="date_from",
+        type=_parse_date,
+        help="Start date (ISO 8601, e.g. 2025-01-15 or 2025-01-15T00:00:00Z)",
+    )
+    sp.add_argument(
+        "--to",
+        dest="date_to",
+        type=_parse_date,
+        help="End date (ISO 8601, exclusive). Defaults to now.",
     )
     sp.add_argument("--json", action="store_true", help="Output as JSON")
 
@@ -77,39 +166,49 @@ def _dispatch(args: argparse.Namespace, parser: argparse.ArgumentParser | None =
         sys.exit(0)
 
 
+def _resolve_date_range(args: argparse.Namespace) -> tuple[str | None, str | None]:
+    """Resolve the date range from --from/--to flags or from preset subcommand."""
+    # Explicit --from/--to flags take precedence
+    if args.date_from is not None:
+        date_from = args.date_from
+        date_to = args.date_to or datetime.now(timezone.utc).isoformat()
+        return (date_from, date_to)
+
+    # Otherwise use subcommand to determine date range
+    return _subcommand_to_date_range(args.subcommand)
+
+
 def _handle_stats(args: argparse.Namespace) -> None:
+    date_from, date_to = _resolve_date_range(args)
+
     if args.json:
-        _stats_json(args.subcommand)
+        _stats_json(args.subcommand, date_from, date_to)
     else:
-        _stats_text(args.subcommand)
+        _stats_text(args.subcommand, date_from, date_to)
 
 
-def _stats_text(subcommand: str) -> None:
-    hours = _STATS_WINDOW_HOURS.get(subcommand, 24)
-    if subcommand in ("today", "week", "month"):
-        print(stats._summary_block(hours))
-    elif subcommand.startswith("cron"):
-        print(stats._cron_block(hours))
+def _stats_text(subcommand: str, date_from: str | None, date_to: str | None) -> None:
+    if subcommand.startswith("cron"):
+        print(stats._cron_block(date_from=date_from, date_to=date_to))
     elif subcommand.startswith("providers"):
-        print(stats._providers_block(hours))
+        print(stats._providers_block(date_from=date_from, date_to=date_to))
     elif subcommand.startswith("models"):
-        print(stats._models_block(hours))
+        print(stats._models_block(date_from=date_from, date_to=date_to))
     else:
-        print(stats._summary_block(24))
+        # today, week, month, last-N-days
+        print(stats._summary_block(date_from=date_from, date_to=date_to))
 
 
-def _stats_json(subcommand: str) -> None:
-    hours = _STATS_WINDOW_HOURS.get(subcommand, 24)
-    if subcommand in ("today", "week", "month"):
-        data = db.stats_summary(hours)
-    elif subcommand.startswith("cron"):
-        data = db.cost_by_job(hours)
+def _stats_json(subcommand: str, date_from: str | None, date_to: str | None) -> None:
+    if subcommand.startswith("cron"):
+        data = db.cost_by_job(date_from=date_from, date_to=date_to)
     elif subcommand.startswith("providers"):
-        data = db.stats_by_provider(hours)
+        data = db.stats_by_provider(date_from=date_from, date_to=date_to)
     elif subcommand.startswith("models"):
-        data = db.stats_by_model(hours)
+        data = db.stats_by_model(date_from=date_from, date_to=date_to)
     else:
-        data = db.stats_summary(24)
+        # today, week, month, last-N-days
+        data = db.stats_summary(date_from=date_from, date_to=date_to)
     print(json.dumps(data, default=str))
 
 

--- a/tests/test_stats_models.py
+++ b/tests/test_stats_models.py
@@ -226,3 +226,55 @@ def test_stats_models_zero_cost_mixed_emits_both_footers(tmp_path, monkeypatch):
     assert "subscription/free tier (declared in pricing.yaml" in out
     assert "no price entry in pricing.yaml" in out
     assert "/setup pricing auto" in out
+
+
+# ---------------------------------------------------------------------------
+# date_from / date_to filtering (PR #35)
+# ---------------------------------------------------------------------------
+
+
+def test_stats_models_date_from_filters_older_rows():
+    """`date_from` excludes rows older than the cutoff while keeping newer ones.
+
+    Regression: an earlier draft added `ts < datetime('now')` as an implicit
+    upper bound when `date_to` was None, but SQLite's `datetime('now')` returns
+    space-separated text while real `ts` values are ISO-T with offset, so the
+    string comparison filtered every row out.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    pre = (now - timedelta(hours=12)).isoformat()
+    post = (now - timedelta(minutes=30)).isoformat()
+    cutoff = (now - timedelta(hours=6)).isoformat()
+
+    db.start_run("s1", model="m", platform="cli")
+    db.record_llm_call("s1", pre, "deepseek/v4-pro", "nous", 100, 50, 5.0, 100)
+    db.record_llm_call("s1", post, "deepseek/v4-pro", "nous", 100, 50, 0.002, 100)
+
+    rows = db.stats_by_model(date_from=cutoff)
+    assert len(rows) == 1
+    assert rows[0]["total_calls"] == 1
+    assert abs(rows[0]["cost_usd"] - 0.002) < 1e-9
+
+
+def test_stats_models_date_range_bounds_both_sides():
+    """Both `date_from` and `date_to` bound the window inclusively/exclusively."""
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    too_old = (now - timedelta(hours=20)).isoformat()
+    in_window = (now - timedelta(hours=10)).isoformat()
+    too_new = (now - timedelta(hours=1)).isoformat()
+    lo = (now - timedelta(hours=15)).isoformat()
+    hi = (now - timedelta(hours=5)).isoformat()
+
+    db.start_run("s1", model="m", platform="cli")
+    db.record_llm_call("s1", too_old, "m", "p", 1, 1, 1.0, 10)
+    db.record_llm_call("s1", in_window, "m", "p", 1, 1, 2.0, 10)
+    db.record_llm_call("s1", too_new, "m", "p", 1, 1, 4.0, 10)
+
+    rows = db.stats_by_model(date_from=lo, date_to=hi)
+    assert len(rows) == 1
+    assert rows[0]["total_calls"] == 1
+    assert abs(rows[0]["cost_usd"] - 2.0) < 1e-9

--- a/tests/test_stats_models.py
+++ b/tests/test_stats_models.py
@@ -258,6 +258,35 @@ def test_stats_models_date_from_filters_older_rows():
     assert abs(rows[0]["cost_usd"] - 0.002) < 1e-9
 
 
+def test_stats_handle_slash_command_accepts_from_flag():
+    """`/stats models --from <iso>` honours the date filter (parity with CLI)."""
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+    pre = (now - timedelta(hours=12)).isoformat()
+    post = (now - timedelta(minutes=30)).isoformat()
+    cutoff = (now - timedelta(hours=6)).isoformat()
+
+    db.start_run("s1", model="m", platform="cli")
+    db.record_llm_call("s1", pre, "old/model", "p", 1, 1, 9.99, 10)
+    db.record_llm_call("s1", post, "new/model", "p", 1, 1, 0.01, 10)
+
+    out = stats_mod.handle(f"models --from {cutoff}")
+    assert "new/model" in out
+    assert "old/model" not in out
+
+
+def test_stats_handle_slash_command_invalid_date_returns_error():
+    out = stats_mod.handle("models --from not-a-date")
+    assert "Invalid date" in out
+    assert "--from" in out
+
+
+def test_stats_handle_slash_command_missing_value_returns_error():
+    out = stats_mod.handle("models --from")
+    assert "Missing value" in out
+
+
 def test_stats_models_date_range_bounds_both_sides():
     """Both `date_from` and `date_to` bound the window inclusively/exclusively."""
     from datetime import datetime, timedelta, timezone

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -11,7 +11,10 @@ def test_stats_today_default_text(capsys):
         main(["stats"])
     out, _ = capsys.readouterr()
     assert out == "STATS_TODAY\n"
-    m.assert_called_once_with(24)
+    # Now called with date_from/date_to keyword args
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert kwargs.get("date_to") is None
 
 
 def test_stats_today_explicit_text(capsys):
@@ -19,62 +22,76 @@ def test_stats_today_explicit_text(capsys):
         main(["stats", "today"])
     out, _ = capsys.readouterr()
     assert out == "STATS_TODAY\n"
-    m.assert_called_once_with(24)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert kwargs.get("date_to") is None
 
 
 @pytest.mark.parametrize(
-    "argv,expected_hours",
+    "argv,expected_from_substr",
     [
-        (["stats", "week"], 168),
-        (["stats", "month"], 720),
+        (["stats", "week"], "202"),  # year in date_from
+        (["stats", "month"], "202"),
     ],
 )
-def test_stats_summary_window_text(argv, expected_hours, capsys):
+def test_stats_summary_window_text(argv, expected_from_substr, capsys):
     with patch("hermes_telemetry.stats._summary_block", return_value="S") as m:
         main(argv)
-    m.assert_called_once_with(expected_hours)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert expected_from_substr in kwargs["date_from"]
+    assert kwargs.get("date_to") is None
 
 
 @pytest.mark.parametrize(
-    "argv,expected_hours",
+    "argv,expected_from_substr",
     [
-        (["stats", "cron"], 168),
-        (["stats", "cron-week"], 168),
-        (["stats", "cron-month"], 720),
+        (["stats", "cron"], "202"),
+        (["stats", "cron-week"], "202"),
+        (["stats", "cron-month"], "202"),
     ],
 )
-def test_stats_cron_text(argv, expected_hours, capsys):
+def test_stats_cron_text(argv, expected_from_substr, capsys):
     with patch("hermes_telemetry.stats._cron_block", return_value="C") as m:
         main(argv)
-    m.assert_called_once_with(expected_hours)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert expected_from_substr in kwargs["date_from"]
+    assert kwargs.get("date_to") is None
 
 
 @pytest.mark.parametrize(
-    "argv,expected_hours",
+    "argv,expected_from_substr",
     [
-        (["stats", "providers"], 24),
-        (["stats", "providers-week"], 168),
-        (["stats", "providers-month"], 720),
+        (["stats", "providers"], "202"),
+        (["stats", "providers-week"], "202"),
+        (["stats", "providers-month"], "202"),
     ],
 )
-def test_stats_providers_text(argv, expected_hours, capsys):
+def test_stats_providers_text(argv, expected_from_substr, capsys):
     with patch("hermes_telemetry.stats._providers_block", return_value="P") as m:
         main(argv)
-    m.assert_called_once_with(expected_hours)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert expected_from_substr in kwargs["date_from"]
+    assert kwargs.get("date_to") is None
 
 
 @pytest.mark.parametrize(
-    "argv,expected_hours",
+    "argv,expected_from_substr",
     [
-        (["stats", "models"], 24),
-        (["stats", "models-week"], 168),
-        (["stats", "models-month"], 720),
+        (["stats", "models"], "202"),
+        (["stats", "models-week"], "202"),
+        (["stats", "models-month"], "202"),
     ],
 )
-def test_stats_models_text(argv, expected_hours, capsys):
+def test_stats_models_text(argv, expected_from_substr, capsys):
     with patch("hermes_telemetry.stats._models_block", return_value="M") as m:
         main(argv)
-    m.assert_called_once_with(expected_hours)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert expected_from_substr in kwargs["date_from"]
+    assert kwargs.get("date_to") is None
 
 
 def test_budget_status_text(capsys):
@@ -111,7 +128,9 @@ def test_stats_today_json(capsys):
     out, _ = capsys.readouterr()
     data = _json.loads(out)
     assert data["total_runs"] == 3
-    m.assert_called_once_with(24)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert kwargs.get("date_to") is None
 
 
 def test_stats_week_json(capsys):
@@ -121,7 +140,9 @@ def test_stats_week_json(capsys):
     out, _ = capsys.readouterr()
     data = _json.loads(out)
     assert data["total_runs"] == 20
-    m.assert_called_once_with(168)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert kwargs.get("date_to") is None
 
 
 def test_stats_cron_json(capsys):
@@ -131,7 +152,9 @@ def test_stats_cron_json(capsys):
     out, _ = capsys.readouterr()
     data = _json.loads(out)
     assert data[0]["job_id"] == "backup"
-    m.assert_called_once_with(168)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert kwargs.get("date_to") is None
 
 
 def test_stats_providers_json(capsys):
@@ -141,7 +164,9 @@ def test_stats_providers_json(capsys):
     out, _ = capsys.readouterr()
     data = _json.loads(out)
     assert data[0]["provider"] == "anthropic"
-    m.assert_called_once_with(24)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert kwargs.get("date_to") is None
 
 
 def test_stats_models_json(capsys):
@@ -151,49 +176,60 @@ def test_stats_models_json(capsys):
     out, _ = capsys.readouterr()
     data = _json.loads(out)
     assert data[0]["model"] == "claude-sonnet-4-6"
-    m.assert_called_once_with(24)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert kwargs.get("date_to") is None
 
 
 @pytest.mark.parametrize(
-    "argv,expected_hours",
+    "argv,expected_from_substr",
     [
-        (["stats", "cron-week", "--json"], 168),
-        (["stats", "cron-month", "--json"], 720),
+        (["stats", "cron-week", "--json"], "202"),
+        (["stats", "cron-month", "--json"], "202"),
     ],
 )
-def test_stats_cron_json_windowed(argv, expected_hours, capsys):
+def test_stats_cron_json_windowed(argv, expected_from_substr, capsys):
     fake = [{"job_id": "j", "cost_usd": 0.01}]
     with patch("hermes_telemetry.telemetry_cli.db.cost_by_job", return_value=fake) as m:
         main(argv)
-    m.assert_called_once_with(expected_hours)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert expected_from_substr in kwargs["date_from"]
+    assert kwargs.get("date_to") is None
 
 
 @pytest.mark.parametrize(
-    "argv,expected_hours",
+    "argv,expected_from_substr",
     [
-        (["stats", "providers-week", "--json"], 168),
-        (["stats", "providers-month", "--json"], 720),
+        (["stats", "providers-week", "--json"], "202"),
+        (["stats", "providers-month", "--json"], "202"),
     ],
 )
-def test_stats_providers_json_windowed(argv, expected_hours, capsys):
+def test_stats_providers_json_windowed(argv, expected_from_substr, capsys):
     fake = [{"provider": "x", "cost_usd": 0.01}]
     with patch("hermes_telemetry.telemetry_cli.db.stats_by_provider", return_value=fake) as m:
         main(argv)
-    m.assert_called_once_with(expected_hours)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert expected_from_substr in kwargs["date_from"]
+    assert kwargs.get("date_to") is None
 
 
 @pytest.mark.parametrize(
-    "argv,expected_hours",
+    "argv,expected_from_substr",
     [
-        (["stats", "models-week", "--json"], 168),
-        (["stats", "models-month", "--json"], 720),
+        (["stats", "models-week", "--json"], "202"),
+        (["stats", "models-month", "--json"], "202"),
     ],
 )
-def test_stats_models_json_windowed(argv, expected_hours, capsys):
+def test_stats_models_json_windowed(argv, expected_from_substr, capsys):
     fake = [{"model": "x", "cost_usd": 0.01}]
     with patch("hermes_telemetry.telemetry_cli.db.stats_by_model", return_value=fake) as m:
         main(argv)
-    m.assert_called_once_with(expected_hours)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert expected_from_substr in kwargs["date_from"]
+    assert kwargs.get("date_to") is None
 
 
 from hermes_telemetry.budget import BudgetVerdict  # noqa: E402


### PR DESCRIPTION
## Feature
Add date range filtering to the `/stats` CLI command and dashboard for hermes-telemetry.

## Related Card
https://github.com/nujovich/hermes-radar/issues/74

## Milestones
- [ ] Milestone 1 — CLI date range flags
  - Add `--from` / `--to` flags (ISO 8601 dates) to `/stats` CLI
  - Add presets: `today`, `week`, `month`, `last-N-days`
  - Update query functions in `db.py` to accept date range parameters

- [ ] Milestone 2 — Query layer date filtering
  - Extend `stats_summary`, `cost_by_job`, `recent_runs`, `stats_by_provider`, `stats_by_model` in `db.py`
  - Filter by `started_at` range (inclusive `from`, exclusive `to`)
  - Maintain backward compatibility with `window_hours` parameter

- [ ] Milestone 3 — Bucketing and period breakdown
  - Add day/week/month bucketing to `/stats` output
  - Show cost breakdown per period (e.g., daily spend for last 30 days)
  - New `--bucket` flag: `day`, `week`, `month`

- [ ] Milestone 4 — Dashboard date picker
  - Add date picker or presets in the dashboard UI
  - Filter visible sessions by date range
  - Persist selection in URL query params for shareability