### PR TITLE
BUILD #157: Tiered storage analytics with date and range filters

### DIFF
--- a/BUILD-PLAN-issue-157.md
+++ b/BUILD-PLAN-issue-157.md
@@ -7,6 +7,6 @@ Decision: Option A (tiered storage completo, matching tokentelemetry capabilitie
 
 - [ ] Milestone 1 -- Add tiered storage tables to db.py (daily_rollups, weekly_rollups, monthly_rollups) with migration to schema v10
 - [ ] Milestone 2 -- Implement upsert_rollups() triggered on end_run + periodic compaction
-- [ ] Milestone 3 -- Add retention config (plugin config: retention_days per tier) with auto-prune
+- [x] Milestone 3 -- Add retention config (plugin config: retention_days per tier) with auto-prune
 - [ ] Milestone 4 -- Extend /stats with --granularity flag (day|week|month) and combined agent/model filters
 - [ ] Milestone 5 -- Extend dashboard API with bucketed endpoints and tier-aware queries

--- a/BUILD-PLAN-issue-157.md
+++ b/BUILD-PLAN-issue-157.md
@@ -1,0 +1,12 @@
+BUILD PLAN -- Issue #157: Tiered storage analytics with date/range filters
+
+Card: https://github.com/nujovich/hermes-radar/issues/157
+Decision: Option A (tiered storage completo, matching tokentelemetry capabilities)
+
+## Milestones
+
+- [ ] Milestone 1 -- Add tiered storage tables to db.py (daily_rollups, weekly_rollups, monthly_rollups) with migration to schema v10
+- [ ] Milestone 2 -- Implement upsert_rollups() triggered on end_run + periodic compaction
+- [ ] Milestone 3 -- Add retention config (plugin config: retention_days per tier) with auto-prune
+- [ ] Milestone 4 -- Extend /stats with --granularity flag (day|week|month) and combined agent/model filters
+- [ ] Milestone 5 -- Extend dashboard API with bucketed endpoints and tier-aware queries

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -353,6 +353,68 @@ def budget() -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# Tiered rollups (bucketed analytics history)
+# ---------------------------------------------------------------------------
+def _rollup_table(granularity: str) -> str:
+    """Map a granularity label to its tiered rollup table.
+
+    Falls back to the daily rollup table for any unrecognized value so a
+    stale client can never trigger a SQL parse error (table name is never
+    interpolated from raw user input without this allowlist).
+    """
+    return {
+        "day": "daily_rollups",
+        "week": "weekly_rollups",
+        "month": "monthly_rollups",
+    }.get(granularity, "daily_rollups")
+
+
+@router.get("/rollups")
+def rollups(granularity: str = "day", model: str = "", provider: str = "") -> dict:
+    """Bucketed cost/usage history from the tiered rollup tables.
+
+    Powers the dashboard's time-series analytics widget with pre-aggregated
+    day/week/month buckets, instead of scanning ``llm_calls`` on every
+    render. ``granularity`` selects the tier (``day`` | ``week`` | ``month``;
+    any other value defaults to ``day``). ``model`` / ``provider`` apply
+    tier-aware filters — pass ``''`` (the default) to include all rows.
+
+    The rollup tables are created by db.py schema v10/v11; a missing table is
+    treated as "no history yet" so the dashboard stays functional on older
+    installs.
+    """
+    table = _rollup_table(granularity)
+    clauses = []
+    params: list = []
+    if model:
+        clauses.append("model = ?")
+        params.append(model)
+    if provider:
+        clauses.append("provider = ?")
+        params.append(provider)
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    sql = (
+        f"SELECT period_start, model, provider, tokens_in, tokens_out,"
+        f" cost_usd, api_calls, tool_calls, session_count"
+        f" FROM {table}{where}"
+        f" ORDER BY period_start ASC"
+    )
+    try:
+        rows = _rows(sql, tuple(params))
+    except sqlite3.OperationalError:
+        rows = []
+    total_cost = round(sum(float(r.get("cost_usd") or 0.0) for r in rows), 6)
+    return {
+        "granularity": granularity if granularity in ("day", "week", "month") else "day",
+        "model": model,
+        "provider": provider,
+        "total_cost_usd": total_cost,
+        "bucket_count": len(rows),
+        "rows": rows,
+    }
+
+
 @router.get("/tier-transitions")
 def tier_transitions(window_hours: int = 72) -> dict:
     """Recent free→paid model transitions, newest first.

--- a/db.py
+++ b/db.py
@@ -34,12 +34,13 @@ import os
 import sqlite3
 import threading
 from datetime import datetime, timezone
+from datetime import timedelta as _timedelta
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 10
+_SCHEMA_VERSION = 11
 _local = threading.local()
 
 # Serializes first-time schema setup across threads. Each thread opens its own
@@ -167,6 +168,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _migrate_v8(conn)
     _migrate_v9(conn)
     _migrate_v10(conn)
+    _migrate_v11(conn)
 
 
 def _migrate_v2(conn: sqlite3.Connection) -> None:
@@ -459,6 +461,55 @@ def _migrate_v10(conn: sqlite3.Connection) -> None:
     )
 
 
+def _migrate_v11(conn: sqlite3.Connection) -> None:
+    """Add v11 schema: rollup_contrib table — the per-session source of truth
+    for the tiered rollup tables.
+
+    The daily/weekly/monthly rollup tables are *derived* aggregates shared
+    across sessions. Re-folding a single session by re-scanning all of its
+    llm_calls would double-count on a re-``end_run``. Instead, ``upsert_rollups``
+    writes the session's per-(period, model, provider) contribution into
+    ``rollup_contrib`` first (``ON CONFLICT ... REPLACE`` wipes any prior
+    contribution from the same session), then ``_apply_session_rollups`` adds the
+    *current* contribution to the shared rollup tables. To re-derive the rollups
+    from scratch, ``compact_rollups`` recomputes both ``rollup_contrib`` and the
+    rollup tables from ``llm_calls``.
+
+    Only ``status = 'applied'`` rows count toward the rollups so a re-ended
+    session replaces rather than re-adds its contribution.
+    """
+    cur = conn.execute("SELECT version FROM schema_version WHERE version = 11")
+    if cur.fetchone() is not None:
+        return
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS rollup_contrib (
+            session_id   TEXT NOT NULL,
+            granularity  TEXT NOT NULL,
+            period_start TEXT NOT NULL,
+            model        TEXT NOT NULL DEFAULT '',
+            provider     TEXT NOT NULL DEFAULT '',
+            tokens_in    INTEGER DEFAULT 0,
+            tokens_out   INTEGER DEFAULT 0,
+            cost_usd     REAL DEFAULT 0.0,
+            api_calls    INTEGER DEFAULT 0,
+            status       TEXT NOT NULL DEFAULT 'applied',
+            PRIMARY KEY (session_id, granularity, period_start, model, provider)
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_rollup_contrib_period "
+        "ON rollup_contrib(granularity, period_start)"
+    )
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (11, ?)",
+        (_utcnow(),),
+    )
+
+
 def _utcnow() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -526,6 +577,354 @@ def end_run(session_id: str, status: str, ended_at: str | None = None) -> None:
         """,
         (now, status, now, session_id),
     )
