### PR TITLE
Fix schema migration bug: re-add columns silently skipped by v7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,36 @@ updating the doc.
 
 ---
 
+## Critical rule: schema changes require a migration
+
+Any change to the SQLite shape (new column, new table, new index, renamed
+or retyped column) **MUST** go through a new `_migrate_vN` function in
+`db.py`. Editing `_ensure_schema` directly only affects fresh DBs — every
+upgrading user keeps the old shape and the plugin breaks silently.
+
+Before touching `db.py`, read **ONBOARDING.md § Adding a column or table —
+mandatory checklist** in full. Non-negotiables:
+
+- New shape ⇒ new `_migrate_vN`, never an in-place edit of an existing one.
+- `_SCHEMA_VERSION` bumps in lockstep (CI enforces via `test_schema_idempotent`).
+- Use `_add_column_if_missing` for `ALTER TABLE ADD COLUMN`. Never write a
+  raw `ALTER` wrapped in `try/except sqlite3.OperationalError: pass` — that
+  is the exact pattern that wedged user DBs in the v7 incident (the
+  exception also covers `SQLITE_LOCKED` from cross-process cron contention,
+  so the column never lands but the version gets marked applied).
+- Add a per-version test (`test_schema_vN_columns` or
+  `test_migrate_vN_*`) AND a test that simulates the upgrade path from
+  the previous version with the column missing (template:
+  `test_migrate_v9_repairs_missing_column_from_wedged_v7`).
+- Forward-only: never reuse a version number. A buggy migration is fixed
+  by a follow-up `_migrate_v(N+1)` repair pass, never by editing
+  `_migrate_vN` in place.
+
+Updating the migration table in ONBOARDING.md § Schema evolution is part
+of the same PR, not a follow-up.
+
+---
+
 ## Test and lint commands
 
 ```bash

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -377,9 +377,56 @@ with the highest `_migrate_vN`. `test_schema_idempotent` asserts the count of
 `schema_version` rows equals `_SCHEMA_VERSION`, so adding a migration without
 bumping the constant (or vice versa) fails CI.
 
-**Migration ALTER contract (post-v9):** never wrap an `ALTER TABLE ADD COLUMN`
-in a blanket `except sqlite3.OperationalError: pass` followed by an
-unconditional `INSERT INTO schema_version`. `OperationalError` also covers
+### Adding a column or table — mandatory checklist
+
+Any PR that adds, removes, renames, or retypes a column or table **MUST**
+follow this checklist. Skipping a step has already wedged user DBs in
+production once (the v7 `provider_assumed` incident); the rules below exist
+specifically to prevent the recurrence.
+
+1. **Write a new `_migrate_vN`.** Never edit `_ensure_schema` to alter the
+   shape of an existing table — that only runs on fresh DBs, so every
+   upgrading user keeps the old shape. New shape ⇒ new migration function.
+2. **Bump `_SCHEMA_VERSION` to N** in `db.py` (kept in lockstep —
+   `test_schema_idempotent` enforces this).
+3. **Use `_add_column_if_missing`** for `ALTER TABLE ADD COLUMN`. Do **not**
+   write a raw `ALTER` with a `try/except OperationalError: pass` — that is
+   exactly the pattern that caused the v7 incident. The helper is idempotent
+   (re-running it on an already-migrated DB is a no-op) and lets transient
+   errors propagate so the migration is not marked applied prematurely.
+4. **Guard `CREATE TABLE` with `IF NOT EXISTS`.** Same idempotency reason.
+5. **Reads must tolerate the column being absent** if the code path can run
+   *before* `_ensure_schema()` (rare, but `_get_conn` is the only entry —
+   audit any new entry point that bypasses it).
+6. **Writes that reference the new column must come AFTER the migration is
+   registered.** If you add the column in v9 but the matching `INSERT`/`UPDATE`
+   was deployed in the same release, you are fine — `_ensure_schema` runs at
+   connect, before any write. But if you reference the column from a `SELECT`
+   query in `stats.py` or a dashboard endpoint and the migration silently
+   skipped, the query returns nothing or errors — write a test that exercises
+   the upgrade path from the *previous* schema version (see
+   `test_migrate_v9_repairs_missing_column_from_wedged_v7` as the template).
+7. **Add a row to the migration table above** with `What was added` filled in
+   and a link to the issue / PR.
+8. **Add a per-version assertion test**: `test_schema_vN_columns` or
+   `test_schema_vN_recorded` (see existing tests as the pattern).
+9. **Never drop or rename a column in a single migration.** SQLite before
+   3.35 has no `DROP COLUMN`, and even modern SQLite forbids it inside a
+   transaction with foreign keys. If a column truly must go, do it across
+   two releases: deprecate (stop writing) in vN, then remove (table-rebuild
+   migration) in vN+1 only after verifying no installed version still
+   writes it.
+10. **Never reuse a `_SCHEMA_VERSION` number.** Forward-only. If a migration
+    was buggy in production, write `_migrate_v(N+1)` to repair it (the v9
+    repair pass is the canonical example) — never edit `_migrate_vN`
+    in-place to fix the bug, because users who already ran the buggy version
+    have `schema_version=N` and will skip the corrected code.
+
+### Migration ALTER contract (post-v9)
+
+Never wrap an `ALTER TABLE ADD COLUMN` in a blanket
+`except sqlite3.OperationalError: pass` followed by an unconditional
+`INSERT INTO schema_version`. `OperationalError` also covers
 `SQLITE_LOCKED` (which `busy_timeout` does **not** retry across processes — the
 `_schema_lock` only protects threads of the same process; cron jobs run in
 separate processes and *will* contend on first connect after an upgrade) and

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -370,11 +370,24 @@ table before applying.
 | v6 | New table: `free_paid_transitions` (historical free→paid flips for the widget rendered inside `TelemetryPage`) |
 | v7 | `llm_calls.provider_assumed` flag + `runs.provider_assumed_calls` counter (provider-assumed pricing visibility, issue #42) |
 | v8 | New table: `model_unavailable_alerts` (404s captured via `api_request_error` — model removed/deprecated by provider) |
+| v9 | Repair pass — re-adds any column from v2/v3/v4/v7 that was silently skipped by the old blanket `except OperationalError: pass` pattern when an `ALTER TABLE` hit a transient `SQLITE_LOCKED` (cross-process cron contention). Uses `_add_column_if_missing`; idempotent. |
 
 `_SCHEMA_VERSION` in `db.py` is the latest applied version — keep it in lockstep
 with the highest `_migrate_vN`. `test_schema_idempotent` asserts the count of
 `schema_version` rows equals `_SCHEMA_VERSION`, so adding a migration without
 bumping the constant (or vice versa) fails CI.
+
+**Migration ALTER contract (post-v9):** never wrap an `ALTER TABLE ADD COLUMN`
+in a blanket `except sqlite3.OperationalError: pass` followed by an
+unconditional `INSERT INTO schema_version`. `OperationalError` also covers
+`SQLITE_LOCKED` (which `busy_timeout` does **not** retry across processes — the
+`_schema_lock` only protects threads of the same process; cron jobs run in
+separate processes and *will* contend on first connect after an upgrade) and
+I/O errors. Swallowing those and then marking the version applied permanently
+wedges the DB without raising. Use `_add_column_if_missing` instead — it checks
+`pragma_table_info` first and lets any real `OperationalError` propagate, so
+the surrounding migration is NOT marked applied and the next connect retries.
+This was the root cause of the v7 `provider_assumed` silent-skip incident.
 
 ### `_ensure_run_row` — lazy insert (added v0.3.1)
 

--- a/db.py
+++ b/db.py
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 8
+_SCHEMA_VERSION = 9
 _local = threading.local()
 
 # Serializes first-time schema setup across threads. Each thread opens its own
@@ -75,6 +75,26 @@ def _get_conn() -> sqlite3.Connection:
         with _schema_lock:
             _ensure_schema(conn)
     return _local.conn
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    cur = conn.execute(f"SELECT 1 FROM pragma_table_info('{table}') WHERE name = ?", (column,))
+    return cur.fetchone() is not None
+
+
+def _add_column_if_missing(conn: sqlite3.Connection, table: str, column: str, typedef: str) -> None:
+    """Idempotently add ``column`` to ``table``.
+
+    Distinguishes "already exists" (benign — skip) from any other
+    ``OperationalError`` like ``SQLITE_LOCKED`` or I/O failure (transient —
+    must re-raise so the surrounding migration is NOT marked applied and the
+    next connect retries). Catching ``OperationalError`` blindly and then
+    marking the version as applied is what produced the v7 silent-skip bug
+    (issue: provider_assumed column missing on DBs that show schema_version=7).
+    """
+    if _column_exists(conn, table, column):
+        return
+    conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {typedef}")
 
 
 def _ensure_schema(conn: sqlite3.Connection) -> None:
@@ -145,6 +165,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _migrate_v6(conn)
     _migrate_v7(conn)
     _migrate_v8(conn)
+    _migrate_v9(conn)
 
 
 def _migrate_v2(conn: sqlite3.Connection) -> None:
@@ -155,27 +176,19 @@ def _migrate_v2(conn: sqlite3.Connection) -> None:
     if cur.fetchone() is not None:
         return
 
-    new_cols_llm = [
+    for col, typedef in (
         ("cache_read_tokens", "INTEGER DEFAULT 0"),
         ("cache_write_tokens", "INTEGER DEFAULT 0"),
         ("reasoning_tokens", "INTEGER DEFAULT 0"),
         ("estimated", "INTEGER DEFAULT 0"),
-    ]
-    for col, typedef in new_cols_llm:
-        try:
-            conn.execute(f"ALTER TABLE llm_calls ADD COLUMN {col} {typedef}")
-        except sqlite3.OperationalError:
-            pass  # already exists
+    ):
+        _add_column_if_missing(conn, "llm_calls", col, typedef)
 
-    new_cols_runs = [
+    for col, typedef in (
         ("parent_session_id", "TEXT"),
         ("estimated_llm_calls", "INTEGER DEFAULT 0"),
-    ]
-    for col, typedef in new_cols_runs:
-        try:
-            conn.execute(f"ALTER TABLE runs ADD COLUMN {col} {typedef}")
-        except sqlite3.OperationalError:
-            pass  # already exists
+    ):
+        _add_column_if_missing(conn, "runs", col, typedef)
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (2, ?)",
@@ -190,10 +203,7 @@ def _migrate_v3(conn: sqlite3.Connection) -> None:
     if cur.fetchone() is not None:
         return
 
-    try:
-        conn.execute("ALTER TABLE runs ADD COLUMN sender_id TEXT")
-    except sqlite3.OperationalError:
-        pass  # already exists
+    _add_column_if_missing(conn, "runs", "sender_id", "TEXT")
 
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS budget_alerts (
@@ -225,10 +235,7 @@ def _migrate_v4(conn: sqlite3.Connection) -> None:
         return
 
     for col in ("cache_read_tokens", "cache_write_tokens"):
-        try:
-            conn.execute(f"ALTER TABLE runs ADD COLUMN {col} INTEGER DEFAULT 0")
-        except sqlite3.OperationalError:
-            pass  # already exists
+        _add_column_if_missing(conn, "runs", col, "INTEGER DEFAULT 0")
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (4, ?)",
@@ -299,15 +306,8 @@ def _migrate_v7(conn: sqlite3.Connection) -> None:
     if cur.fetchone() is not None:
         return
 
-    try:
-        conn.execute("ALTER TABLE llm_calls ADD COLUMN provider_assumed INTEGER DEFAULT 0")
-    except sqlite3.OperationalError:
-        pass  # already exists
-
-    try:
-        conn.execute("ALTER TABLE runs ADD COLUMN provider_assumed_calls INTEGER DEFAULT 0")
-    except sqlite3.OperationalError:
-        pass  # already exists
+    _add_column_if_missing(conn, "llm_calls", "provider_assumed", "INTEGER DEFAULT 0")
+    _add_column_if_missing(conn, "runs", "provider_assumed_calls", "INTEGER DEFAULT 0")
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (7, ?)",
@@ -348,6 +348,46 @@ def _migrate_v8(conn: sqlite3.Connection) -> None:
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (8, ?)",
+        (_utcnow(),),
+    )
+
+
+def _migrate_v9(conn: sqlite3.Connection) -> None:
+    """Reconcile columns from earlier ALTER-based migrations that may have been
+    silently skipped on DBs migrated under the old ``except OperationalError:
+    pass`` pattern.
+
+    Background: ``_migrate_v2``/``_v3``/``_v4``/``_v7`` used a blanket
+    ``except OperationalError`` around each ALTER and then unconditionally
+    wrote the version marker. A transient ``SQLITE_LOCKED`` (cross-process
+    contention from concurrent cron jobs on the same DB) would be swallowed,
+    the column never added, and the version recorded as applied — wedging the
+    DB until manually repaired.
+
+    This migration re-adds any missing column using ``_add_column_if_missing``
+    (idempotent). It is safe regardless of the prior state.
+    """
+    cur = conn.execute("SELECT version FROM schema_version WHERE version = 9")
+    if cur.fetchone() is not None:
+        return
+
+    for table, col, typedef in (
+        ("llm_calls", "cache_read_tokens", "INTEGER DEFAULT 0"),
+        ("llm_calls", "cache_write_tokens", "INTEGER DEFAULT 0"),
+        ("llm_calls", "reasoning_tokens", "INTEGER DEFAULT 0"),
+        ("llm_calls", "estimated", "INTEGER DEFAULT 0"),
+        ("llm_calls", "provider_assumed", "INTEGER DEFAULT 0"),
+        ("runs", "parent_session_id", "TEXT"),
+        ("runs", "estimated_llm_calls", "INTEGER DEFAULT 0"),
+        ("runs", "sender_id", "TEXT"),
+        ("runs", "cache_read_tokens", "INTEGER DEFAULT 0"),
+        ("runs", "cache_write_tokens", "INTEGER DEFAULT 0"),
+        ("runs", "provider_assumed_calls", "INTEGER DEFAULT 0"),
+    ):
+        _add_column_if_missing(conn, table, col, typedef)
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (9, ?)",
         (_utcnow(),),
     )
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -48,6 +48,120 @@ def test_schema_creates_tables():
     assert "schema_version" in tables
 
 
+def test_migrate_v9_repairs_missing_column_from_wedged_v7(monkeypatch):
+    """Regression: if an earlier process wedged the DB by marking
+    schema_version=7 without actually adding ``llm_calls.provider_assumed``
+    (the v7 ALTER was swallowed by a transient SQLITE_LOCKED under the old
+    blanket-except code), the next connect must self-heal via v9 — not crash
+    every ``record_llm_call`` with ``no such column: provider_assumed``."""
+    conn = db._get_conn()
+
+    # Simulate the wedged state: drop the column added by v7, while leaving
+    # schema_version=7 (and 8, 9) in place. SQLite has no DROP COLUMN before
+    # 3.35; instead we rebuild the table without the column to mimic the
+    # production state observed in the field.
+    conn.execute("ALTER TABLE llm_calls RENAME TO _llm_calls_old")
+    conn.execute("""
+        CREATE TABLE llm_calls (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id          TEXT NOT NULL,
+            ts                  TEXT NOT NULL,
+            model               TEXT,
+            provider            TEXT DEFAULT '',
+            tokens_in           INTEGER DEFAULT 0,
+            tokens_out          INTEGER DEFAULT 0,
+            cost_usd            REAL DEFAULT 0,
+            latency_ms          INTEGER DEFAULT 0,
+            cache_read_tokens   INTEGER DEFAULT 0,
+            cache_write_tokens  INTEGER DEFAULT 0,
+            reasoning_tokens    INTEGER DEFAULT 0,
+            estimated           INTEGER DEFAULT 0
+        )
+    """)
+    conn.execute("DROP TABLE _llm_calls_old")
+    # Force v9 to re-run by deleting its marker (mimics a DB that predates v9)
+    conn.execute("DELETE FROM schema_version WHERE version = 9")
+
+    cols = {r[0] for r in conn.execute("SELECT name FROM pragma_table_info('llm_calls')")}
+    assert "provider_assumed" not in cols  # wedged state confirmed
+
+    # Re-run migrations: v9 must self-heal
+    db._ensure_schema(conn)
+
+    cols = {r[0] for r in conn.execute("SELECT name FROM pragma_table_info('llm_calls')")}
+    assert "provider_assumed" in cols, "v9 must re-add provider_assumed when v7 silently skipped it"
+
+    # And record_llm_call must now succeed end-to-end
+    db.record_llm_call(
+        session_id="repair-test",
+        ts="2026-06-20T20:00:00+00:00",
+        model="deepseek-chat",
+        provider="deepseek",
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=0.001,
+        latency_ms=500,
+        provider_assumed=False,
+    )
+    row = conn.execute(
+        "SELECT tokens_in, tokens_out, provider_assumed FROM llm_calls WHERE session_id = 'repair-test'"
+    ).fetchone()
+    assert row["tokens_in"] == 100
+    assert row["tokens_out"] == 50
+    assert row["provider_assumed"] == 0
+
+
+def test_alter_failure_does_not_mark_migration_applied(monkeypatch):
+    """Regression: if ALTER TABLE raises a non-"duplicate column" error
+    (e.g. SQLITE_LOCKED from cross-process contention), the surrounding
+    migration must NOT write its schema_version row — otherwise the next
+    connect skips the migration permanently and the column never lands."""
+    import sqlite3 as _sqlite3
+
+    conn = db._get_conn()
+    # Pretend we're a pre-v7 DB that just finished v6.
+    conn.execute("DELETE FROM schema_version WHERE version >= 7")
+    # Drop columns added by v7 to mimic a fresh-from-v6 DB.
+    conn.execute("ALTER TABLE llm_calls RENAME TO _old")
+    conn.execute("""
+        CREATE TABLE llm_calls (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            ts TEXT NOT NULL,
+            model TEXT,
+            provider TEXT DEFAULT '',
+            tokens_in INTEGER DEFAULT 0,
+            tokens_out INTEGER DEFAULT 0,
+            cost_usd REAL DEFAULT 0,
+            latency_ms INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0,
+            reasoning_tokens INTEGER DEFAULT 0,
+            estimated INTEGER DEFAULT 0
+        )
+    """)
+    conn.execute("DROP TABLE _old")
+
+    # Force the ALTER inside _add_column_if_missing to raise SQLITE_LOCKED.
+    original = db._add_column_if_missing
+    call_count = {"n": 0}
+
+    def flaky(conn_, table, column, typedef):
+        call_count["n"] += 1
+        if call_count["n"] == 1 and column == "provider_assumed":
+            raise _sqlite3.OperationalError("database is locked")
+        return original(conn_, table, column, typedef)
+
+    monkeypatch.setattr(db, "_add_column_if_missing", flaky)
+
+    with pytest.raises(_sqlite3.OperationalError, match="locked"):
+        db._migrate_v7(conn)
+
+    # Crucial: v7 must NOT be marked applied, so the next connect retries.
+    v7 = conn.execute("SELECT version FROM schema_version WHERE version = 7").fetchone()
+    assert v7 is None, "migration must not be marked applied if ALTER failed transiently"
+
+
 def test_schema_idempotent():
     """Calling _ensure_schema twice must not raise or duplicate version rows.
 


### PR DESCRIPTION
## Summary

Fixes a critical bug where schema migrations v2, v3, v4, and v7 could silently skip adding columns when an `ALTER TABLE` hit a transient `SQLITE_LOCKED` error (from cross-process cron contention). The old code wrapped each ALTER in a blanket `except OperationalError: pass` and then unconditionally marked the migration applied, permanently wedging the database.

Introduces migration v9 as a repair pass that:
1. Re-adds any missing columns from earlier migrations using a new `_add_column_if_missing()` helper
2. Distinguishes "column already exists" (benign) from transient errors like `SQLITE_LOCKED` (must propagate)
3. Ensures the surrounding migration is NOT marked applied if an ALTER fails, so the next connect retries

Also refactors v2–v7 migrations to use `_add_column_if_missing()` going forward, preventing future silent skips.

## Type of change
- [x] fix — bug fix
- [x] test — adding/correcting tests

## Changes

**db.py:**
- Bump `_SCHEMA_VERSION` from 8 to 9
- Add `_column_exists()` helper to check if a column is present via `pragma_table_info`
- Add `_add_column_if_missing()` helper that idempotently adds columns and lets real errors propagate
- Refactor `_migrate_v2()`, `_migrate_v3()`, `_migrate_v4()`, `_migrate_v7()` to use the new helper instead of blanket `except OperationalError: pass`
- Add `_migrate_v9()` that re-adds all columns from v2/v3/v4/v7 that may have been skipped

**tests/test_db.py:**
- Add `test_migrate_v9_repairs_missing_column_from_wedged_v7()` — verifies v9 detects and repairs a DB wedged by v7's silent skip, and that `record_llm_call()` succeeds afterward
- Add `test_alter_failure_does_not_mark_migration_applied()` — verifies that when `_add_column_if_missing()` raises `SQLITE_LOCKED`, the surrounding migration is NOT marked applied

**ONBOARDING.md:**
- Document v9 migration in the schema version table
- Add "Migration ALTER contract (post-v9)" section explaining why blanket `except OperationalError: pass` is unsafe and how to use `_add_column_if_missing()` correctly

## Testing

- `test_migrate_v9_repairs_missing_column_from_wedged_v7()` confirms v9 detects a missing `provider_assumed` column (the actual field that was silently skipped in production) and re-adds it, then verifies `record_llm_call()` succeeds end-to-end
- `test_alter_failure_does_not_mark_migration_applied()` confirms that transient `SQLITE_LOCKED` errors are not swallowed and do not mark the migration applied
- Existing `test_schema_idempotent()` continues to pass, verifying that running migrations twice does not duplicate version rows

## Checklist
- [x] Tests pass locally (`pytest tests/ -v`)
- [x] Lint passes (`ruff check . && ruff format --check .`)
- [x] ONBOARDING.md updated with v9 documentation and migration contract

https://claude.ai/code/session_01WoVD8Ee1QZU2YJtEJKdmrY