### PR TITLE
Disambiguate $0.00 rows: subscription vs missing pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,18 +403,27 @@ hermes-telemetry — providers (last 24 h)
 
 ```
 hermes-telemetry — models (last 24 h)
-================================================================================================
-  Provider             Model                                           Calls   Real   Est         Cost
-  ----------------------------------------------------------------------------------------------
-  openrouter           owl-alpha                                          66     66     0    $0.000000
-  openrouter           anthropic/claude-sonnet-4-6                        42     42     0    $0.314378
-  openrouter           anthropic/claude-opus-4-7                           8      8     0    $2.225595
+============================================================================================================
+  Provider             Model                                           Calls   Real   Est         Cost  Notes
+  ----------------------------------------------------------------------------------------------------------
+  nous                 deepseek/deepseek-v4-pro-20260423                 449    448     1    $2.318788
+  nous                 nvidia/nemotron-3-ultra:free                      153    153     0    $0.000000  subscription/free-tier
+  openrouter           some/unpriced-model                                12     12     0    $0.000000  no price entry
 
-  Rows are grouped by provider, then by calls (desc). A model showing $0.00 has no price entry
-  in pricing.yaml — run /setup pricing auto to refresh, or add it manually.
+  Rows are grouped by provider, then by calls (desc).
+  1 model(s) at $0.00 are subscription/free tier (declared in pricing.yaml via `_subscription: true`).
+  1 model(s) at $0.00 have no price entry in pricing.yaml — run /setup pricing auto
+  to refresh, or add them manually.
 ```
 
-Breaks each provider's spend down to individual models. Rows are grouped by provider (ascending), then ordered by call count within each provider; the `Model` column is kept wide so dated model keys stay readable. Columns: `Calls` (total), `Real` (calls with provider-reported usage), `Est` (calls with locally estimated tokens), and `Cost`. A model showing `$0.000000` has no price entry in `pricing.yaml`.
+Breaks each provider's spend down to individual models. Rows are grouped by provider (ascending), then ordered by call count within each provider; the `Model` column is kept wide so dated model keys stay readable. Columns: `Calls` (total), `Real` (calls with provider-reported usage), `Est` (calls with locally estimated tokens), `Cost`, and `Notes`.
+
+The `Notes` column disambiguates `$0.000000` rows so the user can tell intentional zeros from missing pricing:
+
+- **`subscription/free-tier`** — the model is declared with `_subscription: true` in `pricing.yaml`. The $0 is intentional (subscription plan or free tier), not a bug. Pricing refresh preserves these entries verbatim.
+- **`no price entry`** — there is no row for this model in `pricing.yaml`. The $0 means Hermes had nothing to multiply by; run `/setup pricing auto` to refresh, or add a manual entry.
+
+The footer reflects the same split: subscription rows are claimed as declared, no-entry rows keep the original `/setup pricing auto` hint, and a mixed window emits both lines.
 
 ### `/budget`
 

--- a/stats.py
+++ b/stats.py
@@ -204,12 +204,21 @@ def _models_block(window_hours: int = 24) -> str:
     if not rows:
         return f"No API calls recorded in the {_window_label(window_hours)}."
 
+    # Subscription models (`_subscription: true` in pricing.yaml) are an
+    # explicitly declared $0 — surface them so the $0.00 footer can stop
+    # claiming every zero-cost row is a missing-pricing problem.
+    from . import pricing as _pricing
+
+    subscription_models = _pricing._load_custom_pricing().get("subscription_models", set())
+
     lines = [
         f"hermes-telemetry — models ({_window_label(window_hours)})",
-        "=" * 96,
-        f"  {'Provider':<20} {'Model':<46} {'Calls':>6} {'Real':>6} {'Est':>5} {'Cost':>12}",
-        "  " + "-" * 94,
+        "=" * 108,
+        f"  {'Provider':<20} {'Model':<46} {'Calls':>6} {'Real':>6} {'Est':>5} {'Cost':>12}  Notes",
+        "  " + "-" * 106,
     ]
+    sub_zero_count = 0
+    noentry_zero_count = 0
     for r in rows:
         prov = (r.get("provider") or "(unknown)")[:20]
         # Model names (esp. OpenRouter's dated keys) are kept wide so the date