+    # Roll the session up into the tiered daily/weekly/monthly rollup tables so
+    # later /stats --granularity queries can read pre-aggregated buckets instead
+    # of scanning llm_calls. Failure here must never break the session end
+    # itself, so swallow and log.
+    try:
+        upsert_rollups(session_id)
+    except Exception:  # pragma: no cover - defensive, rollups are best-effort
+        logger.exception("upsert_rollups failed for session %s", session_id)
+
+
+# ---------------------------------------------------------------------------
+# Tiered rollups (issue #157, M2)
+# ---------------------------------------------------------------------------
+
+_ROLLUP_TABLES = ("daily_rollups", "weekly_rollups", "monthly_rollups")
+_ROLLUP_GRANULARITIES = ("daily", "weekly", "monthly")
+
+
+def _period_starts(dt: datetime) -> tuple[str, str, str]:
+    """Return (day, week_start, month_start) ISO date strings for *dt*.
+
+    Week is Monday-based: ``week_start`` is the Monday of the ISO week containing
+    *dt*. All three are pure date strings ('YYYY-MM-DD') so they sort and group
+    lexically.
+    """
+    day = dt.strftime("%Y-%m-%d")
+    week_start = (dt - _timedelta(days=dt.weekday())).strftime("%Y-%m-%d")
+    month_start = dt.strftime("%Y-%m-01")
+    return day, week_start, month_start
+
+
+def _compute_session_contrib(
+    session_id: str,
+) -> list[tuple[str, str, str, str, int, int, float, int]]:
+    """Aggregate one session's ``llm_calls`` into per-(granularity, period,
+    model, provider) contribution rows.
+
+    Returns a list of tuples ready to insert into ``rollup_contrib``:
+        (granularity, period_start, model, provider, tokens_in, tokens_out,
+         cost_usd, api_calls).
+    A session contributes at most once per (granularity, period, model, provider)
+    group, so ``session_count`` (derived in the rollup tables) stays correct even
+    when a single session makes multiple calls into the same bucket.
+    """
+    conn = _get_conn()
+    rows = conn.execute(
+        """
+        SELECT ts, model, provider, tokens_in, tokens_out, cost_usd
+        FROM llm_calls
+        WHERE session_id = ?
+        """,
+        (session_id,),
+    ).fetchall()
+    if not rows:
+        return []
+
+    # key -> [tokens_in, tokens_out, cost_usd, api_calls]
+    agg: dict[tuple[str, str, str, str], list[float]] = {}
+    for r in rows:
+        ts = r["ts"]
+        try:
+            dt = datetime.fromisoformat(ts)
+        except ValueError:
+            # Fall back to the date portion if the timestamp is malformed.
+            dt = datetime.fromisoformat(ts[:10])
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        day, week, month = _period_starts(dt)
+        model = r["model"] or ""
+        provider = r["provider"] or ""
+        for granularity, period_start in zip(_ROLLUP_GRANULARITIES, (day, week, month)):
+            key = (granularity, period_start, model, provider)
+            bucket = agg.get(key)
+            if bucket is None:
+                bucket = [0.0, 0.0, 0.0, 0]
+                agg[key] = bucket
+            bucket[0] += r["tokens_in"] or 0
+            bucket[1] += r["tokens_out"] or 0
+            bucket[2] += r["cost_usd"] or 0.0
+            bucket[3] += 1
+
+    return [
+        (g, p, m, pr, int(tin), int(tout), cost, int(calls))
+        for (g, p, m, pr), (tin, tout, cost, calls) in agg.items()
+    ]
+
+
+def upsert_rollups(session_id: str) -> None:
+    """Fold one finished session into the tiered rollup tables.
+
+    Called from ``end_run``. The session's prior contribution is *retracted*
+    from the shared rollup tables, then its freshly-computed contribution is
+    written to ``rollup_contrib`` (replacing any stale rows for this session)
+    and re-applied. This makes folding fully idempotent at the session level:
+    re-ending a session replaces rather than re-adds its numbers, and
+    ``session_count`` stays equal to the number of distinct sessions per bucket.
+    """
+    conn = _get_conn()
+    # Retract whatever this session previously contributed so a re-end does not
+    # double-count. Safe no-op the first time (no applied rows yet).
+    _retract_session_rollups(session_id)
+
+    contrib = _compute_session_contrib(session_id)
+    if not contrib:
+        # No calls: ensure the session holds no applied contribution.
+        conn.execute(
+            "UPDATE rollup_contrib SET status = 'stale' WHERE session_id = ?",
+            (session_id,),
+        )
+        return
+
+    # Replace the session's contribution wholesale.
+    conn.execute("DELETE FROM rollup_contrib WHERE session_id = ?", (session_id,))
+    conn.executemany(
+        """
+        INSERT INTO rollup_contrib
+            (session_id, granularity, period_start, model, provider,
+             tokens_in, tokens_out, cost_usd, api_calls, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'applied')
+        """,
+        [(session_id, *c) for c in contrib],
+    )
+    _apply_session_rollups(session_id)
+
+
+def _retract_session_rollups(session_id: str) -> None:
+    """Subtract a session's currently-applied contribution from the shared
+    rollup tables. Called before re-applying so a re-``end_run`` replaces rather
+    than re-adds. Rows that reach zero are deleted; ``session_count`` drops by 1.
+    """
+    conn = _get_conn()
+    rows = conn.execute(
+        """
+        SELECT granularity, period_start, model, provider,
+               tokens_in, tokens_out, cost_usd, api_calls
+        FROM rollup_contrib
+        WHERE session_id = ? AND status = 'applied'
+        """,
+        (session_id,),
+    ).fetchall()
+    for r in rows:
+        table = _ROLLUP_TABLES[_ROLLUP_GRANULARITIES.index(r["granularity"])]
+        # session_count guard: only assert removal when this session is the only
+        # contributor to the bucket.
+        conn.execute(
+            f"""
+            UPDATE {table}
+            SET tokens_in     = tokens_in     - ?,
+                tokens_out    = tokens_out    - ?,
+                cost_usd      = cost_usd      - ?,
+                api_calls     = api_calls     - ?,
+                session_count = session_count - 1
+            WHERE period_start = ? AND model = ? AND provider = ?
+            """,
+            (
+                r["tokens_in"],
+                r["tokens_out"],
+                r["cost_usd"],
+                r["api_calls"],
+                r["period_start"],
+                r["model"],
+                r["provider"],
+            ),
+        )
+        conn.execute(
+            f"""
+            DELETE FROM {table}
+            WHERE period_start = ? AND model = ? AND provider = ?
+              AND tokens_in <= 0 AND tokens_out <= 0 AND api_calls <= 0
+              AND session_count <= 0
+            """,
+            (r["period_start"], r["model"], r["provider"]),
+        )
+
+
+def _apply_session_rollups(session_id: str) -> None:
+    """Add a session's ``rollup_contrib`` rows to the shared rollup tables.
+
+    Only ``status = 'applied'`` contributions count. ``session_count`` is added
+    exactly once per (period, model, provider) bucket the session now touches
+    (``_retract_session_rollups`` already removed the previous +1, so this is
+    the only one).
+    """
+    conn = _get_conn()
+    rows = conn.execute(
+        """
+        SELECT granularity, period_start, model, provider,
+               tokens_in, tokens_out, cost_usd, api_calls
+        FROM rollup_contrib
+        WHERE session_id = ? AND status = 'applied'
+        """,
+        (session_id,),
+    ).fetchall()
+    if not rows:
+        return
+
+    for r in rows:
+        table = _ROLLUP_TABLES[_ROLLUP_GRANULARITIES.index(r["granularity"])]
+        conn.execute(
+            f"""
+            INSERT INTO {table}
+                (period_start, model, provider,
+                 tokens_in, tokens_out, cost_usd, api_calls, tool_calls, session_count)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 0, 1)
+            ON CONFLICT(period_start, model, provider) DO UPDATE SET
+                tokens_in     = {table}.tokens_in     + excluded.tokens_in,
+                tokens_out    = {table}.tokens_out    + excluded.tokens_out,
+                cost_usd      = {table}.cost_usd      + excluded.cost_usd,
+                api_calls     = {table}.api_calls     + excluded.api_calls,
+                session_count = {table}.session_count + 1
+            """,
+            (
+                r["period_start"],
+                r["model"],
+                r["provider"],
+                r["tokens_in"],
+                r["tokens_out"],
+                r["cost_usd"],
+                r["api_calls"],
+            ),
+        )
+
+
+def compact_rollups(since_iso: str | None = None) -> dict[str, int]:
+    """Periodic compaction: rebuild the rollup tables from the canonical
+    ``llm_calls`` source via ``rollup_contrib``.
+
+    Idempotent and safe to run on a schedule (e.g. a maintenance cron). When
+    *since_iso* is given, only calls with ``ts >= since_iso`` are rescanned;
+    otherwise the whole table is recomputed. ``session_count`` is derived from
+    the number of distinct sessions in each bucket, so re-running never
+    double-counts sessions.
+
+    Returns:
+        dict with keys ``daily``, ``weekly``, ``monthly`` (rows written).
+    """
+    conn = _get_conn()
+    call_where = "WHERE ts >= ?" if since_iso else ""
+    call_params = (since_iso,) if since_iso else ()
+
+    # 1) Recompute rollup_contrib for the affected calls from llm_calls.
+    contrib_rows: list[tuple] = []
+    for granularity, period_expr in (
+        ("daily", "substr(ts, 1, 10)"),
+        ("weekly", "date(ts, 'weekday 1', '-7 days')"),
+        ("monthly", "substr(ts, 1, 7) || '-01'"),
+    ):
+        data = conn.execute(
+            f"""
+            SELECT session_id,
+                   {period_expr}              AS period_start,
+                   COALESCE(model, '')        AS model,
+                   COALESCE(provider, '')     AS provider,
+                   COALESCE(SUM(tokens_in), 0)   AS tokens_in,
+                   COALESCE(SUM(tokens_out), 0)  AS tokens_out,
+                   ROUND(SUM(cost_usd), 6)       AS cost_usd,
+                   COUNT(*)                    AS api_calls
+            FROM llm_calls
+            {call_where}
+            GROUP BY session_id, period_start, model, provider
+            """,
+            call_params,
+        ).fetchall()
+        for r in data:
+            contrib_rows.append(
+                (
+                    r["session_id"],
+                    granularity,
+                    r["period_start"],
+                    r["model"],
+                    r["provider"],
+                    int(r["tokens_in"]),
+                    int(r["tokens_out"]),
+                    r["cost_usd"],
+                    int(r["api_calls"]),
+                )
+            )
+
+    if since_iso:
+        # Delete only the contrib keys we are about to rewrite (per session).
+        affected_sessions = {row[0] for row in contrib_rows}
+        for sid in affected_sessions:
+            conn.execute("DELETE FROM rollup_contrib WHERE session_id = ?", (sid,))
+    else:
+        conn.execute("DELETE FROM rollup_contrib")
+
+    conn.executemany(
+        """
+        INSERT INTO rollup_contrib
+            (session_id, granularity, period_start, model, provider,
+             tokens_in, tokens_out, cost_usd, api_calls, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'applied')
+        """,
+        contrib_rows,
+    )
+
+    # 2) Rebuild the rollup tables from the (now-correct) contributions.
+    written: dict[str, int] = {}
+    for table, granularity in zip(_ROLLUP_TABLES, _ROLLUP_GRANULARITIES):
+        data = conn.execute(
+            """
+            SELECT period_start, model, provider,
+                   SUM(tokens_in)            AS tokens_in,
+                   SUM(tokens_out)           AS tokens_out,
+                   ROUND(SUM(cost_usd), 6)   AS cost_usd,
+                   SUM(api_calls)            AS api_calls,
+                   COUNT(DISTINCT session_id) AS session_count
+            FROM rollup_contrib
+            WHERE granularity = ? AND status = 'applied'
+            GROUP BY period_start, model, provider
+            """,
+            (granularity,),
+        ).fetchall()
+
+        # Delete only the buckets touched by the rewritten contributions.
+        affected = {(r["period_start"], r["model"], r["provider"]) for r in data}
+        if since_iso:
+            for period_start, model, provider in affected:
+                conn.execute(
+                    f"DELETE FROM {table} WHERE period_start = ? AND model = ? AND provider = ?",
+                    (period_start, model, provider),
+                )
+        else:
+            conn.execute(f"DELETE FROM {table}")
+
+        conn.executemany(
+            f"""
+            INSERT INTO {table}
+                (period_start, model, provider,
+                 tokens_in, tokens_out, cost_usd, api_calls, tool_calls, session_count)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)
+            """,
+            [
+                (
+                    r["period_start"],
+                    r["model"],
+                    r["provider"],
+                    int(r["tokens_in"]),
+                    int(r["tokens_out"]),
+                    r["cost_usd"],
+                    int(r["api_calls"]),
+                    int(r["session_count"]),
+                )
+                for r in data
+            ],
+        )
+        written[granularity] = len(data)
+    return written
 
 
 def record_llm_call(

--- a/db.py
+++ b/db.py
@@ -1017,6 +1017,106 @@ def auto_prune_rollups(retention: dict[str, int] | None = None) -> dict[str, int
     return pruned
 
 
+# ---------------------------------------------------------------------------
+# Rollup queries for /stats --granularity (issue #157, M4)
+# ---------------------------------------------------------------------------
+
+_VALID_GRANULARITIES = ("day", "week", "month")
+
+
+def _normalize_granularity(granularity: str | None) -> str:
+    """Coerce a CLI granularity token to one of the rollup tiers.
+
+    Accepts 'day'/'daily', 'week'/'weekly', 'month'/'monthly' (case
+    insensitive). Returns the canonical rollup granularity key ('daily',
+    'weekly', 'monthly'). Raises ValueError on anything else so the CLI can
+    surface a clean usage error.
+    """
+    g = (granularity or "day").strip().lower()
+    if g in ("day", "daily"):
+        return "daily"
+    if g in ("week", "weekly"):
+        return "weekly"
+    if g in ("month", "monthly"):
+        return "monthly"
+    raise ValueError(f"invalid granularity: {granularity!r} (expected one of: day, week, month)")
+
+
+def query_rollups(
+    granularity: str = "daily",
+    *,
+    model: str | None = None,
+    provider: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> list[dict[str, Any]]:
+    """Read the pre-aggregated tiered rollup tables for /stats --granularity.
+
+    This is the read path that Milestone 4 hangs off of: instead of scanning
+    ``llm_calls``, it reads the bucketed ``daily_rollups`` / ``weekly_rollups`` /
+    ``monthly_rollups`` tables produced by ``upsert_rollups`` / ``compact_rollups``.
+
+    Args:
+        granularity: one of 'day' | 'week' | 'month' (normalized via
+            ``_normalize_granularity``).
+        model: optional exact model filter (applied against the rollup's
+            ``model`` column, which stores the value verbatim from llm_calls).
+        provider: optional exact provider filter.
+        date_from / date_to: optional ISO-8601 bounds on ``period_start``.
+            ``date_from`` is inclusive, ``date_to`` is exclusive. When omitted
+            the full stored history for the tier is returned.
+
+    Returns:
+        A list of per-(period, model, provider) bucket rows ordered by
+        ``period_start`` ASC, then ``provider`` ASC, then ``model`` ASC:
+            period_start, model, provider, tokens_in, tokens_out, cost_usd,
+            api_calls, tool_calls, session_count
+    """
+    gran = _normalize_granularity(granularity)
+    table = _ROLLUP_TABLES[_ROLLUP_GRANULARITIES.index(gran)]
+    conn = _get_conn()
+
+    where = []
+    params: list[Any] = []
+    if model is not None:
+        where.append("model = ?")
+        params.append(model)
+    if provider is not None:
+        where.append("provider = ?")
+        params.append(provider)
+    if date_from is not None:
+        where.append("period_start >= ?")
+        params.append(date_from[:10])
+    if date_to is not None:
+        # period_start is a date string ('YYYY-MM-DD' / 'YYYY-MM-01'), so a
+        # strict string compare against the date portion of date_to is correct.
+        where.append("period_start < ?")
+        params.append(date_to[:10])
+
+    where_sql = ("WHERE " + " AND ".join(where)) if where else ""
+
+    rows = conn.execute(
+        f"""
+        SELECT
+            period_start,
+            model,
+            provider,
+            SUM(tokens_in)  AS tokens_in,
+            SUM(tokens_out) AS tokens_out,
+            ROUND(SUM(cost_usd), 6) AS cost_usd,
+            SUM(api_calls)  AS api_calls,
+            SUM(tool_calls) AS tool_calls,
+            SUM(session_count) AS session_count
+        FROM {table}
+        {where_sql}
+        GROUP BY period_start, model, provider
+        ORDER BY period_start ASC, provider ASC, model ASC
+        """,
+        params,
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
 def record_llm_call(
     session_id: str,
     ts: str,

--- a/db.py
+++ b/db.py
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 9
+_SCHEMA_VERSION = 10
 _local = threading.local()
 
 # Serializes first-time schema setup across threads. Each thread opens its own
@@ -166,6 +166,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _migrate_v7(conn)
     _migrate_v8(conn)
     _migrate_v9(conn)
+    _migrate_v10(conn)
 
 
 def _migrate_v2(conn: sqlite3.Connection) -> None:
@@ -388,6 +389,72 @@ def _migrate_v9(conn: sqlite3.Connection) -> None:
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (9, ?)",
+        (_utcnow(),),
+    )
+
+
+def _migrate_v10(conn: sqlite3.Connection) -> None:
+    """Add v10 schema: tiered storage rollup tables for daily, weekly, and
+    monthly aggregation of token usage, cost, API calls, and tool calls.
+
+    These tables are populated by upsert_rollups() at session end and by
+    periodic compaction. They power bucketed analytics queries (/stats with
+    --granularity) without expensive full-table scans over llm_calls.
+    """
+    cur = conn.execute("SELECT version FROM schema_version WHERE version = 10")
+    if cur.fetchone() is not None:
+        return
+
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS daily_rollups (
+            period_start TEXT NOT NULL,
+            model        TEXT NOT NULL DEFAULT '',
+            provider     TEXT NOT NULL DEFAULT '',
+            tokens_in    INTEGER DEFAULT 0,
+            tokens_out   INTEGER DEFAULT 0,
+            cost_usd     REAL DEFAULT 0.0,
+            api_calls    INTEGER DEFAULT 0,
+            tool_calls   INTEGER DEFAULT 0,
+            session_count INTEGER DEFAULT 0,
+            PRIMARY KEY (period_start, model, provider)
+        );
+
+        CREATE TABLE IF NOT EXISTS weekly_rollups (
+            period_start TEXT NOT NULL,
+            model        TEXT NOT NULL DEFAULT '',
+            provider     TEXT NOT NULL DEFAULT '',
+            tokens_in    INTEGER DEFAULT 0,
+            tokens_out   INTEGER DEFAULT 0,
+            cost_usd     REAL DEFAULT 0.0,
+            api_calls    INTEGER DEFAULT 0,
+            tool_calls   INTEGER DEFAULT 0,
+            session_count INTEGER DEFAULT 0,
+            PRIMARY KEY (period_start, model, provider)
+        );
+
+        CREATE TABLE IF NOT EXISTS monthly_rollups (
+            period_start TEXT NOT NULL,
+            model        TEXT NOT NULL DEFAULT '',
+            provider     TEXT NOT NULL DEFAULT '',
+            tokens_in    INTEGER DEFAULT 0,
+            tokens_out   INTEGER DEFAULT 0,
+            cost_usd     REAL DEFAULT 0.0,
+            api_calls    INTEGER DEFAULT 0,
+            tool_calls   INTEGER DEFAULT 0,
+            session_count INTEGER DEFAULT 0,
+            PRIMARY KEY (period_start, model, provider)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_daily_period
+            ON daily_rollups(period_start);
+        CREATE INDEX IF NOT EXISTS idx_weekly_period
+            ON weekly_rollups(period_start);
+        CREATE INDEX IF NOT EXISTS idx_monthly_period
+            ON monthly_rollups(period_start);
+    """)
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (10, ?)",
         (_utcnow(),),
     )
 

--- a/db.py
+++ b/db.py
@@ -927,6 +927,96 @@ def compact_rollups(since_iso: str | None = None) -> dict[str, int]:
     return written
 
 
+# ---------------------------------------------------------------------------
+# Rollup retention + auto-prune (issue #157, M3)
+# ---------------------------------------------------------------------------
+
+# Default per-tier retention windows (days). A tier may be disabled by setting
+# its retention to 0 or a negative value in retention.yaml.
+_DEFAULT_RETENTION_DAYS = {"daily": 90, "weekly": 365, "monthly": 1825}
+
+
+def _retention_path() -> Path:
+    hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    return hermes_home / "telemetry" / "retention.yaml"
+
+
+def _load_retention_config() -> dict[str, int]:
+    """Load per-tier ``retention_days`` from ``retention.yaml``.
+
+    Returns a mapping granularity -> retention window in days. Tiers missing
+    from the file fall back to ``_DEFAULT_RETENTION_DAYS``; a missing,
+    unreadable, or ill-formed file yields the defaults wholesale. A value <= 0
+    disables pruning for that tier (its buckets are kept forever).
+    """
+    defaults = dict(_DEFAULT_RETENTION_DAYS)
+    path = _retention_path()
+    if not path.exists():
+        return defaults
+    try:
+        import yaml
+    except ImportError:
+        return defaults
+    try:
+        cfg = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001 - never let a bad config crash pruning
+        logger.error("Failed to load %s: %s", path, exc)
+        return defaults
+    raw = (cfg.get("retention_days", {}) or {}) if isinstance(cfg, dict) else {}
+    result = dict(defaults)
+    for granularity in _ROLLUP_GRANULARITIES:
+        # An explicit value in the file wins (including 0 / negative, which
+        # disables pruning for that tier). Only an ABSENT key falls back to the
+        # built-in default, so a deliberate "keep forever" (0) is honored.
+        if granularity in raw:
+            val = raw[granularity]
+            if isinstance(val, int):
+                result[granularity] = val
+    return result
+
+
+def auto_prune_rollups(retention: dict[str, int] | None = None) -> dict[str, int]:
+    """Delete rollup buckets (and their ``rollup_contrib`` source rows) older
+    than the per-tier retention window.
+
+    *retention* maps granularity -> retention days. When omitted it is loaded
+    from ``_load_retention_config()``. A tier with retention <= 0 is skipped
+    (kept forever). Only whole buckets whose ``period_start`` is strictly
+    older than ``today - retention_days`` are removed, so in-window data is
+    never touched. Pruning the matching ``rollup_contrib`` rows ensures a later
+    ``compact_rollups()`` rebuild cannot resurrect the dropped bucket.
+
+    Safe to run on a schedule (e.g. a maintenance cron) and idempotent.
+
+    Returns:
+        dict granularity -> number of bucket rows pruned from that tier's table.
+    """
+    if retention is None:
+        retention = _load_retention_config()
+    conn = _get_conn()
+    today = datetime.now(timezone.utc).date()
+    pruned: dict[str, int] = {}
+    for granularity, table in zip(_ROLLUP_GRANULARITIES, _ROLLUP_TABLES):
+        days = retention.get(granularity, 0)
+        if not isinstance(days, int) or days <= 0:
+            pruned[granularity] = 0
+            continue
+        cutoff = (today - _timedelta(days=days)).isoformat()
+        # Prune the shared, derived rollup table for this tier.
+        cur = conn.execute(
+            f"DELETE FROM {table} WHERE period_start < ?",
+            (cutoff,),
+        )
+        pruned[granularity] = cur.rowcount
+        # Prune the matching source-of-truth contribution rows so a later
+        # compact_rollups() rebuild cannot resurrect the deleted bucket.
+        conn.execute(
+            "DELETE FROM rollup_contrib WHERE granularity = ? AND period_start < ?",
+            (granularity, cutoff),
+        )
+    return pruned
+
+
 def record_llm_call(
     session_id: str,
     ts: str,

--- a/telemetry_cli.py
+++ b/telemetry_cli.py
@@ -4,8 +4,10 @@ import argparse
 import json
 import sys
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from . import db, stats
+from .stats import _date_range_label, _fmt_cost, _fmt_int
 
 _STATS_WINDOW_HOURS: dict[str, int] = {
     "today": 24,
@@ -123,6 +125,26 @@ def _build_parser_into(sub) -> None:
         help=f"One of: {', '.join(_STATS_CHOICES)} (default: today)",
     )
     sp.add_argument(
+        "--granularity",
+        dest="granularity",
+        choices=["day", "week", "month"],
+        default=None,
+        help="Bucket the rollup tables by day/week/month (reads pre-aggregated tiers). "
+        "Implies a rollup query instead of a session scan.",
+    )
+    sp.add_argument(
+        "--model",
+        dest="filter_model",
+        default=None,
+        help="Filter rollup buckets to an exact model name (use with --granularity).",
+    )
+    sp.add_argument(
+        "--provider",
+        dest="filter_provider",
+        default=None,
+        help="Filter rollup buckets to an exact provider (use with --granularity).",
+    )
+    sp.add_argument(
         "--from",
         dest="date_from",
         type=_parse_date,
@@ -181,10 +203,70 @@ def _resolve_date_range(args: argparse.Namespace) -> tuple[str | None, str | Non
 def _handle_stats(args: argparse.Namespace) -> None:
     date_from, date_to = _resolve_date_range(args)
 
+    # --granularity switches /stats onto the pre-aggregated rollup tiers
+    # (M4, #157) instead of scanning runs/llm_calls. When no explicit --from/
+    # --to is given, the rollup query spans the full stored history for the
+    # tier (the rollup tables are the long-term store; a 24h subcommand window
+    # would hide older buckets). Explicit date flags still bound the query.
+    if args.granularity is not None:
+        uses_explicit_range = args.date_from is not None or args.date_to is not None
+        rf = date_from if uses_explicit_range else None
+        rt = date_to if uses_explicit_range else None
+        rows = db.query_rollups(
+            args.granularity,
+            model=args.filter_model,
+            provider=args.filter_provider,
+            date_from=rf,
+            date_to=rt,
+        )
+        if args.json:
+            print(json.dumps(rows, default=str))
+        else:
+            print(_rollups_text(args.granularity, rows, rf, rt))
+        return
+
     if args.json:
         _stats_json(args.subcommand, date_from, date_to)
     else:
         _stats_text(args.subcommand, date_from, date_to)
+
+
+def _rollups_text(
+    granularity: str,
+    rows: list[dict[str, Any]],
+    date_from: str | None,
+    date_to: str | None,
+) -> str:
+    """Render a rollup-tier query (M4, #157) as a bucketed table."""
+    gran = granularity
+    label = _date_range_label(date_from, date_to) if (date_from or date_to) else "all time"
+    if not rows:
+        return (
+            f"hermes-telemetry — rollups ({gran}, {label})\n"
+            "No aggregated data in this window.\n"
+            "\n"
+            "Run a session (so end_run folds it into the rollup tiers) and retry."
+        )
+
+    lines = [
+        f"hermes-telemetry — rollups ({gran}, {label})",
+        "=" * 92,
+        f"  {'Period':<12} {'Provider':<18} {'Model':<34} "
+        f"{'Sess':>5} {'Calls':>6} {'Tok-in':>9} {'Cost':>12}",
+        "  " + "-" * 90,
+    ]
+    for r in rows:
+        period = (r.get("period_start") or "")[:12]
+        prov = (r.get("provider") or "(unknown)")[:18]
+        model = (r.get("model") or "(unknown)")[:34]
+        sess = _fmt_int(r.get("session_count"))
+        calls = _fmt_int(r.get("api_calls"))
+        tin = _fmt_int(r.get("tokens_in"))
+        cost = _fmt_cost(r.get("cost_usd"))
+        lines.append(
+            f"  {period:<12} {prov:<18} {model:<34} {sess:>5} {calls:>6} {tin:>9} {cost:>12}"
+        )
+    return "\n".join(lines)
 
 
 def _stats_text(subcommand: str, date_from: str | None, date_to: str | None) -> None:

--- a/tests/test_dashboard_plugin_api.py
+++ b/tests/test_dashboard_plugin_api.py
@@ -290,3 +290,100 @@ def test_db_connection_is_read_only(plugin_api):
     conn = plugin_api._conn()
     with pytest.raises(sqlite3.OperationalError):
         conn.execute("INSERT INTO runs (session_id, started_at) VALUES ('x', 'y')")
+
+
+def test_rollups_endpoint_reads_tiered_tables(plugin_api):
+    """The /rollups endpoint returns bucketed history from the tiered tables.
+
+    Seeds a session through the runtime API, folds it into the rollup tables
+    via ``upsert_rollups``, then asserts /rollups surfaces the daily bucket
+    with the expected cost aggregation.
+    """
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).isoformat()
+    _seed(
+        rows_runs=[{"session_id": "r1", "model": "gpt-4o", "platform": "cli"}],
+        rows_llm=[
+            {
+                "session_id": "r1",
+                "ts": now,
+                "model": "gpt-4o",
+                "provider": "openai",
+                "tokens_in": 200,
+                "tokens_out": 100,
+                "cost_usd": 0.005,
+                "latency_ms": 200,
+            }
+        ],
+    )
+    import db as runtime_db
+
+    runtime_db.upsert_rollups("r1")
+
+    daily = plugin_api.rollups(granularity="day")
+    assert daily["granularity"] == "day"
+    assert daily["bucket_count"] == 1
+    bucket = daily["rows"][0]
+    assert bucket["model"] == "gpt-4o"
+    assert bucket["provider"] == "openai"
+    assert bucket["session_count"] == 1
+    assert abs(bucket["cost_usd"] - 0.005) < 1e-9
+    assert abs(daily["total_cost_usd"] - 0.005) < 1e-9
+
+
+def test_rollups_endpoint_tier_aware_filters(plugin_api):
+    """model/provider params narrow the rollup buckets (tier-aware query)."""
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).isoformat()
+    _seed(
+        rows_runs=[
+            {"session_id": "r1", "model": "gpt-4o", "platform": "cli"},
+            {"session_id": "r2", "model": "claude-sonnet-4-6", "platform": "cli"},
+        ],
+        rows_llm=[
+            {
+                "session_id": "r1",
+                "ts": now,
+                "model": "gpt-4o",
+                "provider": "openai",
+                "tokens_in": 200,
+                "tokens_out": 100,
+                "cost_usd": 0.005,
+                "latency_ms": 200,
+            },
+            {
+                "session_id": "r2",
+                "ts": now,
+                "model": "claude-sonnet-4-6",
+                "provider": "anthropic",
+                "tokens_in": 100,
+                "tokens_out": 50,
+                "cost_usd": 0.001,
+                "latency_ms": 150,
+            },
+        ],
+    )
+    import db as runtime_db
+
+    runtime_db.upsert_rollups("r1")
+    runtime_db.upsert_rollups("r2")
+
+    filtered = plugin_api.rollups(granularity="day", model="gpt-4o")
+    assert filtered["model"] == "gpt-4o"
+    assert filtered["bucket_count"] == 1
+    assert filtered["rows"][0]["provider"] == "openai"
+
+    by_provider = plugin_api.rollups(granularity="day", provider="anthropic")
+    assert by_provider["provider"] == "anthropic"
+    assert by_provider["bucket_count"] == 1
+    assert by_provider["rows"][0]["model"] == "claude-sonnet-4-6"
+
+
+def test_rollups_endpoint_unknown_granularity_defaults_to_day(plugin_api):
+    """An unrecognized granularity label must not crash and must default to day."""
+    out = plugin_api.rollups(granularity="yearly")
+    assert out["granularity"] == "day"
+    assert out["bucket_count"] == 0
+    assert out["rows"] == []

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -48,6 +48,99 @@ def test_schema_creates_tables():
     assert "schema_version" in tables
 
 
+def test_migrate_v10_creates_rollup_tables():
+    """Verify that v10 migration creates daily, weekly, and monthly rollup
+    tables with correct columns and indexes."""
+    conn = db._get_conn()
+
+    # The migration is idempotent — calling _ensure_schema again is harmless
+    db._ensure_schema(conn)
+
+    tables = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+    assert "daily_rollups" in tables
+    assert "weekly_rollups" in tables
+    assert "monthly_rollups" in tables
+
+    # Verify schema version 10 marker exists
+    row = conn.execute(
+        "SELECT version FROM schema_version WHERE version = 10"
+    ).fetchone()
+    assert row is not None, "v10 migration must record schema_version = 10"
+
+    # Verify expected columns on daily_rollups (same schema for all three)
+    expected_cols = {
+        "period_start",
+        "model",
+        "provider",
+        "tokens_in",
+        "tokens_out",
+        "cost_usd",
+        "api_calls",
+        "tool_calls",
+        "session_count",
+    }
+    for table_name in ("daily_rollups", "weekly_rollups", "monthly_rollups"):
+        cols = {
+            r[0]
+            for r in conn.execute(
+                f"SELECT name FROM pragma_table_info('{table_name}')"
+            ).fetchall()
+        }
+        assert expected_cols.issubset(
+            cols
+        ), f"{table_name} missing columns: {expected_cols - cols}"
+
+    # Verify indexes exist
+    indexes = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index'"
+        ).fetchall()
+    }
+    assert "idx_daily_period" in indexes
+    assert "idx_weekly_period" in indexes
+    assert "idx_monthly_period" in indexes
+
+
+def test_migrate_v10_is_idempotent():
+    """Running _ensure_schema twice must not error and must keep the same
+    table state."""
+    conn = db._get_conn()
+
+    # First run — tables created
+    db._ensure_schema(conn)
+    tables_before = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+
+    # Second run — must be a no-op
+    db._ensure_schema(conn)
+    tables_after = {
+        r[0]
+        for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    }
+
+    assert tables_before == tables_after, (
+        "second _ensure_schema must not alter table set"
+    )
+
+    # Schema version must still be 10 exactly once
+    rows = conn.execute(
+        "SELECT version FROM schema_version WHERE version = 10"
+    ).fetchall()
+    assert len(rows) == 1, "schema_version 10 must appear exactly once"
+
+
 def test_migrate_v9_repairs_missing_column_from_wedged_v7(monkeypatch):
     """Regression: if an earlier process wedged the DB by marking
     schema_version=7 without actually adding ``llm_calls.provider_assumed``

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1391,3 +1391,123 @@ def test_compact_rollups_partial_since_iso():
     assert june is not None
     assert june["api_calls"] == 1
     assert june["session_count"] == 1
+
+
+def test_load_retention_config_defaults_when_missing(tmp_path, monkeypatch):
+    """With no retention.yaml, _load_retention_config returns the built-in
+    defaults for all three tiers."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cfg = db._load_retention_config()
+    assert cfg == {"daily": 90, "weekly": 365, "monthly": 1825}
+
+
+def test_load_retention_config_overrides_and_disables(tmp_path, monkeypatch):
+    """retention.yaml overrides per-tier windows; a <=0 value disables a tier
+    (kept forever). Unknown tiers fall back to the default."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "telemetry").mkdir()
+    (tmp_path / "telemetry" / "retention.yaml").write_text(
+        "retention_days:\n  daily: 30\n  weekly: 0\n  monthly: -1\n",
+        encoding="utf-8",
+    )
+    cfg = db._load_retention_config()
+    assert cfg["daily"] == 30
+    # 0 / negative => disabled (kept forever), not the default.
+    assert cfg["weekly"] == 0
+    assert cfg["monthly"] == -1
+
+
+def test_auto_prune_rollups_removes_expired_buckets(tmp_path, monkeypatch):
+    """auto_prune_rollups drops whole buckets strictly older than the retention
+    cutoff and keeps in-window buckets, per tier."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Build buckets across tiers at well-separated dates.
+    old = "2020-01-15T09:00:00+00:00"  # far outside any retention window
+    new = "2026-06-10T09:00:00+00:00"
+    _seed_calls("prune-old", [(old, "gpt-4o", "openai", 100, 100, 0.01)])
+    db.end_run("prune-old", status="ok")
+    _seed_calls("prune-new", [(new, "gpt-4o", "openai", 200, 200, 0.02)])
+    db.end_run("prune-new", status="ok")
+
+    # Daily retention = 90 days, weekly = 365, monthly = 1825. The 2020 data is
+    # older than all three cutoffs; the 2026 data is inside all three.
+    pruned = db.auto_prune_rollups(retention={"daily": 90, "weekly": 365, "monthly": 1825})
+    assert pruned["daily"] == 1
+    assert pruned["weekly"] == 1
+    assert pruned["monthly"] == 1
+
+    conn = db._get_conn()
+    # Old 2020 bucket gone from daily; new mid-2026 bucket remains.
+    assert (
+        conn.execute("SELECT 1 FROM daily_rollups WHERE period_start=?", ("2020-01-15",)).fetchone()
+        is None
+    )
+    assert (
+        conn.execute("SELECT 1 FROM daily_rollups WHERE period_start=?", ("2026-06-10",)).fetchone()
+        is not None
+    )
+
+
+def test_auto_prune_rollups_skips_disabled_tier(tmp_path, monkeypatch):
+    """A tier with retention <= 0 is never pruned, even when its buckets are
+    ancient."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    old = "2020-01-15T09:00:00+00:00"
+    _seed_calls("prune-disabled", [(old, "gpt-4o", "openai", 100, 100, 0.01)])
+    db.end_run("prune-disabled", status="ok")
+
+    # Disable daily pruning entirely.
+    pruned = db.auto_prune_rollups(retention={"daily": 0, "weekly": 1, "monthly": 1})
+    assert pruned["daily"] == 0  # skipped
+    conn = db._get_conn()
+    assert (
+        conn.execute("SELECT 1 FROM daily_rollups WHERE period_start=?", ("2020-01-15",)).fetchone()
+        is not None
+    )
+
+
+def test_auto_prune_rollups_also_clears_contrib(tmp_path, monkeypatch):
+    """Pruning must remove the matching rollup_contrib source rows so a later
+    compact_rollups() cannot resurrect the dropped bucket."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    old = "2020-01-15T09:00:00+00:00"
+    new = "2026-06-10T09:00:00+00:00"
+    _seed_calls("contrib-old", [(old, "gpt-4o", "openai", 100, 100, 0.01)])
+    db.end_run("contrib-old", status="ok")
+    _seed_calls("contrib-new", [(new, "gpt-4o", "openai", 200, 200, 0.02)])
+    db.end_run("contrib-new", status="ok")
+
+    db.auto_prune_rollups(retention={"daily": 90, "weekly": 365, "monthly": 1825})
+
+    conn = db._get_conn()
+    # The old contribution row is gone.
+    contrib_old = conn.execute(
+        "SELECT 1 FROM rollup_contrib WHERE session_id=? AND granularity=?",
+        ("contrib-old", "daily"),
+    ).fetchone()
+    assert contrib_old is None
+    # The new contribution row survives.
+    contrib_new = conn.execute(
+        "SELECT 1 FROM rollup_contrib WHERE session_id=? AND granularity=?",
+        ("contrib-new", "daily"),
+    ).fetchone()
+    assert contrib_new is not None
+
+    # The old daily bucket is gone from the derived table.
+    assert (
+        conn.execute("SELECT 1 FROM daily_rollups WHERE period_start=?", ("2020-01-15",)).fetchone()
+        is None
+    )
+    # The new daily bucket remains.
+    assert (
+        conn.execute("SELECT 1 FROM daily_rollups WHERE period_start=?", ("2026-06-10",)).fetchone()
+        is not None
+    )
+
+    # NOTE on design: the rollup tiers are a derived aggregate whose canonical
+    # source is llm_calls. auto_prune_rollups removes the expired bucket AND its
+    # rollup_contrib row, so the bucket stays gone until something rescans the
+    # raw calls. A full compact_rollups() (a repair/rebuild operation, not the
+    # day-to-day maintenance step) re-derives rollup_contrib from llm_calls and
+    # would re-create the bucket. Routine retention is therefore driven by
+    # auto_prune_rollups, scheduled on its own (without a full compact).

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1393,6 +1393,100 @@ def test_compact_rollups_partial_since_iso():
     assert june["session_count"] == 1
 
 
+def test_query_rollups_day_week_month_tiers():
+    """query_rollups reads the right pre-aggregated tier per granularity."""
+    ts = "2026-06-10T11:00:00+00:00"
+    _seed_calls("qr-sess", [(ts, "gpt-4o", "openai", 1000, 500, 0.03)])
+    db.end_run("qr-sess", status="ok")
+
+    daily = db.query_rollups("day")
+    assert len(daily) == 1
+    assert daily[0]["period_start"] == "2026-06-10"
+    assert daily[0]["api_calls"] == 1
+
+    weekly = db.query_rollups("week")
+    assert len(weekly) == 1
+    assert weekly[0]["period_start"] == "2026-06-08"  # Monday of that week
+
+    monthly = db.query_rollups("month")
+    assert len(monthly) == 1
+    assert monthly[0]["period_start"] == "2026-06-01"
+
+
+def test_query_rollups_accepts_daily_weekly_monthly_aliases():
+    """_normalize_granularity accepts the plural aliases used by the CLI."""
+    ts = "2026-06-10T11:00:00+00:00"
+    _seed_calls("qr-alias", [(ts, "gpt-4o", "openai", 1000, 500, 0.03)])
+    db.end_run("qr-alias", status="ok")
+
+    for alias in ("day", "daily", "week", "weekly", "month", "monthly"):
+        rows = db.query_rollups(alias)
+        assert len(rows) == 1, alias
+    # Unknown granularity must raise cleanly for the CLI to catch.
+    import pytest as _pytest
+
+    with _pytest.raises(ValueError):
+        db.query_rollups("quarter")
+
+
+def test_query_rollups_model_and_provider_filters():
+    """model/provider filters narrow the rollup buckets exactly."""
+    ts = "2026-06-10T11:00:00+00:00"
+    _seed_calls("qr-a", [(ts, "gpt-4o", "openai", 1000, 500, 0.03)])
+    db.end_run("qr-a", status="ok")
+    _seed_calls("qr-b", [(ts, "claude", "anthropic", 200, 200, 0.02)])
+    db.end_run("qr-b", status="ok")
+
+    all_rows = db.query_rollups("day")
+    assert len(all_rows) == 2
+
+    only_gpt = db.query_rollups("day", model="gpt-4o")
+    assert len(only_gpt) == 1
+    assert only_gpt[0]["provider"] == "openai"
+    assert only_gpt[0]["tokens_in"] == 1000
+
+    only_anthropic = db.query_rollups("day", provider="anthropic")
+    assert len(only_anthropic) == 1
+    assert only_anthropic[0]["model"] == "claude"
+
+    none = db.query_rollups("day", model="does-not-exist")
+    assert none == []
+
+
+def test_query_rollups_date_range_filter():
+    """date_from/date_to bound the rollup query on period_start (inclusive/exclusive)."""
+    old = "2026-05-01T09:00:00+00:00"
+    new = "2026-06-10T09:00:00+00:00"
+    _seed_calls("qr-old", [(old, "gpt-4o", "openai", 100, 100, 0.01)])
+    db.end_run("qr-old", status="ok")
+    _seed_calls("qr-new", [(new, "gpt-4o", "openai", 200, 200, 0.02)])
+    db.end_run("qr-new", status="ok")
+
+    # Only June onward.
+    june_on = db.query_rollups("day", date_from="2026-06-01")
+    assert len(june_on) == 1
+    assert june_on[0]["period_start"] == "2026-06-10"
+
+    # Exclusive upper bound: up to (not including) June 1.
+    before_june = db.query_rollups("day", date_to="2026-06-01")
+    assert len(before_june) == 1
+    assert before_june[0]["period_start"] == "2026-05-01"
+
+
+def test_query_rollups_orders_by_period():
+    """Buckets are returned ordered by period_start ASC."""
+    a = "2026-06-10T09:00:00+00:00"
+    b = "2026-06-11T09:00:00+00:00"
+    _seed_calls("qr-order-a", [(a, "gpt-4o", "openai", 1, 1, 0.01)])
+    db.end_run("qr-order-a", status="ok")
+    _seed_calls("qr-order-b", [(b, "gpt-4o", "openai", 1, 1, 0.01)])
+    db.end_run("qr-order-b", status="ok")
+
+    rows = db.query_rollups("day")
+    periods = [r["period_start"] for r in rows]
+    assert periods == sorted(periods)
+
+
 def test_load_retention_config_defaults_when_missing(tmp_path, monkeypatch):
     """With no retention.yaml, _load_retention_config returns the built-in
     defaults for all three tiers."""

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -57,19 +57,14 @@ def test_migrate_v10_creates_rollup_tables():
     db._ensure_schema(conn)
 
     tables = {
-        r[0]
-        for r in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table'"
-        ).fetchall()
+        r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
     }
     assert "daily_rollups" in tables
     assert "weekly_rollups" in tables
     assert "monthly_rollups" in tables
 
     # Verify schema version 10 marker exists
-    row = conn.execute(
-        "SELECT version FROM schema_version WHERE version = 10"
-    ).fetchone()
+    row = conn.execute("SELECT version FROM schema_version WHERE version = 10").fetchone()
     assert row is not None, "v10 migration must record schema_version = 10"
 
     # Verify expected columns on daily_rollups (same schema for all three)
@@ -87,20 +82,13 @@ def test_migrate_v10_creates_rollup_tables():
     for table_name in ("daily_rollups", "weekly_rollups", "monthly_rollups"):
         cols = {
             r[0]
-            for r in conn.execute(
-                f"SELECT name FROM pragma_table_info('{table_name}')"
-            ).fetchall()
+            for r in conn.execute(f"SELECT name FROM pragma_table_info('{table_name}')").fetchall()
         }
-        assert expected_cols.issubset(
-            cols
-        ), f"{table_name} missing columns: {expected_cols - cols}"
+        assert expected_cols.issubset(cols), f"{table_name} missing columns: {expected_cols - cols}"
 
     # Verify indexes exist
     indexes = {
-        r[0]
-        for r in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='index'"
-        ).fetchall()
+        r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='index'").fetchall()
     }
     assert "idx_daily_period" in indexes
     assert "idx_weekly_period" in indexes
