### PR TITLE
fix(pricing): record assumed rate instead of $0 for cross-provider prices (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Provider-aware pricing guard no longer records `cost=0` on real paid calls**
+  (issue #42). When the only matching price for a call was an OpenRouter-sourced
+  entry served by a *different* provider (e.g. Nous Portal reselling
+  `moonshotai/kimi-k2.6` at the OpenRouter rate), the guard rejected it and the
+  call silently recorded zero spend — the worst failure mode for a cost tracker.
+  The lookup now applies the rate as a best-effort estimate, tags it
+  `_provider_assumed`, and logs a one-time WARNING per `(model, provider)` pair
+  advising the user to pin the rate. Source-neutral, `_subscription`, and
+  `_DEFAULT_PRICING` seed entries still take precedence, so the flat-sub and
+  NIM same-id collisions remain correctly priced. See
+  `ONBOARDING.md § Provider-aware lookup guard`.
+
+### Added
+
+- **Provider-assumed visibility** (issue #42 follow-up). Calls priced with an
+  assumed rate are now persisted and surfaced, not just logged:
+  - DB schema **v6** adds `llm_calls.provider_assumed` and a
+    `runs.provider_assumed_calls` counter (`db._migrate_v6`), mirroring the
+    existing `estimated` per-call flag.
+  - `pricing.is_provider_assumed(model, provider)` predicate (parallel to
+    `is_explicitly_priced`); `post_api_request` flags each affected row.
+  - `/stats providers` gains an `Asm%` column; the dashboard (standalone and
+    Hermes plugin) shows an `Asm?` column in Requests and an `Assumed` count in
+    Providers (`provider_assumed_calls` / `provider_assumed_pct` in the API).
+  - Assumed cost counts as **real spend** for budgets — it does not degrade hard
+    verdicts (unlike estimated usage), since the resold-at-same-rate case is
+    usually the correct number.
+
 ## [0.6.0] - 2026-06-16
 
 ### Added — Hermes dashboard plugin surface

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -455,6 +455,23 @@ this guard made it load-bearing.
 `nemotron` are normalized by Hermes `normalize_provider()` before the hook fires,
 verified against `hermes_cli/providers.py`).
 
+**Inverted safe-default for the lookup path (added v0.6.1, issue #42):** the
+guard's original failure mode was "fail to zero" — if the only candidate was a
+source-ineligible OpenRouter entry, the lookup returned `None` and the call
+recorded `cost=0`. For a cost-tracking plugin this is the *worst* failure: a
+real paid call (e.g. Nous Portal reselling `moonshotai/kimi-k2.6` at the
+OpenRouter rate) silently reads as zero spend. The lookup now **errs on the side
+of recording cost**: when no eligible candidate matches but a source-ineligible
+one would have, `_lookup_form` returns that price tagged `_provider_assumed:
+True`, and `estimate_cost` logs a **one-time WARNING per `(model, provider)`
+pair** advising the user to pin the rate. Eligible matches, `_DEFAULT_PRICING`
+seeds, the `:free` rule, and source-neutral / `_subscription` overrides all win
+*first* — the assumed fallback only fires when the sole available price is one
+the guard would otherwise reject. This means a genuine flat-sub / wrong-rate
+collision must be protected by a source-neutral `_subscription` (or hand-added)
+entry; without one, the call now over-counts-with-warning instead of
+under-counting-silently — the deliberately safer default for a cost tracker.
+
 **Why NIM seeds live in `_DEFAULT_PRICING` (code), not the YAML:** for the
 same-id collision, the OpenRouter entry in `models:` is excluded for a
 `provider="nvidia"` call, and the lookup falls through to the source-neutral
@@ -477,6 +494,25 @@ price dict** by `_load_custom_pricing` (captured into parallel structures
 | `_source` | Which source wrote the entry (`openrouter`, `google-ai`, ...) | Drives the provider-aware guard |
 | `_estimated_price` | OpenRouter model with no fixed price (negative→$0) | Counted by `estimated_price_share`; degrades hard budget verdicts to soft under `warn_only` |
 | `_subscription` | A **declared** $0 (flat-sub / free-tier) rate, hand-added | Distinguishes a genuine $0 from a lookup miss; tracked in `_meta.subscription_models`; **excluded** from `estimated_price_models` |
+
+A fourth key, `_provider_assumed`, is **not** a stored YAML tag — it is a
+runtime-only marker synthesized by `_lookup_form` (issue #42) when a
+source-ineligible entry is applied as a best-effort estimate. It rides on the
+resolved price dict purely so `estimate_cost` can fire its one-time
+provider-assumed warning; `_load_custom_pricing` never reads or writes it.
+
+The marker is also **surfaced** (not just logged): `post_api_request` calls
+`pricing.is_provider_assumed(model, provider)` and persists a per-call boolean
+to the DB — `llm_calls.provider_assumed` plus a `runs.provider_assumed_calls`
+counter (schema **v6**, `db._migrate_v6`). It mirrors the per-call `estimated`
+flag end to end: `/stats providers` shows an `Asm%` column, and the dashboard
+(both the standalone `serve.py` and the Hermes plugin) exposes it as an `Asm?`
+column in Requests and an `Assumed` count in Providers (`provider_assumed_calls`
+/ `provider_assumed_pct` in the API). **Deliberately unlike `_estimated_price`,
+a provider-assumed cost does NOT degrade budget verdicts** — the resold-at-the-
+same-rate case is usually the *correct* number, so it counts as real spend for
+enforcement (the issue's "err on the side of recording cost"); the flag exists
+only to make the assumption visible so the user can pin the rate.
 
 **Adding a subscription/flat-rate model:** enter it under the provider's
 **native (bare) id** with `input: 0.0`, `output: 0.0`, `_subscription: true`.

--- a/__init__.py
+++ b/__init__.py
@@ -285,6 +285,14 @@ def register(ctx) -> None:  # noqa: ANN001
             cost = pricing.estimate_cost(full_usage, effective_model, provider)
             latency_ms = int(api_duration * 1000)
 
+            # Provider-assumed pricing (issue #42): the cost is real spend, but it
+            # used a source-ineligible (OpenRouter) rate because no source-eligible
+            # price existed for this provider. Flag the row so /stats and the
+            # dashboard can surface it; estimate_cost already warned once. Only a
+            # nonzero cost is meaningfully "assumed" — a $0 row (e.g. usage=None
+            # with an empty stash) is not a pricing question, so don't flag it.
+            provider_assumed = cost > 0.0 and pricing.is_provider_assumed(effective_model, provider)
+
             # Free→paid transition detection (issues #16/#32).
             # Only models with explicit pricing (not unknown-model fallback) are
             # tracked: an unknown model at $0 is not "free by design" and should
@@ -323,6 +331,7 @@ def register(ctx) -> None:  # noqa: ANN001
                 cache_write_tokens=cache_write_tok,
                 reasoning_tokens=reasoning_tok,
                 estimated=estimated,
+                provider_assumed=provider_assumed,
             )
         except Exception as exc:
             tele_log.error("post_api_request hook failed: %s", exc)

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -132,6 +132,7 @@
         { key: "cost_usd",   label: "Cost",    render: (r) => fmtUsd(r.cost_usd) },
         { key: "latency_ms", label: "Latency", render: (r) => fmtMs(r.latency_ms) },
         { key: "estimated",  label: "Est?",    render: (r) => (r.estimated ? "yes" : "no") },
+        { key: "provider_assumed", label: "Asm?", render: (r) => (r.provider_assumed ? "yes" : "no") },
       ],
     });
   }
@@ -147,6 +148,7 @@
         { key: "provider",       label: "Provider" },
         { key: "total_calls",    label: "Calls",     render: (r) => fmtInt(r.total_calls) },
         { key: "estimated_calls", label: "Estimated", render: (r) => fmtInt(r.estimated_calls) },
+        { key: "provider_assumed_calls", label: "Assumed", render: (r) => fmtInt(r.provider_assumed_calls) },
         { key: "cost_usd",       label: "Cost",      render: (r) => fmtUsd(r.cost_usd) },
         { key: "tokens_in",      label: "Tok in",    render: (r) => fmtInt(r.tokens_in) },
         { key: "tokens_out",     label: "Tok out",   render: (r) => fmtInt(r.tokens_out) },

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1090,11 +1090,11 @@ function buildRunsQuery(windowPreset, limit = 30) {
 
 function renderProviderBreakdownTable(rows) {
   if (!rows || !rows.length) return renderTableCard('providerBreakdownTable', 'Provider Cost + Token Breakdown', '<div class="text-muted">No provider data for this range.</div>');
-  let t = '<table><thead><tr><th>Provider</th><th>Calls</th><th>Real</th><th>Est</th><th>In</th><th>Out</th><th>Cache Read</th><th>Reasoning</th><th>Total</th><th>Cost</th><th>Avg/Call</th></tr></thead><tbody>';
+  let t = '<table><thead><tr><th>Provider</th><th>Calls</th><th>Real</th><th>Est</th><th>Asm</th><th>In</th><th>Out</th><th>Cache Read</th><th>Reasoning</th><th>Total</th><th>Cost</th><th>Avg/Call</th></tr></thead><tbody>';
   for (const row of rows) {
     const provider = row.provider || '—';
     const jsProvider = jsAttr(provider);
-    t += `<tr class="clickable-row" onclick='addDrilldown({provider:${jsProvider}})'><td class="text-muted"><span class="inline-btn data-chip provider-chip" title="${escHtml(provider)}">${escHtml(provider)}</span></td><td>${nf(row.total_calls)}</td><td>${nf(row.real_calls)}</td><td>${nf(row.estimated_calls)}</td><td>${nf(row.tokens_in)}</td><td>${nf(row.tokens_out)}</td><td>${nf(row.cache_read_tokens)}</td><td>${nf(row.reasoning_tokens)}</td><td>${nf(row.total_tokens)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtCost(row.avg_cost_per_call)}</td></tr>`;
+    t += `<tr class="clickable-row" onclick='addDrilldown({provider:${jsProvider}})'><td class="text-muted"><span class="inline-btn data-chip provider-chip" title="${escHtml(provider)}">${escHtml(provider)}</span></td><td>${nf(row.total_calls)}</td><td>${nf(row.real_calls)}</td><td>${nf(row.estimated_calls)}</td><td>${nf(row.provider_assumed_calls)}</td><td>${nf(row.tokens_in)}</td><td>${nf(row.tokens_out)}</td><td>${nf(row.cache_read_tokens)}</td><td>${nf(row.reasoning_tokens)}</td><td>${nf(row.total_tokens)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtCost(row.avg_cost_per_call)}</td></tr>`;
   }
   t += '</tbody></table><div class="subtle-note">Click a provider row to inspect the exact sessions behind it.</div>';
   return renderTableCard('providerBreakdownTable', 'Provider Cost + Token Breakdown', t);
@@ -1187,16 +1187,16 @@ function renderCacheEfficiency(data) {
 function renderRequestForensics(data) {
   const rows = data?.rows || [];
   const hiddenDeleted = Number(data?.hidden_deleted_requests || 0);
-  let t = '<table><thead><tr><th>Time</th><th>Provider</th><th>Model</th><th>Platform</th><th>Status</th><th>In</th><th>Out</th><th>Cache</th><th>Cost</th><th>Latency</th><th>Est</th><th>Request ID</th></tr></thead><tbody>';
+  let t = '<table><thead><tr><th>Time</th><th>Provider</th><th>Model</th><th>Platform</th><th>Status</th><th>In</th><th>Out</th><th>Cache</th><th>Cost</th><th>Latency</th><th>Est</th><th>Asm</th><th>Request ID</th></tr></thead><tbody>';
   if (!rows.length) {
-    t += '<tr><td colspan="12" class="text-muted">No LLM requests match the current range and filters.</td></tr>';
+    t += '<tr><td colspan="13" class="text-muted">No LLM requests match the current range and filters.</td></tr>';
   } else {
     for (const row of rows) {
       const provider = row.provider || '—';
       const modelRaw = row.model || '—';
       const platform = row.platform || 'cli';
       const status = row.status || 'running';
-      t += `<tr class="clickable-row" onclick='openRequestDetail(${Number(row.id || 0)})'><td class="text-muted">${fmtLocalTs(row.ts, {seconds:true})}</td><td><span class="inline-btn data-chip provider-chip" title="${escHtml(provider)}" onclick='event.stopPropagation(); addDrilldown({provider:${jsAttr(provider)}})'>${escHtml(provider)}</span></td><td class="text-muted" title="${escHtml(modelRaw)}"><span class="inline-btn data-chip model-chip" onclick='event.stopPropagation(); addDrilldown({model:${jsAttr(modelRaw)}})'>${escHtml(modelRaw)}</span></td><td><span onclick='event.stopPropagation(); addDrilldown({platform:${jsAttr(platform)}})'>${platformBadge(platform)}</span></td><td><span onclick='event.stopPropagation(); addDrilldown({status:${jsAttr(status)}})'>${statusBadge(status)}</span></td><td>${nf(row.tokens_in || 0)}</td><td>${nf(row.tokens_out || 0)}</td><td>${nf(row.cache_read_tokens || 0)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.latency_ms)}</td><td>${row.estimated ? statusBadge('running') : statusBadge('ok')}</td><td><code>${nf(row.id || 0)}</code></td></tr>`;
+      t += `<tr class="clickable-row" onclick='openRequestDetail(${Number(row.id || 0)})'><td class="text-muted">${fmtLocalTs(row.ts, {seconds:true})}</td><td><span class="inline-btn data-chip provider-chip" title="${escHtml(provider)}" onclick='event.stopPropagation(); addDrilldown({provider:${jsAttr(provider)}})'>${escHtml(provider)}</span></td><td class="text-muted" title="${escHtml(modelRaw)}"><span class="inline-btn data-chip model-chip" onclick='event.stopPropagation(); addDrilldown({model:${jsAttr(modelRaw)}})'>${escHtml(modelRaw)}</span></td><td><span onclick='event.stopPropagation(); addDrilldown({platform:${jsAttr(platform)}})'>${platformBadge(platform)}</span></td><td><span onclick='event.stopPropagation(); addDrilldown({status:${jsAttr(status)}})'>${statusBadge(status)}</span></td><td>${nf(row.tokens_in || 0)}</td><td>${nf(row.tokens_out || 0)}</td><td>${nf(row.cache_read_tokens || 0)}</td><td>${fmtCost(row.cost_usd)}</td><td>${fmtMs(row.latency_ms)}</td><td>${row.estimated ? statusBadge('running') : statusBadge('ok')}</td><td>${row.provider_assumed ? statusBadge('running') : statusBadge('ok')}</td><td><code>${nf(row.id || 0)}</code></td></tr>`;
     }
   }
   t += `</tbody></table><div class="table-actions"><div>${nf(rows.length)} shown / ${nf(data?.total_requests || 0)} matching request(s)</div><div class="text-muted">${hiddenDeleted ? `${nf(hiddenDeleted)} request(s) hidden with deleted Hermes sessions.` : 'Click a request row for request-level forensics.'}</div></div>`;
@@ -1444,6 +1444,7 @@ function renderRequestDetail(data) {
   html += `<div class="insight-card"><div class="label">Model</div><div class="value" style="font-size:16px"><span class="inline-btn data-chip model-chip" title="${escHtml(req.model || '—')}" onclick='closeRequestDetail(); addDrilldown({model:${jsAttr(req.model || '—')}})'>${escHtml(req.model || '—')}</span></div></div>`;
   html += `<div class="insight-card"><div class="label">Cost / Latency</div><div class="value">${fmtCost(req.cost_usd)} / ${fmtMs(req.latency_ms)}</div></div>`;
   html += `<div class="insight-card"><div class="label">Estimated</div><div class="value">${req.estimated ? 'Yes' : 'No'}</div></div>`;
+  html += `<div class="insight-card"><div class="label">Provider-assumed rate</div><div class="value">${req.provider_assumed ? 'Yes' : 'No'}</div></div>`;
   html += '</div></div>';
 
   html += '<div class="drawer-section"><h4>Request metrics</h4><table><tbody>';

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -172,7 +172,7 @@ def requests(limit: int = 100, window_hours: int = 0) -> dict:
         SELECT lc.id, lc.ts, lc.session_id, lc.model, lc.provider,
                lc.tokens_in, lc.tokens_out, lc.cache_read_tokens,
                lc.cache_write_tokens, lc.reasoning_tokens,
-               lc.cost_usd, lc.latency_ms, lc.estimated,
+               lc.cost_usd, lc.latency_ms, lc.estimated, lc.provider_assumed,
                r.platform, r.cron_job_id, r.status
         FROM llm_calls lc
         LEFT JOIN runs r ON r.session_id = lc.session_id
@@ -194,6 +194,7 @@ def providers(window_hours: int = 24) -> dict:
                COUNT(*) AS total_calls,
                SUM(CASE WHEN estimated=0 THEN 1 ELSE 0 END) AS real_calls,
                SUM(CASE WHEN estimated=1 THEN 1 ELSE 0 END) AS estimated_calls,
+               SUM(CASE WHEN provider_assumed=1 THEN 1 ELSE 0 END) AS provider_assumed_calls,
                ROUND(COALESCE(SUM(cost_usd), 0), 6) AS cost_usd,
                COALESCE(SUM(tokens_in), 0)  AS tokens_in,
                COALESCE(SUM(tokens_out), 0) AS tokens_out,

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -528,6 +528,7 @@ def api_providers(window_hours=24):
                COUNT(*) AS total_calls,
                SUM(CASE WHEN estimated=0 THEN 1 ELSE 0 END) AS real_calls,
                SUM(CASE WHEN estimated=1 THEN 1 ELSE 0 END) AS estimated_calls,
+               SUM(CASE WHEN provider_assumed=1 THEN 1 ELSE 0 END) AS provider_assumed_calls,
                ROUND(COALESCE(SUM(cost_usd), 0), 6) AS cost_usd,
                COALESCE(SUM(tokens_in), 0) AS tokens_in,
                COALESCE(SUM(tokens_out), 0) AS tokens_out,
@@ -886,6 +887,7 @@ def api_requests(
         SELECT lc.id, lc.ts, lc.session_id, lc.model, lc.provider,
                lc.tokens_in, lc.tokens_out, lc.cache_read_tokens, lc.cache_write_tokens,
                lc.reasoning_tokens, lc.cost_usd, lc.latency_ms, lc.estimated,
+               lc.provider_assumed,
                r.platform, r.cron_job_id, r.status, r.tool_calls
         FROM llm_calls lc
         LEFT JOIN runs r ON r.session_id = lc.session_id
@@ -934,6 +936,7 @@ def api_request_detail(request_id: int):
         SELECT lc.id, lc.ts, lc.session_id, lc.model, lc.provider,
                lc.tokens_in, lc.tokens_out, lc.cache_read_tokens, lc.cache_write_tokens,
                lc.reasoning_tokens, lc.cost_usd, lc.latency_ms, lc.estimated,
+               lc.provider_assumed,
                r.platform, r.cron_job_id, r.status, r.started_at, r.ended_at,
                r.duration_ms, r.api_calls, r.tool_calls, r.cost_usd AS session_cost_usd
         FROM llm_calls lc

--- a/db.py
+++ b/db.py
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 5
+_SCHEMA_VERSION = 6
 _local = threading.local()
 
 # Serializes first-time schema setup across threads. Each thread opens its own
@@ -142,6 +142,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _migrate_v3(conn)
     _migrate_v4(conn)
     _migrate_v5(conn)
+    _migrate_v6(conn)
 
 
 def _migrate_v2(conn: sqlite3.Connection) -> None:
@@ -254,6 +255,34 @@ def _migrate_v5(conn: sqlite3.Connection) -> None:
     )
 
 
+def _migrate_v6(conn: sqlite3.Connection) -> None:
+    """Add v6 schema: provider_assumed flag on llm_calls and a per-session
+    counter on runs (issue #42).
+
+    Marks calls whose cost used a provider-assumed rate — a source-ineligible
+    (OpenRouter) price applied to a call another provider served, because no
+    source-eligible price existed. The cost is real spend; the flag only lets
+    stats / dashboard surface it as 'assumed' so the user can pin the rate."""
+    cur = conn.execute("SELECT version FROM schema_version WHERE version = 6")
+    if cur.fetchone() is not None:
+        return
+
+    try:
+        conn.execute("ALTER TABLE llm_calls ADD COLUMN provider_assumed INTEGER DEFAULT 0")
+    except sqlite3.OperationalError:
+        pass  # already exists
+
+    try:
+        conn.execute("ALTER TABLE runs ADD COLUMN provider_assumed_calls INTEGER DEFAULT 0")
+    except sqlite3.OperationalError:
+        pass  # already exists
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (6, ?)",
+        (_utcnow(),),
+    )
+
+
 def _utcnow() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -336,14 +365,16 @@ def record_llm_call(
     cache_write_tokens: int = 0,
     reasoning_tokens: int = 0,
     estimated: bool = False,
+    provider_assumed: bool = False,
 ) -> None:
     conn = _get_conn()
     conn.execute(
         """
         INSERT INTO llm_calls
             (session_id, ts, model, provider, tokens_in, tokens_out, cost_usd, latency_ms,
-             cache_read_tokens, cache_write_tokens, reasoning_tokens, estimated)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             cache_read_tokens, cache_write_tokens, reasoning_tokens, estimated,
+             provider_assumed)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             session_id,
@@ -358,6 +389,7 @@ def record_llm_call(
             cache_write_tokens,
             reasoning_tokens,
             1 if estimated else 0,
+            1 if provider_assumed else 0,
         ),
     )
     _ensure_run_row(session_id, ts)
@@ -388,6 +420,12 @@ def record_llm_call(
     if estimated:
         conn.execute(
             "UPDATE runs SET estimated_llm_calls = estimated_llm_calls + 1 WHERE session_id = ?",
+            (session_id,),
+        )
+    if provider_assumed:
+        conn.execute(
+            "UPDATE runs SET provider_assumed_calls = provider_assumed_calls + 1 "
+            "WHERE session_id = ?",
             (session_id,),
         )
 
@@ -724,7 +762,8 @@ def stats_by_provider(
     """Per-provider breakdown for /stats providers.
 
     Returns one row per provider seen in llm_calls within the window:
-      provider, total_calls, real_calls, estimated_calls, estimated_pct, cost_usd
+      provider, total_calls, real_calls, estimated_calls, estimated_pct,
+      provider_assumed_calls, provider_assumed_pct, cost_usd
     """
     conn = _get_conn()
     where_sql, params = _build_where_clause_ts(window_hours, date_from, date_to)
@@ -736,6 +775,7 @@ def stats_by_provider(
             COUNT(*)                                            AS total_calls,
             SUM(CASE WHEN estimated = 0 THEN 1 ELSE 0 END)    AS real_calls,
             SUM(CASE WHEN estimated = 1 THEN 1 ELSE 0 END)    AS estimated_calls,
+            SUM(CASE WHEN provider_assumed = 1 THEN 1 ELSE 0 END) AS provider_assumed_calls,
             ROUND(SUM(cost_usd), 6)                            AS cost_usd
         FROM llm_calls
         WHERE {where_sql}
@@ -749,7 +789,9 @@ def stats_by_provider(
         row = dict(r)
         total = row.get("total_calls") or 0
         est = row.get("estimated_calls") or 0
+        assumed = row.get("provider_assumed_calls") or 0
         row["estimated_pct"] = (est / total) if total else 0.0
+        row["provider_assumed_pct"] = (assumed / total) if total else 0.0
         result.append(row)
     return result
 
@@ -760,7 +802,8 @@ def stats_by_model(
     """Per-model breakdown within each provider, for /stats models.
 
     Returns one row per (provider, model) seen in llm_calls within the window:
-      provider, model, total_calls, real_calls, estimated_calls, estimated_pct, cost_usd
+      provider, model, total_calls, real_calls, estimated_calls, estimated_pct,
+      provider_assumed_calls, provider_assumed_pct, cost_usd
 
     Ordered by provider (asc) then call count (desc) so each provider's busiest
     models surface first — this is the view that exposes dated models costing
@@ -777,6 +820,7 @@ def stats_by_model(
             COUNT(*)                                          AS total_calls,
             SUM(CASE WHEN estimated = 0 THEN 1 ELSE 0 END)   AS real_calls,
             SUM(CASE WHEN estimated = 1 THEN 1 ELSE 0 END)   AS estimated_calls,
+            SUM(CASE WHEN provider_assumed = 1 THEN 1 ELSE 0 END) AS provider_assumed_calls,
             ROUND(SUM(cost_usd), 6)                           AS cost_usd
         FROM llm_calls
         WHERE {where_sql}
@@ -790,7 +834,9 @@ def stats_by_model(
         row = dict(r)
         total = row.get("total_calls") or 0
         est = row.get("estimated_calls") or 0
+        assumed = row.get("provider_assumed_calls") or 0
         row["estimated_pct"] = (est / total) if total else 0.0
+        row["provider_assumed_pct"] = (assumed / total) if total else 0.0
         result.append(row)
     return result
 

--- a/pricing.py
+++ b/pricing.py
@@ -139,6 +139,10 @@ _DEFAULT_CACHE_READ_MULTIPLIER = 0.10
 _DEFAULT_CACHE_WRITE_MULTIPLIER = 1.25
 
 _warned_unknown: set[tuple[str, str]] = set()
+# (model, provider) pairs already warned about a provider-assumed price (issue
+# #42): a source-ineligible entry was applied as a best-effort estimate rather
+# than recording a silent $0. Deduped so the warning fires once per pair.
+_warned_provider_assumed: set[tuple[str, str]] = set()
 _custom_pricing: dict | None = None  # parsed YAML data (models + defaults)
 
 
@@ -267,13 +271,30 @@ def _lookup_form(model_lc: str, provider: str = "") -> dict | None:
     custom entry is skipped so the lookup falls through to the next candidate
     (e.g. a NIM call skips the same-id OpenRouter entry and lands on the
     source-neutral `_DEFAULT_PRICING` seed).
+
+    Inverted last-resort (issue #42): if NO source-eligible candidate matches but
+    a source-ineligible one would have, the lookup returns that price tagged
+    ``_provider_assumed: True`` instead of ``None``. For a cost tracker, applying
+    a best-effort rate (with a one-time warning at `estimate_cost`) beats
+    silently recording $0 on a real paid call. Source-eligible matches and the
+    `_DEFAULT_PRICING`/`:free` rules always win first, so this only fires when the
+    sole price available is one the guard would otherwise reject — the common
+    "popular model resold at the OpenRouter rate" case (e.g. Nous Portal serving
+    `moonshotai/kimi-k2.6`). A source-neutral override or `_subscription` entry
+    still pre-empts it.
     """
     custom = _load_custom_pricing()
     custom_models = custom.get("models", {})
     model_sources = custom.get("model_sources", {})
 
-    if model_lc in custom_models and _source_eligible(model_sources.get(model_lc), provider):
-        return custom_models[model_lc]
+    # Best source-ineligible match seen, used only if nothing eligible matches.
+    # An ineligible *exact* match outranks any ineligible prefix match.
+    assumed: dict | None = None
+
+    if model_lc in custom_models:
+        if _source_eligible(model_sources.get(model_lc), provider):
+            return custom_models[model_lc]
+        assumed = custom_models[model_lc]
     if model_lc in _DEFAULT_PRICING:
         return _DEFAULT_PRICING[model_lc]
     # Free-tier suffix: OpenRouter (and similar gateways) advertise free variants
@@ -302,8 +323,14 @@ def _lookup_form(model_lc: str, provider: str = "") -> dict | None:
         *((k, v, None) for k, v in _PREFIX_PRICING),
     ]
     for prefix, prices, source in sorted(candidates, key=lambda x: -len(x[0])):
-        if model_lc.startswith(prefix) and _source_eligible(source, provider):
-            return prices
+        if model_lc.startswith(prefix):
+            if _source_eligible(source, provider):
+                return prices
+            if assumed is None:
+                # Longest ineligible prefix (candidates are sorted longest-first).
+                assumed = prices
+    if assumed is not None:
+        return {**assumed, "_provider_assumed": True}
     return None
 
 
@@ -373,13 +400,17 @@ def _resolve_pricing(model: str, provider: str = "") -> dict | None:
     # reasoning defaults to output price unless overridden
     reasoning = float(base.get("reasoning", output_price))
 
-    return dict(
+    resolved = dict(
         input=input_price,
         output=output_price,
         cache_read=cache_read,
         cache_write=cache_write,
         reasoning=reasoning,
     )
+    # Propagate the provider-assumed marker (issue #42) so estimate_cost can warn.
+    if base.get("_provider_assumed"):
+        resolved["_provider_assumed"] = True
+    return resolved
 
 
 def estimate_cost(usage: dict, model: str, provider: str = "") -> float:
@@ -445,6 +476,26 @@ def estimate_cost(usage: dict, model: str, provider: str = "") -> float:
                 )
         return 0.0
 
+    # Provider-assumed price (issue #42): the only matching entry was source-
+    # ineligible for this provider, so we applied it as a best-effort estimate
+    # rather than recording a silent $0. Warn once per (model, provider) so the
+    # user can pin the rate explicitly — far safer than a silent under-count.
+    if prices.get("_provider_assumed"):
+        warn_key = (model, provider)
+        if warn_key not in _warned_provider_assumed:
+            _warned_provider_assumed.add(warn_key)
+            logger.warning(
+                "hermes-telemetry: no price registered for model %r under provider "
+                "%r — applying an OpenRouter-sourced rate as a best-effort estimate "
+                "(cost may be inaccurate if %r bills differently). To pin the rate "
+                "and silence this, add models[%r] to ~/.hermes/telemetry/pricing.yaml "
+                "(omit _source, or set _subscription: true for a flat-rate/free plan).",
+                model,
+                provider,
+                provider,
+                model,
+            )
+
     cost = (
         input_tokens * prices["input"]
         + output_tokens * prices["output"]
@@ -465,6 +516,22 @@ def is_explicitly_priced(model: str, provider: str = "") -> bool:
     known_free_models and can trigger the free→paid transition alert.
     """
     return _resolve_pricing(model, provider) is not None
+
+
+def is_provider_assumed(model: str, provider: str = "") -> bool:
+    """Return True if pricing *model* under *provider* relies on a provider-assumed
+    rate (issue #42).
+
+    True only when the lookup had no source-eligible price and fell back to a
+    source-ineligible entry (an OpenRouter rate applied to a different provider)
+    as a best-effort estimate. The cost is real and counted as spend, but it is
+    flagged so the request can be surfaced as "assumed" in stats / dashboard and
+    the user prompted to pin the rate. Returns False for unknown models, genuine
+    source-eligible matches, `_DEFAULT_PRICING` seeds, and `:free`/`_subscription`
+    entries.
+    """
+    resolved = _resolve_pricing(model, provider)
+    return bool(resolved and resolved.get("_provider_assumed"))
 
 
 def get_known_free_models() -> list:

--- a/stats.py
+++ b/stats.py
@@ -182,8 +182,9 @@ def _providers_block(
     lines = [
         f"hermes-telemetry — providers ({label})",
         "=" * 72,
-        f"  {'Provider':<28} {'Calls':>6} {'Real':>6} {'Est':>5} {'Est%':>6} {'Cost':>12}",
-        "  " + "-" * 67,
+        f"  {'Provider':<28} {'Calls':>6} {'Real':>6} {'Est':>5} {'Est%':>6} "
+        f"{'Asm%':>6} {'Cost':>12}",
+        "  " + "-" * 75,
     ]
     for r in rows:
         prov = (r.get("provider") or "(unknown)")[:28]
@@ -191,8 +192,11 @@ def _providers_block(
         real = _fmt_int(r.get("real_calls"))
         est = _fmt_int(r.get("estimated_calls"))
         est_pct = f"{r.get('estimated_pct', 0.0) * 100:.0f}%"
+        asm_pct = f"{r.get('provider_assumed_pct', 0.0) * 100:.0f}%"
         cost = _fmt_cost(r.get("cost_usd"))
-        lines.append(f"  {prov:<28} {total:>6} {real:>6} {est:>5} {est_pct:>6} {cost:>12}")
+        lines.append(
+            f"  {prov:<28} {total:>6} {real:>6} {est:>5} {est_pct:>6} {asm_pct:>6} {cost:>12}"
+        )
 
     lines.append("")
     lines.append("  Provider key:")
@@ -210,6 +214,12 @@ def _providers_block(
     lines.append(
         "  If Est% > 0 for your main provider, budget hard-verdicts may be "
         "degraded to soft under on_estimated.mode: warn_only."
+    )
+    lines.append(
+        "  Asm% = share of calls priced with an assumed rate (issue #42): an "
+        "OpenRouter-sourced price applied because no provider-native rate was "
+        "registered. The cost counts as real spend; pin the rate in pricing.yaml "
+        "(models[<id>], omit _source) to make it explicit and clear Asm%."
     )
 
     # Check for estimated-price models

--- a/tests/test_dashboard_plugin_api.py
+++ b/tests/test_dashboard_plugin_api.py
@@ -64,6 +64,50 @@ def _seed(rows_runs=(), rows_llm=(), rows_tool=()):
         runtime_db.record_tool_call(**r)
 
 
+def test_requests_and_providers_expose_provider_assumed(plugin_api):
+    """The /requests and /providers endpoints surface the provider_assumed flag
+    and per-provider assumed count (issue #42)."""
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).isoformat()
+    _seed(
+        rows_runs=[{"session_id": "sa", "model": "moonshotai/kimi-k2.6", "platform": "cli"}],
+        rows_llm=[
+            {
+                "session_id": "sa",
+                "ts": now,
+                "model": "moonshotai/kimi-k2.6",
+                "provider": "nous",
+                "tokens_in": 100,
+                "tokens_out": 50,
+                "cost_usd": 0.0004,
+                "latency_ms": 100,
+                "provider_assumed": True,
+            },
+            {
+                "session_id": "sa",
+                "ts": now,
+                "model": "claude-sonnet-4-6",
+                "provider": "nous",
+                "tokens_in": 100,
+                "tokens_out": 50,
+                "cost_usd": 0.001,
+                "latency_ms": 100,
+                "provider_assumed": False,
+            },
+        ],
+    )
+
+    reqs = plugin_api.requests(limit=10, window_hours=24)
+    flags = {r["model"]: r["provider_assumed"] for r in reqs["rows"]}
+    assert flags["moonshotai/kimi-k2.6"] == 1
+    assert flags["claude-sonnet-4-6"] == 0
+
+    providers = plugin_api.providers(window_hours=24)
+    nous = next(r for r in providers["rows"] if r["provider"] == "nous")
+    assert nous["provider_assumed_calls"] == 1
+
+
 def test_health(plugin_api):
     out = plugin_api.health()
     assert out["ok"] is True

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -261,6 +261,109 @@ def test_schema_v2_columns():
     assert "estimated_llm_calls" in runs_cols
 
 
+def test_schema_v6_provider_assumed_columns():
+    """v6 adds provider_assumed on llm_calls and provider_assumed_calls on runs."""
+    conn = db._get_conn()
+    llm_cols = {row[1] for row in conn.execute("PRAGMA table_info(llm_calls)").fetchall()}
+    assert "provider_assumed" in llm_cols
+    runs_cols = {row[1] for row in conn.execute("PRAGMA table_info(runs)").fetchall()}
+    assert "provider_assumed_calls" in runs_cols
+
+
+def test_record_llm_call_provider_assumed():
+    """provider_assumed=True stores the flag and increments the runs counter."""
+    db.start_run("sess-asm", model="moonshotai/kimi-k2.6", platform="cli")
+    db.record_llm_call(
+        "sess-asm",
+        "2026-01-01T00:00:00+00:00",
+        "moonshotai/kimi-k2.6",
+        "nous",
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=0.0004,
+        latency_ms=100,
+        provider_assumed=True,
+    )
+    conn = db._get_conn()
+    call = conn.execute(
+        "SELECT provider_assumed FROM llm_calls WHERE session_id='sess-asm'"
+    ).fetchone()
+    assert call["provider_assumed"] == 1
+    run = conn.execute(
+        "SELECT provider_assumed_calls FROM runs WHERE session_id='sess-asm'"
+    ).fetchone()
+    assert run["provider_assumed_calls"] == 1
+
+    # A second non-assumed call must not increment the counter.
+    db.record_llm_call(
+        "sess-asm",
+        "2026-01-01T00:01:00+00:00",
+        "moonshotai/kimi-k2.6",
+        "nous",
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=0.0004,
+        latency_ms=100,
+        provider_assumed=False,
+    )
+    run = conn.execute(
+        "SELECT provider_assumed_calls FROM runs WHERE session_id='sess-asm'"
+    ).fetchone()
+    assert run["provider_assumed_calls"] == 1
+
+
+def test_record_llm_call_default_provider_assumed_zero():
+    """A normal call leaves provider_assumed at 0 (default)."""
+    db.start_run("sess-asm0", model="claude-sonnet-4-6", platform="cli")
+    db.record_llm_call(
+        "sess-asm0",
+        "2026-01-01T00:00:00+00:00",
+        "claude-sonnet-4-6",
+        "anthropic",
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=0.001,
+        latency_ms=100,
+    )
+    conn = db._get_conn()
+    call = conn.execute(
+        "SELECT provider_assumed FROM llm_calls WHERE session_id='sess-asm0'"
+    ).fetchone()
+    assert call["provider_assumed"] == 0
+
+
+def test_stats_by_provider_exposes_provider_assumed():
+    """stats_by_provider reports provider_assumed_calls and provider_assumed_pct."""
+    db.start_run("sess-pp", model="moonshotai/kimi-k2.6", platform="cli")
+    # 1 assumed + 1 real under the same provider → pct = 0.5
+    db.record_llm_call(
+        "sess-pp",
+        db._utcnow(),
+        "moonshotai/kimi-k2.6",
+        "nous",
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=0.0004,
+        latency_ms=100,
+        provider_assumed=True,
+    )
+    db.record_llm_call(
+        "sess-pp",
+        db._utcnow(),
+        "claude-sonnet-4-6",
+        "nous",
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=0.001,
+        latency_ms=100,
+        provider_assumed=False,
+    )
+    rows = {r["provider"]: r for r in db.stats_by_provider(window_hours=24)}
+    assert "nous" in rows
+    assert rows["nous"]["provider_assumed_calls"] == 1
+    assert abs(rows["nous"]["provider_assumed_pct"] - 0.5) < 1e-9
+
+
 def test_record_llm_call_with_cache_tokens():
     db.start_run("sess-cache", model="claude-sonnet-4-6", platform="cli")
     db.record_llm_call(

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -32,9 +32,11 @@ def reset_pricing(tmp_path_factory, monkeypatch):
 
     pricing._custom_pricing = None
     pricing._warned_unknown.clear()
+    pricing._warned_provider_assumed.clear()
     yield
     pricing._custom_pricing = None
     pricing._warned_unknown.clear()
+    pricing._warned_provider_assumed.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -616,8 +618,17 @@ def test_google_alt_form_resolves_dated_variant_via_longest_prefix(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_openrouter_entry_blocked_for_nous(tmp_path, monkeypatch, caplog):
-    """An OpenRouter-sourced price is not eligible for a provider=nous call."""
+def test_openrouter_entry_assumed_for_nous_with_warning(tmp_path, monkeypatch, caplog):
+    """When the ONLY match for a provider=nous call is OpenRouter-sourced, the
+    rate is applied as a best-effort estimate (NOT silently $0) and a one-time
+    WARNING fires (issue #42).
+
+    This inverts the original issue-#24 safe-default ("fail to zero"): for a
+    cost tracker, a flagged best-effort number a user will react to beats a
+    silent under-count they will not. The flat-sub / wrong-rate cases stay
+    protected by a source-neutral `_subscription` (or hand-added) entry, which
+    pre-empts this fallback — see test_subscription_model_zero_cost_no_warning.
+    """
     import logging
 
     _write_pricing_yaml(
@@ -637,8 +648,11 @@ def test_openrouter_entry_blocked_for_nous(tmp_path, monkeypatch, caplog):
             "qwen3.7-plus",
             provider="nous",
         )
-    assert cost == 0.0  # NOT 0.40+1.60 — OpenRouter price must not leak to Nous
-    assert any("nous" in r.message for r in caplog.records)
+    # Best-effort: the OpenRouter rate is recorded, not a silent $0.
+    assert abs(cost - (0.40 + 1.60)) < 1e-9
+    # And the user is warned, with both the model and the provider named.
+    msgs = [r.message for r in caplog.records]
+    assert any("qwen3.7-plus" in m and "nous" in m for m in msgs)
 
 
 def test_openrouter_entry_used_for_openrouter(tmp_path, monkeypatch):
@@ -748,6 +762,133 @@ def test_subscription_models_tracked_in_loader(tmp_path, monkeypatch):
     # Price-key dict must NOT carry the _-prefixed metadata
     assert "_subscription" not in custom["models"]["qwen3.7-plus"]
     assert "_source" not in custom["models"]["qwen/qwen3.7-plus"]
+
+
+# ---------------------------------------------------------------------------
+# Provider-assumed fallback (issue #42) — inverted safe-default for the lookup
+# path. A source-ineligible entry is applied (flagged + warned once) instead of
+# recording a silent $0, but only when no eligible candidate exists.
+# ---------------------------------------------------------------------------
+
+
+def test_provider_assumed_warns_once_per_pair(tmp_path, monkeypatch, caplog):
+    """The provider-assumed warning fires once per (model, provider) pair."""
+    import logging
+
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "moonshotai/kimi-k2.6":
+            input: 0.68
+            output: 3.41
+            _source: openrouter
+    """),
+    )
+    pricing._warned_provider_assumed.clear()
+    with caplog.at_level(logging.WARNING, logger="hermes_telemetry.pricing"):
+        for _ in range(3):
+            pricing.estimate_cost(
+                {"input_tokens": 100, "output_tokens": 100},
+                "moonshotai/kimi-k2.6",
+                provider="nous",
+            )
+    warns = [r for r in caplog.records if "moonshotai/kimi-k2.6" in r.message]
+    assert len(warns) == 1
+    # A different provider for the same model warns again (distinct pairing).
+    with caplog.at_level(logging.WARNING, logger="hermes_telemetry.pricing"):
+        pricing.estimate_cost({"input_tokens": 100}, "moonshotai/kimi-k2.6", provider="fireworks")
+    warns = [r for r in caplog.records if "moonshotai/kimi-k2.6" in r.message]
+    assert len(warns) == 2
+
+
+def test_provider_assumed_via_prefix_match(tmp_path, monkeypatch):
+    """The inverted default also covers a prefix-only ineligible match: a dated
+    variant whose only price is an OpenRouter-sourced dateless key still gets a
+    best-effort cost for a mismatched provider instead of $0."""
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "moonshotai/kimi-k2.6":
+            input: 0.68
+            output: 3.41
+            _source: openrouter
+    """),
+    )
+    cost = pricing.estimate_cost(
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+        "moonshotai/kimi-k2.6-20260601",  # dated variant → prefix match only
+        provider="nous",
+    )
+    assert abs(cost - (0.68 + 3.41)) < 1e-9
+
+
+def test_empty_provider_does_not_warn_assumed(tmp_path, monkeypatch, caplog):
+    """provider="" stays backward-compatible: the OpenRouter entry is directly
+    eligible (not 'assumed'), so no provider-assumed warning fires."""
+    import logging
+
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "moonshotai/kimi-k2.6":
+            input: 0.68
+            output: 3.41
+            _source: openrouter
+    """),
+    )
+    pricing._warned_provider_assumed.clear()
+    with caplog.at_level(logging.WARNING, logger="hermes_telemetry.pricing"):
+        cost = pricing.estimate_cost({"input_tokens": 1_000_000}, "moonshotai/kimi-k2.6")
+    assert abs(cost - 0.68) < 1e-9
+    assert not any("best-effort" in r.message for r in caplog.records)
+
+
+def test_is_provider_assumed_predicate(tmp_path, monkeypatch):
+    """is_provider_assumed is True only for a source-ineligible best-effort match."""
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "moonshotai/kimi-k2.6":
+            input: 0.68
+            output: 3.41
+            _source: openrouter
+    """),
+    )
+    # Mismatched provider with no eligible price → assumed.
+    assert pricing.is_provider_assumed("moonshotai/kimi-k2.6", "nous") is True
+    # Same entry under openrouter is directly eligible → not assumed.
+    assert pricing.is_provider_assumed("moonshotai/kimi-k2.6", "openrouter") is False
+    # Backward-compat blind lookup is eligible → not assumed.
+    assert pricing.is_provider_assumed("moonshotai/kimi-k2.6", "") is False
+    # Source-neutral default model is never assumed.
+    assert pricing.is_provider_assumed("claude-sonnet-4-6", "nous") is False
+    # Unknown model is not assumed (it is simply unpriced).
+    assert pricing.is_provider_assumed("totally-unknown-xyz", "nous") is False
+
+
+def test_provider_assumed_is_explicitly_priced(tmp_path, monkeypatch):
+    """A provider-assumed price counts as explicitly priced (it produces a real
+    cost), so it is not mistaken for an unknown model."""
+    _write_pricing_yaml(
+        tmp_path,
+        monkeypatch,
+        textwrap.dedent("""
+        models:
+          "moonshotai/kimi-k2.6":
+            input: 0.68
+            output: 3.41
+            _source: openrouter
+    """),
+    )
+    assert pricing.is_explicitly_priced("moonshotai/kimi-k2.6", "nous") is True
 
 
 # ── NVIDIA NIM seeds + same-id collision with OpenRouter ──

--- a/tests/test_subagent_reconciliation.py
+++ b/tests/test_subagent_reconciliation.py
@@ -489,3 +489,58 @@ def test_subagent_stop_failure_statuses(status):
     ).fetchone()
     assert row is not None, f"No tool_calls row recorded for child_status={status!r}"
     assert row[0] == 0, f"child_status={status!r} should record ok=False but got ok={row[0]}."
+
+
+# ---------------------------------------------------------------------------
+# Provider-assumed pricing end-to-end (issue #42): a paid call whose only price
+# is an OpenRouter-sourced entry under a different provider must record cost>0
+# AND flag the row provider_assumed=1 (not a silent $0).
+# ---------------------------------------------------------------------------
+
+
+def test_post_api_request_flags_provider_assumed(tmp_path):
+    import hermes_telemetry.db as db
+    import hermes_telemetry.pricing as pricing
+
+    # Seed an OpenRouter-sourced price into the isolated HERMES_HOME.
+    tele = tmp_path / "telemetry"
+    tele.mkdir(parents=True, exist_ok=True)
+    (tele / "pricing.yaml").write_text(
+        'models:\n  "moonshotai/kimi-k2.6":\n    input: 0.68\n    output: 3.41\n'
+        "    _source: openrouter\n"
+    )
+    pricing.reload_custom_pricing()
+
+    ctx = MockPluginContext()
+    _init_mod.register(ctx)
+
+    SID = "sess_assumed_001"
+    ctx.fire("on_session_start", session_id=SID, model="moonshotai/kimi-k2.6", platform="cli")
+    ctx.fire("pre_api_request", session_id=SID, api_call_count=0, approx_input_tokens=1_000_000)
+    ctx.fire(
+        "post_api_request",
+        session_id=SID,
+        model="moonshotai/kimi-k2.6",
+        provider="nous",
+        api_duration=1.0,
+        api_call_count=0,
+        assistant_content_chars=4_000_000,
+        usage={
+            "input_tokens": 1_000_000,
+            "output_tokens": 1_000_000,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+        },
+    )
+
+    conn = db._get_conn()
+    row = conn.execute(
+        "SELECT cost_usd, provider_assumed, estimated FROM llm_calls WHERE session_id = ?",
+        (SID,),
+    ).fetchone()
+    assert row is not None
+    assert row["provider_assumed"] == 1  # flagged, not silently dropped
+    assert row["estimated"] == 0  # real usage, not a usage=None estimate
+    assert abs(row["cost_usd"] - (0.68 + 3.41)) < 1e-9  # real cost recorded, NOT $0
+    pricing.reload_custom_pricing()


### PR DESCRIPTION
## What & why

Fixes #42. The provider-aware pricing guard rejected an OpenRouter-sourced price
for a call another provider actually served (e.g. Nous Portal reselling
`moonshotai/kimi-k2.6` at the OpenRouter rate). The lookup fell through to the
unknown-model path and recorded **`cost=0`** — a silent under-count, which is the
worst possible failure for a cost-tracking plugin: it gives false reassurance of
zero spend while the upstream bill grows.

## The fix (issue proposal 1: invert the safe-default)

When **no source-eligible** price matches but a source-ineligible one would have,
the lookup now applies that rate as a **best-effort estimate** tagged
`_provider_assumed`, and `estimate_cost` logs a **one-time WARNING** per
`(model, provider)` pair telling the user how to pin the rate.

This only fires as a last resort — source-neutral overrides, `_DEFAULT_PRICING`
seeds, the `:free` rule, and `_subscription` entries all still win first. So the
two cases the original guard (#24) was built for stay correct:
- **Nous flat-sub** → protected by a source-neutral `_subscription` entry.
- **NIM same-id collision** → still falls through to the `_DEFAULT_PRICING` seed.

## Visibility (persist + surface, not just log)

The assumed flag is persisted and surfaced end-to-end, mirroring the existing
`estimated` per-call flag:
- DB **schema v6**: `llm_calls.provider_assumed` + `runs.provider_assumed_calls`.
- `pricing.is_provider_assumed(model, provider)` predicate; `post_api_request`
  flags the row **only when `cost > 0`** (a $0 row is not a pricing question).
- `/stats providers` gains an `Asm%` column.
- Both dashboards (standalone `serve.py`/`index.html` and the Hermes plugin
  `plugin_api.py`/`dist/index.js`) show an `Asm?` column in Requests and an
  `Assumed` count in Providers.

**Budget decision:** an assumed cost counts as **real spend** — it does NOT
degrade hard budget verdicts (unlike `_estimated_price`). The resold-at-the-same-
rate case is usually the *correct* number, so softening enforcement would
contradict the issue's "err on the side of recording cost" intent.

## Backward compatibility (users who already applied the manual workaround)

Verified in an isolated `HERMES_HOME` (4/4 scenarios pass):

| Existing config | Before | After |
|---|---|---|
| Full workaround (removed `_source` → source-neutral) | rate, no warning | **unchanged** |
| Partial workaround (`_source` removed, still in `auto_models`) | rate, no warning | **unchanged** |
| `_subscription: true` (flat-sub) | $0, no warning | **unchanged** |
| **No** workaround (still `_source: openrouter`) | **$0 silent** | rate + one-time warning |

Only the no-workaround group changes, and only for the better: a flagged
best-effort number (with an actionable warning) instead of a silent under-count.
No existing config breaks; nothing requires migration.

## Manual verification (run before writing automated tests, per request)

Reproduced the bug and validated the fix in a throwaway `HERMES_HOME` (never the
dev's real `~/.hermes`) before touching the test suite:

- **Before fix:** paid `kimi-k2.6` call under `provider=nous` → `cost=0.0`.
- **After fix:** `cost=4.09`, one-time warning fires and dedupes; OpenRouter
  direct, `_subscription`→$0, NIM seed, and unknown-model→$0 all still hold (6/6).

## Tests

- `ruff format --check . && ruff check .` clean; `pytest tests/` → **299 passed**,
  6 skipped.
- New regression coverage: pricing (lookup inversion, warning dedup, prefix
  fallback, `is_provider_assumed`), DB (schema v6, persistence, aggregation),
  dashboard plugin API, and an end-to-end `post_api_request` test.
- Pre-existing unrelated failure `test_dashboard.py::...viewer_timezone`
  (machine-TZ dependent, CEST vs UTC) is untouched by this change and fails the
  same way on the clean tree.