@@ -218,15 +227,31 @@ def _models_block(window_hours: int = 24) -> str:
         total = _fmt_int(r.get("total_calls"))
         real = _fmt_int(r.get("real_calls"))
         est = _fmt_int(r.get("estimated_calls"))
-        cost = _fmt_cost(r.get("cost_usd"))
-        lines.append(f"  {prov:<20} {model:<46} {total:>6} {real:>6} {est:>5} {cost:>12}")
+        cost_v = float(r.get("cost_usd") or 0.0)
+        cost = _fmt_cost(cost_v)
+        note = ""
+        if cost_v == 0.0:
+            if (r.get("model") or "").lower() in subscription_models:
+                note = "subscription/free-tier"
+                sub_zero_count += 1
+            else:
+                note = "no price entry"
+                noentry_zero_count += 1
+        lines.append(f"  {prov:<20} {model:<46} {total:>6} {real:>6} {est:>5} {cost:>12}  {note}")
 
     lines.append("")
-    lines.append(
-        "  Rows are grouped by provider, then by calls (desc). A model showing "
-        "$0.00 has no price entry"
-    )
-    lines.append("  in pricing.yaml — run /setup pricing auto to refresh, or add it manually.")
+    lines.append("  Rows are grouped by provider, then by calls (desc).")
+    if sub_zero_count:
+        lines.append(
+            f"  {sub_zero_count} model(s) at $0.00 are subscription/free tier "
+            "(declared in pricing.yaml via `_subscription: true`)."
+        )
+    if noentry_zero_count:
+        lines.append(
+            f"  {noentry_zero_count} model(s) at $0.00 have no price entry in "
+            "pricing.yaml — run /setup pricing auto"
+        )
+        lines.append("  to refresh, or add them manually.")
     return "\n".join(lines)
 
 

--- a/tests/test_stats_models.py
+++ b/tests/test_stats_models.py
@@ -141,3 +141,88 @@ def test_stats_models_week_subcommand():
     out = stats_mod.handle("models week")
     assert "modelX" in out
     assert "last 7 days" in out
+
+
+# ---------------------------------------------------------------------------
+# $0.00 row classification: subscription vs no-price-entry
+# ---------------------------------------------------------------------------
+
+
+def _seed_pricing_yaml(tmp_path, body: str) -> None:
+    pricing_dir = tmp_path / "telemetry"
+    pricing_dir.mkdir(parents=True, exist_ok=True)
+    (pricing_dir / "pricing.yaml").write_text(body)
+
+
+def test_stats_models_zero_cost_subscription_row_labeled(tmp_path, monkeypatch):
+    """A $0.00 row whose model is flagged `_subscription: true` is tagged as
+    subscription/free-tier and the footer claims it as declared, NOT as missing
+    pricing."""
+    _seed_pricing_yaml(
+        tmp_path,
+        "models:\n"
+        "  nvidia/nemotron-3-ultra:free:\n"
+        "    input: 0.0\n"
+        "    output: 0.0\n"
+        "    _subscription: true\n",
+    )
+    # conftest already set HERMES_HOME=tmp_path; reload the pricing cache so it
+    # picks up the file we just wrote.
+    import hermes_telemetry.pricing as pricing
+
+    pricing.reload_custom_pricing()
+
+    now = db._utcnow()
+    db.start_run("s1", model="m", platform="cli")
+    db.record_llm_call("s1", now, "nvidia/nemotron-3-ultra:free", "nous", 100, 50, 0.0, 100)
+
+    out = stats_mod.handle("models")
+    assert "nvidia/nemotron-3-ultra:free" in out
+    assert "subscription/free-tier" in out
+    assert "subscription/free tier (declared in pricing.yaml" in out
+    # Should NOT claim missing pricing for this row.
+    assert "no price entry" not in out
+
+
+def test_stats_models_zero_cost_no_entry_row_labeled(tmp_path, monkeypatch):
+    """A $0.00 row NOT flagged as subscription is tagged 'no price entry' and
+    the footer keeps the original /setup pricing auto hint."""
+    import hermes_telemetry.pricing as pricing
+
+    pricing.reload_custom_pricing()  # ensure empty cache (no pricing.yaml)
+
+    now = db._utcnow()
+    db.start_run("s1", model="m", platform="cli")
+    db.record_llm_call("s1", now, "some/unpriced-model", "openrouter", 100, 50, 0.0, 100)
+
+    out = stats_mod.handle("models")
+    assert "some/unpriced-model" in out
+    assert "no price entry" in out
+    assert "/setup pricing auto" in out
+    assert "subscription/free-tier" not in out
+
+
+def test_stats_models_zero_cost_mixed_emits_both_footers(tmp_path, monkeypatch):
+    """When the window contains both kinds of $0.00 rows, both footer lines are
+    emitted so the user can tell them apart."""
+    _seed_pricing_yaml(
+        tmp_path,
+        "models:\n"
+        "  nvidia/nemotron-3-ultra:free:\n"
+        "    input: 0.0\n"
+        "    output: 0.0\n"
+        "    _subscription: true\n",
+    )
+    import hermes_telemetry.pricing as pricing
+
+    pricing.reload_custom_pricing()
+
+    now = db._utcnow()
+    db.start_run("s1", model="m", platform="cli")
+    db.record_llm_call("s1", now, "nvidia/nemotron-3-ultra:free", "nous", 10, 10, 0.0, 50)
+    db.record_llm_call("s1", now, "some/unpriced-model", "openrouter", 10, 10, 0.0, 50)
+
+    out = stats_mod.handle("models")
+    assert "subscription/free tier (declared in pricing.yaml" in out
+    assert "no price entry in pricing.yaml" in out
+    assert "/setup pricing auto" in out