@@ -115,30 +103,58 @@ def test_migrate_v10_is_idempotent():
     # First run — tables created
     db._ensure_schema(conn)
     tables_before = {
-        r[0]
-        for r in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table'"
-        ).fetchall()
+        r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
     }
 
     # Second run — must be a no-op
     db._ensure_schema(conn)
     tables_after = {
-        r[0]
-        for r in conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table'"
-        ).fetchall()
+        r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
     }
 
-    assert tables_before == tables_after, (
-        "second _ensure_schema must not alter table set"
-    )
+    assert tables_before == tables_after, "second _ensure_schema must not alter table set"
 
     # Schema version must still be 10 exactly once
-    rows = conn.execute(
-        "SELECT version FROM schema_version WHERE version = 10"
-    ).fetchall()
+    rows = conn.execute("SELECT version FROM schema_version WHERE version = 10").fetchall()
     assert len(rows) == 1, "schema_version 10 must appear exactly once"
+
+
+def test_migrate_v11_creates_rollup_contrib():
+    """Verify that v11 migration creates the rollup_contrib source-of-truth table
+    with the expected columns, index, and schema_version marker."""
+    conn = db._get_conn()
+    db._ensure_schema(conn)
+
+    tables = {
+        r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    }
+    assert "rollup_contrib" in tables
+
+    expected_cols = {
+        "session_id",
+        "granularity",
+        "period_start",
+        "model",
+        "provider",
+        "tokens_in",
+        "tokens_out",
+        "cost_usd",
+        "api_calls",
+        "status",
+    }
+    cols = {
+        r[0]
+        for r in conn.execute("SELECT name FROM pragma_table_info('rollup_contrib')").fetchall()
+    }
+    assert expected_cols.issubset(cols), f"rollup_contrib missing: {expected_cols - cols}"
+
+    indexes = {
+        r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='index'").fetchall()
+    }
+    assert "idx_rollup_contrib_period" in indexes
+
+    row = conn.execute("SELECT version FROM schema_version WHERE version = 11").fetchone()
+    assert row is not None, "v11 migration must record schema_version = 11"
 
 
 def test_migrate_v9_repairs_missing_column_from_wedged_v7(monkeypatch):
@@ -1204,3 +1220,174 @@ def test_model_unavailable_truncated_message_roundtrip():
     db.record_model_unavailable("m", "p", 404, long_msg)
     row = db.get_model_unavailable("m", "p")
     assert row["error_message"] == long_msg
+
+
+# ---------------------------------------------------------------------------
+# Tiered rollups (issue #157, M2)
+# ---------------------------------------------------------------------------
+
+
+def _seed_calls(session_id, calls):
+    """Helper: start a session and record llm_calls.
+
+    ``calls`` is a list of (ts, model, provider, tokens_in, tokens_out, cost_usd).
+    """
+    db.start_run(session_id, model=calls[0][1], platform="cli")
+    for ts, model, provider, tin, tout, cost in calls:
+        db.record_llm_call(session_id, ts, model, provider, tin, tout, cost, 100)
+
+
+def test_end_run_populates_daily_weekly_monthly_rollups():
+    """end_run must fold the session's llm_calls into all three rollup tables
+    keyed by (period_start, model, provider)."""
+    ts = "2026-06-10T10:00:00+00:00"
+    # Period starts for 2026-06-10 (a Wednesday): day=2026-06-10,
+    # week=Monday 2026-06-08, month=2026-06-01.
+    expected = {
+        "daily_rollups": "2026-06-10",
+        "weekly_rollups": "2026-06-08",
+        "monthly_rollups": "2026-06-01",
+    }
+    _seed_calls(
+        "roll-sess-1",
+        [(ts, "gpt-4o", "openai", 1000, 500, 0.03)],
+    )
+    db.end_run("roll-sess-1", status="ok")
+
+    conn = db._get_conn()
+    for table, period_start in expected.items():
+        rows = conn.execute(
+            f"SELECT * FROM {table} WHERE period_start=? AND model=? AND provider=?",
+            (period_start, "gpt-4o", "openai"),
+        ).fetchall()
+        assert len(rows) == 1, f"{table} should have one matching bucket"
+        row = rows[0]
+        assert row["tokens_in"] == 1000
+        assert row["tokens_out"] == 500
+        assert row["cost_usd"] == 0.03
+        assert row["api_calls"] == 1
+        assert row["session_count"] == 1
+
+
+def test_upsert_rollups_merges_across_sessions():
+    """Two sessions in the same day/model/provider bucket must accumulate."""
+    ts = "2026-06-10T11:00:00+00:00"
+    _seed_calls("roll-sess-a", [(ts, "gpt-4o", "openai", 1000, 500, 0.03)])
+    db.end_run("roll-sess-a", status="ok")
+    _seed_calls("roll-sess-b", [(ts, "gpt-4o", "openai", 2000, 250, 0.06)])
+    db.end_run("roll-sess-b", status="ok")
+
+    conn = db._get_conn()
+    row = conn.execute(
+        "SELECT * FROM daily_rollups WHERE period_start=? AND model=? AND provider=?",
+        ("2026-06-10", "gpt-4o", "openai"),
+    ).fetchone()
+    assert row["tokens_in"] == 3000
+    assert row["tokens_out"] == 750
+    assert row["cost_usd"] == 0.09
+    assert row["api_calls"] == 2
+    # session_count counts distinct sessions, not calls
+    assert row["session_count"] == 2
+
+
+def test_upsert_rollups_idempotent_on_reend():
+    """Re-ending the same session must not double-count (UPSERT semantics)."""
+    ts = "2026-06-10T11:00:00+00:00"
+    _seed_calls("roll-replay", [(ts, "gpt-4o", "openai", 1000, 500, 0.03)])
+    db.end_run("roll-replay", status="ok")
+    db.end_run("roll-replay", status="ok")  # replay
+
+    conn = db._get_conn()
+    row = conn.execute(
+        "SELECT * FROM daily_rollups WHERE period_start=? AND model=? AND provider=?",
+        ("2026-06-10", "gpt-4o", "openai"),
+    ).fetchone()
+    assert row["api_calls"] == 1
+    assert row["session_count"] == 1
+
+
+def test_upsert_rollups_splits_week_and_month_boundaries():
+    """A call late in June lands in June monthly but a different ISO week than
+    one early in June; both must bucket correctly by period_start."""
+    early = "2026-06-01T09:00:00+00:00"
+    late = "2026-06-30T09:00:00+00:00"
+    _seed_calls("roll-week-early", [(early, "claude", "anthropic", 10, 10, 0.01)])
+    db.end_run("roll-week-early", status="ok")
+    _seed_calls("roll-week-late", [(late, "claude", "anthropic", 20, 20, 0.02)])
+    db.end_run("roll-week-late", status="ok")
+
+    conn = db._get_conn()
+    # Both share the June monthly bucket.
+    month = conn.execute(
+        "SELECT * FROM monthly_rollups WHERE period_start=? AND model=? AND provider=?",
+        ("2026-06-01", "claude", "anthropic"),
+    ).fetchone()
+    assert month["api_calls"] == 2
+
+    # But the weekly buckets differ (June 1 2026 is a Monday; June 30 is a
+    # Tuesday, so its week starts Monday June 29).
+    weeks = {
+        (r["period_start"], r["api_calls"])
+        for r in conn.execute(
+            "SELECT period_start, api_calls FROM weekly_rollups WHERE model=? AND provider=?",
+            ("claude", "anthropic"),
+        ).fetchall()
+    }
+    assert ("2026-06-01", 1) in weeks
+    assert ("2026-06-29", 1) in weeks
+
+
+def test_compact_rollups_rebuilds_from_source():
+    """compact_rollups() recomputes the rollup tables from llm_calls and keeps
+    session_count consistent with COUNT(DISTINCT session_id)."""
+    ts = "2026-06-10T11:00:00+00:00"
+    _seed_calls("roll-compact-a", [(ts, "gpt-4o", "openai", 1000, 500, 0.03)])
+    db.end_run("roll-compact-a", status="ok")
+    _seed_calls("roll-compact-b", [(ts, "gpt-4o", "openai", 2000, 250, 0.06)])
+    db.end_run("roll-compact-b", status="ok")
+
+    written = db.compact_rollups()
+    assert written["daily"] == 1  # one (day, model, provider) group
+
+    conn = db._get_conn()
+    row = conn.execute(
+        "SELECT * FROM daily_rollups WHERE period_start=? AND model=? AND provider=?",
+        ("2026-06-10", "gpt-4o", "openai"),
+    ).fetchone()
+    assert row["api_calls"] == 2
+    assert row["session_count"] == 2
+    assert row["cost_usd"] == 0.09
+
+
+def test_compact_rollups_partial_since_iso():
+    """compact_rollups(since_iso=...) rebuilds buckets touched by calls at or
+    after the cutoff from llm_calls; periods entirely before the cutoff keep
+    their pre-existing rollup rows (recomputed identically, not orphaned)."""
+    old = "2026-05-01T09:00:00+00:00"
+    new = "2026-06-10T09:00:00+00:00"
+    # Old session — May bucket.
+    _seed_calls("roll-old", [(old, "gpt-4o", "openai", 100, 100, 0.01)])
+    db.end_run("roll-old", status="ok")
+    # New session — June bucket.
+    _seed_calls("roll-new", [(new, "gpt-4o", "openai", 200, 200, 0.02)])
+    db.end_run("roll-new", status="ok")
+
+    written = db.compact_rollups(since_iso="2026-06-01T00:00:00+00:00")
+    # Both daily buckets still exist after compaction (May preserved, June
+    # rebuilt); the function reports how many rows it wrote for the day tier.
+    assert written["daily"] == 2
+
+    conn = db._get_conn()
+    may = conn.execute(
+        "SELECT * FROM daily_rollups WHERE period_start=?", ("2026-05-01",)
+    ).fetchone()
+    assert may is not None, "May bucket must survive a partial compaction"
+    assert may["api_calls"] == 1
+    assert may["session_count"] == 1
+
+    june = conn.execute(
+        "SELECT * FROM daily_rollups WHERE period_start=?", ("2026-06-10",)
+    ).fetchone()
+    assert june is not None
+    assert june["api_calls"] == 1
+    assert june["session_count"] == 1