### PR DESCRIPTION
## Summary

Distinguish between intentional $0.00 rows (subscription/free-tier models declared in `pricing.yaml` with `_subscription: true`) and unintentional ones (models with no pricing entry). This prevents the footer from incorrectly claiming all zero-cost rows are missing pricing.

Changes:
- Add a `Notes` column to the models table showing `subscription/free-tier` or `no price entry` for $0.00 rows
- Load subscription model set from pricing cache and check each zero-cost row against it
- Emit separate footer lines for each category so users can distinguish them
- Update README with examples and explanation of the new behavior

## Type of change
- [x] feat — new feature
- [x] test — adding/correcting tests
- [x] docs — documentation only

## Checklist
- [x] Tests pass locally (`pytest tests/ -v`)
- [x] Lint passes (`ruff check . && ruff format --check .`)
- [ ] CHANGELOG.md updated (user-facing changes) — *deferred to release PR*
- [ ] Version bumped in `__init__.py` + `pyproject.toml` + `plugin.yaml` — *deferred to release PR*

## Testing

Added three new test cases covering the scenarios:
1. `test_stats_models_zero_cost_subscription_row_labeled` — verifies $0.00 rows with `_subscription: true` are tagged as subscription/free-tier and footer claims them as declared
2. `test_stats_models_zero_cost_no_entry_row_labeled` — verifies $0.00 rows without a pricing entry are tagged as "no price entry" and footer keeps the `/setup pricing auto` hint
3. `test_stats_models_zero_cost_mixed_emits_both_footers` — verifies a mixed window emits both footer lines so users can tell them apart

All existing tests continue to pass.

## Screenshots / output

Before:
```
  openrouter           owl-alpha                                          66     66     0    $0.000000

  Rows are grouped by provider, then by calls (desc). A model showing $0.00 has no price entry
  in pricing.yaml — run /setup pricing auto to refresh, or add it manually.
```

After:
```
  nous                 nvidia/nemotron-3-ultra:free                      153    153     0    $0.000000  subscription/free-tier
  openrouter           some/unpriced-model                                12     12     0    $0.000000  no price entry

  Rows are grouped by provider, then by calls (desc).
  1 model(s) at $0.00 are subscription/free tier (declared in pricing.yaml via `_subscription: true`).
  1 model(s) at $0.00 have no price entry in pricing.yaml — run /setup pricing auto
  to refresh, or add them manually.
```

https://claude.ai/code/session_01UM51aQjMEBpJUEskFvK6Kh