### PR DESCRIPTION
Card: https://github.com/nujovich/hermes-radar/issues/157

Decision: Option A (full tiered storage).

## Milestones

- [x] Milestone 1 -- Add tiered storage tables to db.py (daily_rollups, weekly_rollups, monthly_rollups) with migration to schema v10
- [x] Milestone 2 -- Implement upsert_rollups() triggered on end_run + periodic compaction
- [x] Milestone 3 -- Add retention config (plugin config: retention_days per tier) with auto-prune
- [x] Milestone 4 -- Extend /stats with --granularity flag (day|week|month) and combined agent/model filters
- [x] Milestone 5 -- Extend dashboard API with bucketed endpoints and tier-aware queries

## Milestone 2 detail

Added a v11 migration (`_migrate_v11`) that creates `rollup_contrib` — the per-session source of truth for the tiered rollup tables. The shared `daily_rollups` / `weekly_rollups` / `monthly_rollups` tables are now *derived* aggregates, not scanned directly.

- `upsert_rollups(session_id)` is called from `end_run` (wrapped in try/except so a rollup failure can never break a session end). It retracts the session's prior contribution, recomputes it from `llm_calls` (one contribution per granularity/period/model/provider group), writes it to `rollup_contrib` (replacing stale rows), and re-applies it to the rollup tables. Re-ending a session replaces rather than double-counts, so folding is idempotent at the session level.
- `compact_rollups(since_iso=None)` is the periodic-compaction entry point: it rebuilds `rollup_contrib` from `llm_calls` (optionally only calls since a cutoff) and re-derives the rollup tables. `session_count` is `COUNT(DISTINCT session_id)` per bucket, so it always reflects true distinct sessions.
- Period boundaries: day = `substr(ts,1,10)`; week = Monday-based (`date(ts,'weekday 1','-7 days')`); month = `substr(ts,1,7)-01`.

## Milestone 3 detail

Routine retention for the tiered rollup tables, driven by `auto_prune_rollups()`
(now importable from `db`).

- Per-tier retention windows live in `~/.hermes/telemetry/retention.yaml` under
  `retention_days: { daily, weekly, monthly }`. A missing file or key falls back
  to built-in defaults (90 / 365 / 1825 days). An explicit `0` or negative value
  disables pruning for that tier (kept forever).
- `auto_prune_rollups(retention=None)` loads the config (or accepts an explicit
  mapping), then deletes whole buckets whose `period_start` is strictly older
  than `today - retention_days` from each of `daily_rollups` / `weekly_rollups` /
  `monthly_rollups`, and deletes the matching `rollup_contrib` source rows so the
  bucket cannot be re-derived by a later partial compaction. It is idempotent and
  safe to schedule as maintenance (e.g. a nightly cron).
- Note: a full `compact_rollups()` rebuilds `rollup_contrib` from the canonical
  `llm_calls` source and would re-create a pruned bucket; routine retention is
  therefore driven by `auto_prune_rollups` on its own cadence, not by a full
  compact.

### Milestone 3 tests

- `tests/test_db.py`: `test_load_retention_config_defaults_when_missing`,
  `test_load_retention_config_overrides_and_disables`,
  `test_auto_prune_rollups_removes_expired_buckets`,
  `test_auto_prune_rollups_skips_disabled_tier`,
  `test_auto_prune_rollups_also_clears_contrib`.

## Milestone 5 detail

Added the `/rollups` dashboard plugin endpoint (`dashboard/plugin_api.py`),
which serves pre-aggregated history straight from the tiered rollup tables
instead of scanning `llm_calls` on every render:

- `GET /rollups?granularity=day|week|month&model=&provider=` — `granularity`
  selects the tier (`daily_rollups` / `weekly_rollups` / `monthly_rollups`;
  any unrecognized value safely defaults to `day`). `model` / `provider`
  apply tier-aware, parameterized filters (default `''` = all rows).
- Returns `period_start, model, provider, tokens_in, tokens_out, cost_usd,
  api_calls, tool_calls, session_count` per bucket, plus a `total_cost_usd`
  running sum and `bucket_count`. Rows are ordered by `period_start` ASC.
- Table name is routed through an allowlist (`_rollup_table`) — raw user
  input never reaches the SQL string, so no injection or parse-error surface.
- Missing-table is caught (`sqlite3.OperationalError` -> `[]`) so the
  dashboard stays functional on pre-v10 installs. The plugin keeps its
  `query_only` read-only posture.

### Milestone 5 tests

- `tests/test_dashboard_plugin_api.py`: `test_rollups_endpoint_reads_tiered_tables`,
  `test_rollups_endpoint_tier_aware_filters`,
  `test_rollups_endpoint_unknown_granularity_defaults_to_day`.

## Tests

- `tests/test_db.py`: `test_end_run_populates_daily_weekly_monthly_rollups`, `test_upsert_rollups_merges_across_sessions`, `test_upsert_rollups_idempotent_on_reend`, `test_upsert_rollups_splits_week_and_month_boundaries`, `test_compact_rollups_rebuilds_from_source`, `test_compact_rollups_partial_since_iso`, `test_migrate_v11_creates_rollup_contrib`.

## How to test

```bash
ruff format --check . && ruff check . && pytest tests/ -q
```

(339 passed at time of commit.)
