### PR TITLE
perf(dashboard): cache heavy endpoints without blocking the UI

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -418,6 +418,7 @@ table before applying.
 | v13 | Repair pass — re-creates `subagent_edges` (+ `idx_subagent_edges_parent`) via `CREATE TABLE IF NOT EXISTS`. Heals DBs upgraded from a build that numbered a *different* migration as v11: the per-profile branch shipped `runs.profile` as v11 before #56 settled `subagent_edges` on v11, so those DBs have `version=11` applied but no table, and v11's early-return skips creation forever. No-op on clean v11 DBs. |
 | v14 | New table: `pricing_snapshots` (append-per-change history of the tariffs Hermes core resolves per `(provider, model)`, with provenance: `source` / `source_url` / `pricing_version` / `fetched_at`). Captured from `agent.usage_pricing.get_pricing_entry` via `core_pricing.py` in the `post_api_request` hook; storage-only (no surface yet). + `idx_pricing_snapshots_model`. |
 | v15 | `pricing_snapshots.resolved_model` — Canonical model name captured when a dated id was normalized to resolve against the core `/models` catalog; NULL when the raw name resolved directly. |
+| v16 | New tables: `endpoint_payload_cache` and `model_efficiency_cache` for standalone-dashboard caches; cache writers share the plugin DB's WAL + 30s busy-timeout posture. |
 
 `_SCHEMA_VERSION` in `db.py` is the latest applied version — keep it in lockstep
 with the highest `_migrate_vN`. `test_schema_idempotent` asserts the count of

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1952,7 +1952,9 @@ async function loadAll(options = {}) {
     const chartHours = Number(windowScope.hours);
     const chartLimitDays = homeTrendLimitFor(windowPreset, chartHours, effectiveHomeGranularity);
     const trendLimit = currentUsageGranularity === 'month' ? 18 : currentUsageGranularity === 'week' ? 24 : 21;
-    const [summary, cron, providers, providerHealth, runsData, budget, tokenBreakdown, modelTokens, modelEfficiency, dailyTokens, dailyTokenChart, dailyModelChart, modelPeriodTrends, modelShareComparison, cacheEfficiency, requestForensics, toolAnalytics, toolFailureHeatmap, errorCenter, cronFailureWaste, sessionEfficiency, smellsData, forecastData] = await Promise.all([
+    // Model efficiency is loaded lazily on the Breakdown page. It is cache-backed,
+    // but keeping it out of this first batch makes the dashboard responsive on a cold cache.
+    const [summary, cron, providers, providerHealth, runsData, budget, tokenBreakdown, modelTokens, dailyTokens, dailyTokenChart, dailyModelChart, modelPeriodTrends, modelShareComparison, cacheEfficiency, requestForensics, toolAnalytics, toolFailureHeatmap, errorCenter, cronFailureWaste, sessionEfficiency, smellsData, forecastData] = await Promise.all([
       fetchJSON(`/api/summary?hours=${hours}`),
       fetchJSON(`/api/cron?hours=${hours}`),
       fetchJSON(`/api/providers?hours=${hours}`),
@@ -1961,7 +1963,6 @@ async function loadAll(options = {}) {
       fetchJSON(withViewerTimezone('/api/budget')),
       fetchJSON(`/api/token-breakdown?hours=${hours}`),
       fetchJSON(`/api/model-tokens?hours=${hours}&limit=100`),
-      fetchJSON(`/api/model-efficiency?hours=${hours}&limit=50`),
       fetchJSON(`/api/daily-tokens?hours=${hours}&page=${currentDailyTokensPage}&per_page=15`),
       fetchJSON(`/api/daily-token-chart?hours=${chartHours}&limit_days=${chartLimitDays}&include_deleted=1&granularity=${effectiveHomeGranularity}`),
       fetchJSON(`/api/daily-model-chart?hours=${chartHours}&limit_days=${chartLimitDays}&top_n=5&include_deleted=1`),
@@ -2054,7 +2055,10 @@ async function loadAll(options = {}) {
       }
       html += renderProviderBreakdownTable(providers);
       html += renderCacheEfficiency(cacheEfficiency);
-      html += renderModelEfficiency(modelEfficiency);
+      // Model efficiency is loaded lazily below — render a placeholder here
+      // and replace it once the cache-backed request completes.
+      const modelEfficiencyMount = `<div id="modelEfficiencyMount" class="loading-shell" style="min-height:120px">Loading model efficiency…</div>`;
+      html += renderTableCard('modelEfficiencyTable', 'Model Efficiency Score', modelEfficiencyMount);
       html += renderEfficiency(sessionEfficiency);
       html += renderModelUsageTrendCard(modelPeriodTrends, modelShareComparison);
       html += renderModelShareComparisonCard(modelShareComparison);
@@ -2111,6 +2115,26 @@ async function loadAll(options = {}) {
     } else if (currentPage === 'breakdown') {
       drawModelUsageTrendChart('model-usage-trend-chart', modelPeriodTrends);
       renderDailyCombinedSvg('daily-combined-svg', dailyTokenChart, dailyModelChart);
+      // Lazy-load model efficiency so breakdown first-paint is not blocked
+      // by the heavy tool_calls ⨝ llm_calls join. The SQLite-backed cache
+      // usually returns in <100ms.
+      fetchJSON(`/api/model-efficiency?hours=${hours}&limit=50`)
+        .then((rows) => {
+          if (requestId !== latestLoadRequestId) return;
+          const mount = document.getElementById('modelEfficiencyMount');
+          if (!mount) return;
+          const tableCard = mount.closest('.table-card');
+          if (!tableCard) return;
+          const newHtml = renderTableCard('modelEfficiencyTable', 'Model Efficiency Score', renderModelEfficiency(rows));
+          const tmp = document.createElement('div');
+          tmp.innerHTML = newHtml;
+          tableCard.replaceWith(tmp.firstElementChild);
+        })
+        .catch((err) => {
+          if (requestId !== latestLoadRequestId) return;
+          const mount = document.getElementById('modelEfficiencyMount');
+          if (mount) mount.innerHTML = `<div class="text-muted">Model efficiency unavailable: ${err.message}</div>`;
+        });
     }
 
   } catch (err) {

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -536,7 +536,7 @@ def api_cron(window_hours=168):
     )
 
 
-def api_providers(window_hours=24):
+def _compute_providers_rows(window_hours=24):
     since_clause_ts = _since_clause(window_hours, "ts")
     return _rows(f"""
         SELECT provider,
@@ -561,6 +561,10 @@ def api_providers(window_hours=24):
         GROUP BY provider
         ORDER BY cost_usd DESC, total_tokens DESC, total_calls DESC
     """)
+
+
+def api_providers(window_hours=24):
+    return ProvidersCache.instance().get_rows(window_hours=window_hours)
 
 
 def api_provider_health(window_hours=24):
@@ -1293,6 +1297,208 @@ def _model_efficiency_cache_key(window_hours, include_deleted, limit):
     return (int(_coerce_window_hours(window_hours)), int(bool(include_deleted)), int(limit))
 
 
+def _endpoint_payload_cache_key(*parts):
+    return json.dumps(parts, separators=(",", ":"), default=str)
+
+
+_ENDPOINT_PAYLOAD_CACHE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS endpoint_payload_cache (
+    cache_name TEXT NOT NULL,
+    cache_key TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    rows_count INTEGER NOT NULL,
+    built_at TEXT NOT NULL,
+    PRIMARY KEY (cache_name, cache_key)
+)
+"""
+
+
+def _ensure_endpoint_payload_cache_table(conn: sqlite3.Connection) -> None:
+    conn.execute(_ENDPOINT_PAYLOAD_CACHE_SCHEMA)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_endpoint_payload_cache_name ON endpoint_payload_cache(cache_name, built_at)"
+    )
+
+
+class _BackgroundPayloadCache:
+    _instance = None
+    _lock = threading.Lock()
+    CACHE_NAME = "base"
+    DEFAULT_REFRESH_SECONDS = 300
+    DEFAULT_KEYS = ()
+
+    def __init__(self, db_path: Path):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(
+            str(self.db_path), isolation_level=None, check_same_thread=False
+        )
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA busy_timeout=5000")
+        _ensure_endpoint_payload_cache_table(self._conn)
+        self._cond = threading.Condition(threading.Lock())
+        self._stop = threading.Event()
+        self._refreshing = False
+        self._thread = threading.Thread(
+            target=self._run, name=f"{self.CACHE_NAME}-cache", daemon=True
+        )
+
+    @classmethod
+    def instance(cls):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = cls(DB_PATH)
+                cls._instance.start()
+            return cls._instance
+
+    @classmethod
+    def reset_for_tests(cls):
+        with cls._lock:
+            if cls._instance is not None:
+                cls._instance.stop()
+            cls._instance = None
+
+    def start(self):
+        if not self._thread.is_alive():
+            self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        with self._cond:
+            self._cond.notify_all()
+
+    def _run(self):
+        try:
+            self._refresh_all()
+        except Exception:
+            logger.exception("initial %s cache refresh failed", self.CACHE_NAME)
+        while not self._stop.is_set():
+            with self._cond:
+                self._cond.wait(timeout=self.DEFAULT_REFRESH_SECONDS)
+            if self._stop.is_set():
+                break
+            try:
+                self._refresh_all()
+            except Exception:
+                logger.exception("scheduled %s cache refresh failed", self.CACHE_NAME)
+
+    def _cache_row(self, key):
+        row = self._conn.execute(
+            "SELECT payload_json, rows_count, built_at FROM endpoint_payload_cache WHERE cache_name = ? AND cache_key = ?",
+            (self.CACHE_NAME, key),
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "payload": json.loads(row["payload_json"]),
+            "rows_count": row["rows_count"],
+            "built_at": row["built_at"],
+        }
+
+    def _write_cache(self, key, payload):
+        with self._cond:
+            self._conn.execute(
+                """
+                INSERT INTO endpoint_payload_cache (cache_name, cache_key, payload_json, rows_count, built_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(cache_name, cache_key) DO UPDATE SET
+                    payload_json = excluded.payload_json,
+                    rows_count = excluded.rows_count,
+                    built_at = excluded.built_at
+                """,
+                (
+                    self.CACHE_NAME,
+                    key,
+                    json.dumps(payload, default=str),
+                    len(payload) if isinstance(payload, list) else len(payload or []),
+                    datetime.now(timezone.utc).isoformat(),
+                ),
+            )
+
+    def get_rows(self, **kwargs):
+        key = self.cache_key(**kwargs)
+        cached = self._cache_row(key)
+        if cached is not None:
+            return cached["payload"]
+        rows = self.compute_rows(**kwargs)
+        try:
+            self._write_cache(key, rows)
+        except Exception:
+            logger.exception("failed to seed %s cache", self.CACHE_NAME)
+        return rows
+
+    def refresh(self, **kwargs):
+        rows = self.compute_rows(**kwargs)
+        self._write_cache(self.cache_key(**kwargs), rows)
+        return rows
+
+    def _refresh_all(self):
+        if self._refreshing:
+            return {"skipped": "already refreshing"}
+        self._refreshing = True
+        try:
+            for kwargs in self.default_refresh_kwargs():
+                try:
+                    self.refresh(**kwargs)
+                except Exception:
+                    logger.exception("%s refresh failed for %s", self.CACHE_NAME, kwargs)
+        finally:
+            self._refreshing = False
+
+    def cache_key(self, **kwargs):
+        raise NotImplementedError
+
+    def compute_rows(self, **kwargs):
+        raise NotImplementedError
+
+    def default_refresh_kwargs(self):
+        return [dict(item) for item in self.DEFAULT_KEYS]
+
+
+class ProvidersCache(_BackgroundPayloadCache):
+    CACHE_NAME = "providers"
+    DEFAULT_KEYS = (
+        {"window_hours": 24},
+        {"window_hours": 168},
+        {"window_hours": 720},
+        {"window_hours": 0},
+    )
+
+    def cache_key(self, **kwargs):
+        return _endpoint_payload_cache_key(int(_coerce_window_hours(kwargs.get("window_hours", 24))))
+
+    def compute_rows(self, **kwargs):
+        return _compute_providers_rows(kwargs.get("window_hours", 24))
+
+
+class DailyTokenChartCache(_BackgroundPayloadCache):
+    CACHE_NAME = "daily-token-chart"
+    DEFAULT_KEYS = (
+        {"window_hours": 24, "limit_days": 26, "include_deleted": True, "granularity": "hour", "tz_name": None},
+        {"window_hours": 168, "limit_days": 14, "include_deleted": True, "granularity": "day", "tz_name": None},
+        {"window_hours": 720, "limit_days": 32, "include_deleted": True, "granularity": "day", "tz_name": None},
+        {"window_hours": 0, "limit_days": 3650, "include_deleted": True, "granularity": "day", "tz_name": None},
+    )
+
+    def cache_key(self, **kwargs):
+        return _endpoint_payload_cache_key(
+            int(_coerce_window_hours(kwargs.get("window_hours", 24))),
+            max(1, min(3650, int(kwargs.get("limit_days", 90)))),
+            int(bool(kwargs.get("include_deleted", False))),
+            _normalize_granularity(kwargs.get("granularity", "day")),
+            _normalize_dashboard_tz_name(kwargs.get("tz_name")),
+        )
+
+    def compute_rows(self, **kwargs):
+        return _compute_daily_token_chart_rows(
+            window_hours=kwargs.get("window_hours", 24),
+            limit_days=kwargs.get("limit_days", 90),
+            include_deleted=kwargs.get("include_deleted", False),
+            granularity=kwargs.get("granularity", "day"),
+            tz_name=kwargs.get("tz_name"),
+        )
+
+
 _MODEL_EFFICIENCY_CACHE_SCHEMA = """
 CREATE TABLE IF NOT EXISTS model_efficiency_cache (
     cache_key TEXT PRIMARY KEY,
@@ -1623,7 +1829,7 @@ def api_daily_tokens(window_hours=24, page=1, per_page=15, tz_name: str | None =
     }
 
 
-def api_daily_token_chart(
+def _compute_daily_token_chart_rows(
     window_hours=24,
     limit_days=90,
     include_deleted=False,
@@ -1847,6 +2053,22 @@ def api_daily_token_chart(
             else 0.0
         )
     return rows
+
+
+def api_daily_token_chart(
+    window_hours=24,
+    limit_days=90,
+    include_deleted=False,
+    granularity="day",
+    tz_name: str | None = None,
+):
+    return DailyTokenChartCache.instance().get_rows(
+        window_hours=window_hours,
+        limit_days=limit_days,
+        include_deleted=include_deleted,
+        granularity=granularity,
+        tz_name=tz_name,
+    )
 
 
 def api_daily_model_chart(
@@ -3518,8 +3740,10 @@ def main(argv=None):
 
     _warn_if_exposed(host)
 
-    # Start the model-efficiency cache in the background so first-paint
-    # never blocks on the heavy tool_calls ⨝ llm_calls join.
+    # Start background caches before binding the server so first-paint
+    # never blocks on heavy historical aggregations.
+    ProvidersCache.instance()
+    DailyTokenChartCache.instance()
     ModelEfficiencyCache.instance()
 
     server = ThreadingHTTPServer((host, port), Handler)

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -23,6 +23,7 @@ unreachable from other hosts. To view it from another machine, either:
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import logging
 import os
@@ -1326,12 +1327,59 @@ def _ensure_dashboard_cache_schema() -> None:
     return None
 
 
+def _payload_rows_count(payload) -> int:
+    """Count logical rows for cache metadata.
+
+    List payloads count elements. Dict payloads prefer an embedded ``rows``
+    list (e.g. provider-health); otherwise they contribute 0 so we don't
+    mistake object-key count for row count.
+    """
+    if isinstance(payload, list):
+        return len(payload)
+    if isinstance(payload, dict):
+        rows = payload.get("rows")
+        if isinstance(rows, list):
+            return len(rows)
+        return 0
+    return 0
+
+
+def _parse_cache_built_at(built_at):
+    if not built_at:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(built_at))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 class _BackgroundPayloadCache:
+    """SQLite-backed payload cache with background priming + TTL freshness.
+
+    ``get_rows`` is a pure presence check no longer: a hit is returned only
+    while ``built_at`` is within ``DEFAULT_REFRESH_SECONDS``. Stale hits are
+    served immediately and an async recompute is kicked for that exact key
+    (so UI presets that are not in ``DEFAULT_KEYS`` still refresh when used).
+    Misses still compute synchronously and seed the cache.
+
+    Shared-connection safety: every read/write on ``self._conn`` is guarded by
+    ``_cond``. The connection uses ``check_same_thread=False`` so request
+    threads and the background refresher can share it; the condition is the
+    serialization that makes that safe. WAL + ``busy_timeout`` only cover
+    *other* connections (plugin writers), not concurrent use of this one.
+    """
+
     _instance = None
     _lock = threading.Lock()
     CACHE_NAME = "base"
     DEFAULT_REFRESH_SECONDS = 300
     DEFAULT_KEYS = ()
+    MAX_ENTRIES = 64
+    # Drop entries older than this even if under MAX_ENTRIES.
+    MAX_ENTRY_AGE_SECONDS = 6 * 3600
 
     def __init__(self, db_path: Path):
         self.db_path = Path(db_path)
@@ -1342,9 +1390,13 @@ class _BackgroundPayloadCache:
         )
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA busy_timeout=30000")
+        # Serialize all use of self._conn across request + background threads.
         self._cond = threading.Condition(threading.Lock())
         self._stop = threading.Event()
         self._refreshing = False
+        self._inflight_keys = set()
+        self._last_refresh_at = None
+        self._last_refresh_seconds = 0.0
         self._thread = threading.Thread(
             target=self._run, name=f"{self.CACHE_NAME}-cache", daemon=True
         )
@@ -1388,18 +1440,51 @@ class _BackgroundPayloadCache:
             except Exception:
                 logger.exception("scheduled %s cache refresh failed", self.CACHE_NAME)
 
+    def _is_fresh(self, built_at) -> bool:
+        dt = _parse_cache_built_at(built_at)
+        if dt is None:
+            return False
+        age = (datetime.now(timezone.utc) - dt).total_seconds()
+        return age <= float(self.DEFAULT_REFRESH_SECONDS)
+
     def _cache_row(self, key):
-        row = self._conn.execute(
-            "SELECT payload_json, rows_count, built_at FROM endpoint_payload_cache WHERE cache_name = ? AND cache_key = ?",
-            (self.CACHE_NAME, key),
-        ).fetchone()
-        if not row:
-            return None
-        return {
-            "payload": json.loads(row["payload_json"]),
-            "rows_count": row["rows_count"],
-            "built_at": row["built_at"],
-        }
+        with self._cond:
+            row = self._conn.execute(
+                "SELECT payload_json, rows_count, built_at FROM endpoint_payload_cache WHERE cache_name = ? AND cache_key = ?",
+                (self.CACHE_NAME, key),
+            ).fetchone()
+            if not row:
+                return None
+            return {
+                "payload": json.loads(row["payload_json"]),
+                "rows_count": row["rows_count"],
+                "built_at": row["built_at"],
+            }
+
+    def _evict_locked(self):
+        """Bound growth: drop expired entries, then keep the newest MAX_ENTRIES."""
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(seconds=self.MAX_ENTRY_AGE_SECONDS)
+        ).isoformat()
+        self._conn.execute(
+            "DELETE FROM endpoint_payload_cache WHERE cache_name = ? AND built_at < ?",
+            (self.CACHE_NAME, cutoff),
+        )
+        rows = self._conn.execute(
+            """
+            SELECT cache_key FROM endpoint_payload_cache
+            WHERE cache_name = ?
+            ORDER BY built_at DESC
+            """,
+            (self.CACHE_NAME,),
+        ).fetchall()
+        if len(rows) <= self.MAX_ENTRIES:
+            return
+        for row in rows[self.MAX_ENTRIES :]:
+            self._conn.execute(
+                "DELETE FROM endpoint_payload_cache WHERE cache_name = ? AND cache_key = ?",
+                (self.CACHE_NAME, row["cache_key"]),
+            )
 
     def _write_cache(self, key, payload):
         with self._cond:
@@ -1416,15 +1501,20 @@ class _BackgroundPayloadCache:
                     self.CACHE_NAME,
                     key,
                     json.dumps(payload, default=str),
-                    len(payload) if isinstance(payload, list) else len(payload or []),
+                    _payload_rows_count(payload),
                     datetime.now(timezone.utc).isoformat(),
                 ),
             )
+            self._evict_locked()
 
     def get_rows(self, **kwargs):
         key = self.cache_key(**kwargs)
         cached = self._cache_row(key)
+        if cached is not None and self._is_fresh(cached["built_at"]):
+            return cached["payload"]
         if cached is not None:
+            # Stale but present: never freeze a dynamic UI window forever.
+            self._kick_async_refresh(kwargs)
             return cached["payload"]
         rows = self.compute_rows(**kwargs)
         try:
@@ -1432,6 +1522,28 @@ class _BackgroundPayloadCache:
         except Exception:
             logger.exception("failed to seed %s cache", self.CACHE_NAME)
         return rows
+
+    def _kick_async_refresh(self, kwargs):
+        key = self.cache_key(**kwargs)
+        with self._cond:
+            if key in self._inflight_keys:
+                return
+            self._inflight_keys.add(key)
+
+        def _worker():
+            try:
+                self.refresh(**kwargs)
+            except Exception:
+                logger.exception(
+                    "async stale refresh failed for %s key=%s", self.CACHE_NAME, key
+                )
+            finally:
+                with self._cond:
+                    self._inflight_keys.discard(key)
+
+        threading.Thread(
+            target=_worker, name=f"{self.CACHE_NAME}-stale-refresh", daemon=True
+        ).start()
 
     def refresh(self, **kwargs):
         rows = self.compute_rows(**kwargs)
@@ -1442,12 +1554,22 @@ class _BackgroundPayloadCache:
         if self._refreshing:
             return {"skipped": "already refreshing"}
         self._refreshing = True
+        started = time.monotonic()
         try:
             for kwargs in self.default_refresh_kwargs():
                 try:
                     self.refresh(**kwargs)
                 except Exception:
                     logger.exception("%s refresh failed for %s", self.CACHE_NAME, kwargs)
+            # Sweep leftovers from drifting calendar keys / one-off windows.
+            with self._cond:
+                self._evict_locked()
+            self._last_refresh_seconds = time.monotonic() - started
+            self._last_refresh_at = datetime.now(timezone.utc).isoformat()
+            return {
+                "refreshed_at": self._last_refresh_at,
+                "elapsed_seconds": round(self._last_refresh_seconds, 3),
+            }
         finally:
             self._refreshing = False
 
@@ -1618,8 +1740,13 @@ def api_model_efficiency_cache_status():
     return ModelEfficiencyCache.instance().status()
 
 
-def api_model_efficiency_refresh(window_hours=0, include_deleted=False):
-    """Force an immediate refresh of the cache for the given window."""
+def api_model_efficiency_refresh(window_hours=None, include_deleted=False):
+    """Force an immediate refresh of the cache for the given window.
+
+    ``window_hours=None`` refreshes the default window set. This endpoint is
+    intentionally unauthenticated like the rest of the standalone dashboard;
+    only expose the server on trusted networks (see ``_warn_if_exposed``).
+    """
     return ModelEfficiencyCache.instance().refresh(
         window_hours=window_hours, include_deleted=include_deleted
     )
@@ -3609,8 +3736,9 @@ def _warn_if_exposed(host: str) -> None:
         f"WARNING: binding dashboard on {host} exposes it to every host "
         "that can reach this interface, and the dashboard has NO "
         "authentication. Anyone who reaches the port will see every "
-        "captured token, cost, and tool-call detail. Do not expose to "
-        "the public internet or to untrusted networks."
+        "captured token, cost, and tool-call detail, and can also trigger "
+        "expensive POST /api/model-efficiency/refresh recomputes. Do not "
+        "expose to the public internet or to untrusted networks."
     )
     print(msg, file=sys.stderr)
     logger.warning("Dashboard bound on %s with no authentication.", host)
@@ -3619,101 +3747,85 @@ def _warn_if_exposed(host: str) -> None:
 # ---------------------------------------------------------------------------
 # ModelEfficiencyCache
 #
-# Background cache for api_model_efficiency. The underlying query joins
+# Thin subclass of `_BackgroundPayloadCache`. The underlying query joins
 # tool_calls × llm_calls over the configured window, which can take seconds
-# once telemetry grows. A single slow endpoint used to block the dashboard
-# UI even with ThreadingHTTPServer (because the browser fires ~10 endpoints
-# in parallel and the slow one dominates first-paint). This cache precomputes
-# the result in a background thread every few minutes so the HTTP handler
-# returns a SQLite row instead of recomputing.
+# once telemetry grows. Storage stays on `model_efficiency_cache` (schema v16)
+# so status/refresh keep their existing shape; TTL / serve-stale / eviction
+# logic is inherited from the base class.
 # ---------------------------------------------------------------------------
-class ModelEfficiencyCache:
-    _instance = None
-    _lock = threading.Lock()
-
-    DEFAULT_REFRESH_SECONDS = 300
+class ModelEfficiencyCache(_BackgroundPayloadCache):
+    CACHE_NAME = "model-efficiency"
     DEFAULT_WINDOWS = (24, 168, 720, 0)  # 1d, 1w, 30d, all
     DEFAULT_LIMITS = (50,)
-
-    def __init__(self, db_path: Path):
-        self.db_path = Path(db_path)
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        _ensure_dashboard_cache_schema()
-        # check_same_thread=False: this connection is touched from both the
-        # background refresh thread and request handlers. We serialize writes
-        # through `_cond` and rely on SQLite's WAL + busy_timeout for reads.
-        self._conn = sqlite3.connect(
-            str(self.db_path), isolation_level=None, check_same_thread=False
-        )
-        self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA busy_timeout=30000")
-        self._cond = threading.Condition(threading.Lock())
-        self._stop = threading.Event()
-        self._refreshing = False
-        self._last_refresh_at = None
-        self._last_refresh_seconds = 0.0
-        self._thread = threading.Thread(
-            target=self._run, name="model-efficiency-cache", daemon=True
-        )
-
-    @classmethod
-    def instance(cls):
-        with cls._lock:
-            if cls._instance is None:
-                cls._instance = cls(DB_PATH)
-                cls._instance.start()
-            return cls._instance
-
-    @classmethod
-    def reset_for_tests(cls):
-        """Reset the singleton (used by tests)."""
-        with cls._lock:
-            if cls._instance is not None:
-                cls._instance.stop()
-            cls._instance = None
-
-    def start(self):
-        if not self._thread.is_alive():
-            self._thread.start()
-
-    def stop(self):
-        self._stop.set()
-        with self._cond:
-            self._cond.notify_all()
-
-    def _run(self):
-        # Prime the cache once at startup, then refresh on a schedule.
-        try:
-            self._refresh_all()
-        except Exception:
-            logger.exception("initial model-efficiency cache refresh failed")
-        while not self._stop.is_set():
-            with self._cond:
-                self._cond.wait(timeout=self.DEFAULT_REFRESH_SECONDS)
-            if self._stop.is_set():
-                break
-            try:
-                self._refresh_all()
-            except Exception:
-                logger.exception("scheduled model-efficiency cache refresh failed")
-
-    def _cache_rows(self, window_hours, include_deleted, limit):
-        key = _model_efficiency_cache_key(window_hours, include_deleted, limit)
-        row = self._conn.execute(
-            "SELECT payload_json, rows_count, built_at FROM model_efficiency_cache WHERE cache_key = ?",
-            (str(key),),
-        ).fetchone()
-        if not row:
-            return None
-        return {
-            "payload": json.loads(row["payload_json"]),
-            "rows_count": row["rows_count"],
-            "built_at": row["built_at"],
+    DEFAULT_KEYS = tuple(
+        {
+            "window_hours": wh,
+            "include_deleted": include_deleted,
+            "limit": limit,
         }
+        for wh in (24, 168, 720, 0)
+        for include_deleted in (False, True)
+        for limit in (50,)
+    )
 
-    def _write_cache(self, window_hours, include_deleted, limit, payload):
+    def cache_key(self, **kwargs):
+        window_hours = kwargs.get("window_hours", 24)
+        include_deleted = kwargs.get("include_deleted", False)
+        limit = max(1, min(int(kwargs.get("limit", 50)), 500))
+        return str(_model_efficiency_cache_key(window_hours, include_deleted, limit))
+
+    def compute_rows(self, **kwargs):
+        window_hours = kwargs.get("window_hours", 24)
+        include_deleted = kwargs.get("include_deleted", False)
+        limit = max(1, min(int(kwargs.get("limit", 50)), 500))
+        return _compute_model_efficiency_rows(window_hours, limit, include_deleted)
+
+    def _cache_row(self, key):
         with self._cond:
-            key = _model_efficiency_cache_key(window_hours, include_deleted, limit)
+            row = self._conn.execute(
+                "SELECT payload_json, rows_count, built_at FROM model_efficiency_cache WHERE cache_key = ?",
+                (str(key),),
+            ).fetchone()
+            if not row:
+                return None
+            return {
+                "payload": json.loads(row["payload_json"]),
+                "rows_count": row["rows_count"],
+                "built_at": row["built_at"],
+            }
+
+    def _evict_locked(self):
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(seconds=self.MAX_ENTRY_AGE_SECONDS)
+        ).isoformat()
+        self._conn.execute(
+            "DELETE FROM model_efficiency_cache WHERE built_at < ?",
+            (cutoff,),
+        )
+        rows = self._conn.execute(
+            "SELECT cache_key FROM model_efficiency_cache ORDER BY built_at DESC"
+        ).fetchall()
+        if len(rows) <= self.MAX_ENTRIES:
+            return
+        for row in rows[self.MAX_ENTRIES :]:
+            self._conn.execute(
+                "DELETE FROM model_efficiency_cache WHERE cache_key = ?",
+                (row["cache_key"],),
+            )
+
+    def _write_cache(self, key, payload, window_hours=None, include_deleted=None, limit=None):
+        if window_hours is None or include_deleted is None or limit is None:
+            try:
+                parsed = ast.literal_eval(str(key))
+                if isinstance(parsed, tuple) and len(parsed) == 3:
+                    window_hours, include_deleted, limit = parsed
+                else:
+                    raise ValueError("unexpected key shape")
+            except Exception:
+                window_hours = 0 if window_hours is None else window_hours
+                include_deleted = False if include_deleted is None else include_deleted
+                limit = 50 if limit is None else limit
+        with self._cond:
             now_iso = datetime.now(timezone.utc).isoformat()
             self._conn.execute(
                 """
@@ -3722,7 +3834,10 @@ class ModelEfficiencyCache:
                 ON CONFLICT(cache_key) DO UPDATE SET
                     payload_json = excluded.payload_json,
                     rows_count = excluded.rows_count,
-                    built_at = excluded.built_at
+                    built_at = excluded.built_at,
+                    window_hours = excluded.window_hours,
+                    include_deleted = excluded.include_deleted,
+                    limit_n = excluded.limit_n
                 """,
                 (
                     str(key),
@@ -3730,32 +3845,38 @@ class ModelEfficiencyCache:
                     int(bool(include_deleted)),
                     int(limit),
                     json.dumps(payload, default=str),
-                    len(payload),
+                    _payload_rows_count(payload),
                     now_iso,
                 ),
             )
+            self._evict_locked()
 
-    def get_rows(self, window_hours, limit, include_deleted):
-        """Return cached rows, computing and seeding on miss."""
+    def get_rows(self, window_hours=24, limit=50, include_deleted=False, **kwargs):
         limit = max(1, min(int(limit), 500))
-        cached = self._cache_rows(window_hours, include_deleted, limit)
-        if cached is not None:
-            return cached["payload"]
-        rows = _compute_model_efficiency_rows(window_hours, limit, include_deleted)
-        try:
-            self._write_cache(window_hours, include_deleted, limit, rows)
-        except Exception:
-            logger.exception("failed to seed model_efficiency_cache")
-        return rows
+        return super().get_rows(
+            window_hours=window_hours, limit=limit, include_deleted=include_deleted
+        )
 
-    def refresh(self, window_hours=None, include_deleted=False):
-        """Force an immediate refresh of one window (or all windows)."""
+    def refresh(self, window_hours=None, include_deleted=False, limit=50, **kwargs):
+        """Force an immediate refresh of one window (or all default windows)."""
         if window_hours is None:
             return self._refresh_all()
         started = time.monotonic()
-        for limit in self.DEFAULT_LIMITS:
-            rows = _compute_model_efficiency_rows(window_hours, limit, include_deleted)
-            self._write_cache(window_hours, include_deleted, limit, rows)
+        # Keep historical behavior: a window refresh primes every default limit.
+        for lim in self.DEFAULT_LIMITS:
+            rows = self.compute_rows(
+                window_hours=window_hours, include_deleted=include_deleted, limit=lim
+            )
+            key = self.cache_key(
+                window_hours=window_hours, include_deleted=include_deleted, limit=lim
+            )
+            self._write_cache(
+                key,
+                rows,
+                window_hours=window_hours,
+                include_deleted=include_deleted,
+                limit=lim,
+            )
         elapsed = time.monotonic() - started
         with self._cond:
             self._last_refresh_seconds = elapsed
@@ -3768,49 +3889,28 @@ class ModelEfficiencyCache:
             }
 
     def _refresh_all(self):
-        if self._refreshing:
-            return {"skipped": "already refreshing"}
-        self._refreshing = True
-        started = time.monotonic()
-        try:
-            for wh in self.DEFAULT_WINDOWS:
-                for include_deleted in (False, True):
-                    for limit in self.DEFAULT_LIMITS:
-                        try:
-                            rows = _compute_model_efficiency_rows(wh, limit, include_deleted)
-                            self._write_cache(wh, include_deleted, limit, rows)
-                        except Exception:
-                            logger.exception(
-                                "model_efficiency_cache refresh failed (window=%s include_deleted=%s)",
-                                wh,
-                                include_deleted,
-                            )
-            self._last_refresh_seconds = time.monotonic() - started
-            self._last_refresh_at = datetime.now(timezone.utc).isoformat()
-            return {
-                "refreshed_at": self._last_refresh_at,
-                "elapsed_seconds": round(self._last_refresh_seconds, 3),
-                "windows": list(self.DEFAULT_WINDOWS),
-                "limits": list(self.DEFAULT_LIMITS),
-            }
-        finally:
-            self._refreshing = False
+        result = super()._refresh_all()
+        if isinstance(result, dict) and "skipped" not in result:
+            result["windows"] = list(self.DEFAULT_WINDOWS)
+            result["limits"] = list(self.DEFAULT_LIMITS)
+        return result
 
     def status(self):
         keys = []
-        for row in self._conn.execute(
-            "SELECT cache_key, window_hours, include_deleted, limit_n, rows_count, built_at FROM model_efficiency_cache ORDER BY window_hours, include_deleted, limit_n"
-        ).fetchall():
-            keys.append(
-                {
-                    "cache_key": row["cache_key"],
-                    "window_hours": row["window_hours"],
-                    "include_deleted": bool(row["include_deleted"]),
-                    "limit": row["limit_n"],
-                    "rows_count": row["rows_count"],
-                    "built_at": row["built_at"],
-                }
-            )
+        with self._cond:
+            for row in self._conn.execute(
+                "SELECT cache_key, window_hours, include_deleted, limit_n, rows_count, built_at FROM model_efficiency_cache ORDER BY window_hours, include_deleted, limit_n"
+            ).fetchall():
+                keys.append(
+                    {
+                        "cache_key": row["cache_key"],
+                        "window_hours": row["window_hours"],
+                        "include_deleted": bool(row["include_deleted"]),
+                        "limit": row["limit_n"],
+                        "rows_count": row["rows_count"],
+                        "built_at": row["built_at"],
+                    }
+                )
         return {
             "refresh_interval_seconds": self.DEFAULT_REFRESH_SECONDS,
             "last_refresh_at": self._last_refresh_at,

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -567,7 +567,7 @@ def api_providers(window_hours=24):
     return ProvidersCache.instance().get_rows(window_hours=window_hours)
 
 
-def api_provider_health(window_hours=24):
+def _compute_provider_health(window_hours=24):
     requested_window = _coerce_window_hours(window_hours)
     effective_window = requested_window if requested_window > 0 else 24
     now = datetime.now(timezone.utc)
@@ -682,6 +682,10 @@ def api_provider_health(window_hours=24):
         )
     )
     return {"window_hours": effective_window, "rows": rows}
+
+
+def api_provider_health(window_hours=24):
+    return ProviderHealthCache.instance().get_rows(window_hours=window_hours)
 
 
 def _build_run_filters(
@@ -1471,6 +1475,22 @@ class ProvidersCache(_BackgroundPayloadCache):
         return _compute_providers_rows(kwargs.get("window_hours", 24))
 
 
+class ProviderHealthCache(_BackgroundPayloadCache):
+    CACHE_NAME = "provider-health"
+    DEFAULT_KEYS = (
+        {"window_hours": 24},
+        {"window_hours": 168},
+        {"window_hours": 720},
+        {"window_hours": 0},
+    )
+
+    def cache_key(self, **kwargs):
+        return _endpoint_payload_cache_key(int(_coerce_window_hours(kwargs.get("window_hours", 24))))
+
+    def compute_rows(self, **kwargs):
+        return _compute_provider_health(kwargs.get("window_hours", 24))
+
+
 class DailyTokenChartCache(_BackgroundPayloadCache):
     CACHE_NAME = "daily-token-chart"
     DEFAULT_KEYS = (
@@ -1495,6 +1515,34 @@ class DailyTokenChartCache(_BackgroundPayloadCache):
             limit_days=kwargs.get("limit_days", 90),
             include_deleted=kwargs.get("include_deleted", False),
             granularity=kwargs.get("granularity", "day"),
+            tz_name=kwargs.get("tz_name"),
+        )
+
+
+class DailyModelChartCache(_BackgroundPayloadCache):
+    CACHE_NAME = "daily-model-chart"
+    DEFAULT_KEYS = (
+        {"window_hours": 24, "limit_days": 26, "top_n": 5, "include_deleted": True, "tz_name": None},
+        {"window_hours": 168, "limit_days": 14, "top_n": 5, "include_deleted": True, "tz_name": None},
+        {"window_hours": 720, "limit_days": 32, "top_n": 5, "include_deleted": True, "tz_name": None},
+        {"window_hours": 0, "limit_days": 3650, "top_n": 5, "include_deleted": True, "tz_name": None},
+    )
+
+    def cache_key(self, **kwargs):
+        return _endpoint_payload_cache_key(
+            int(_coerce_window_hours(kwargs.get("window_hours", 24))),
+            max(1, min(3650, int(kwargs.get("limit_days", 90)))),
+            max(1, min(8, int(kwargs.get("top_n", 5)))),
+            int(bool(kwargs.get("include_deleted", False))),
+            _normalize_dashboard_tz_name(kwargs.get("tz_name")),
+        )
+
+    def compute_rows(self, **kwargs):
+        return _compute_daily_model_chart(
+            window_hours=kwargs.get("window_hours", 24),
+            limit_days=kwargs.get("limit_days", 90),
+            top_n=kwargs.get("top_n", 5),
+            include_deleted=kwargs.get("include_deleted", False),
             tz_name=kwargs.get("tz_name"),
         )
 
@@ -2071,7 +2119,7 @@ def api_daily_token_chart(
     )
 
 
-def api_daily_model_chart(
+def _compute_daily_model_chart(
     window_hours=24, limit_days=90, top_n=5, include_deleted=False, tz_name: str | None = None
 ):
     since_clause_ts = _since_clause(window_hours, "ts")
@@ -2144,6 +2192,18 @@ def api_daily_model_chart(
         "models": model_names,
         "rows": [day_map[d] for d in day_order],
     }
+
+
+def api_daily_model_chart(
+    window_hours=24, limit_days=90, top_n=5, include_deleted=False, tz_name: str | None = None
+):
+    return DailyModelChartCache.instance().get_rows(
+        window_hours=window_hours,
+        limit_days=limit_days,
+        top_n=top_n,
+        include_deleted=include_deleted,
+        tz_name=tz_name,
+    )
 
 
 def api_model_period_trends(
@@ -3743,7 +3803,9 @@ def main(argv=None):
     # Start background caches before binding the server so first-paint
     # never blocks on heavy historical aggregations.
     ProvidersCache.instance()
+    ProviderHealthCache.instance()
     DailyTokenChartCache.instance()
+    DailyModelChartCache.instance()
     ModelEfficiencyCache.instance()
 
     server = ThreadingHTTPServer((host, port), Handler)

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -23,7 +23,6 @@ unreachable from other hosts. To view it from another machine, either:
 from __future__ import annotations
 
 import argparse
-import ast
 import json
 import logging
 import os
@@ -1486,7 +1485,7 @@ class _BackgroundPayloadCache:
                 (self.CACHE_NAME, row["cache_key"]),
             )
 
-    def _write_cache(self, key, payload):
+    def _write_cache(self, key, payload, **_meta):
         with self._cond:
             self._conn.execute(
                 """
@@ -1518,7 +1517,7 @@ class _BackgroundPayloadCache:
             return cached["payload"]
         rows = self.compute_rows(**kwargs)
         try:
-            self._write_cache(key, rows)
+            self._write_cache(key, rows, **kwargs)
         except Exception:
             logger.exception("failed to seed %s cache", self.CACHE_NAME)
         return rows
@@ -1534,9 +1533,7 @@ class _BackgroundPayloadCache:
             try:
                 self.refresh(**kwargs)
             except Exception:
-                logger.exception(
-                    "async stale refresh failed for %s key=%s", self.CACHE_NAME, key
-                )
+                logger.exception("async stale refresh failed for %s key=%s", self.CACHE_NAME, key)
             finally:
                 with self._cond:
                     self._inflight_keys.discard(key)
@@ -1547,7 +1544,7 @@ class _BackgroundPayloadCache:
 
     def refresh(self, **kwargs):
         rows = self.compute_rows(**kwargs)
-        self._write_cache(self.cache_key(**kwargs), rows)
+        self._write_cache(self.cache_key(**kwargs), rows, **kwargs)
         return rows
 
     def _refresh_all(self):
@@ -3813,18 +3810,24 @@ class ModelEfficiencyCache(_BackgroundPayloadCache):
                 (row["cache_key"],),
             )
 
-    def _write_cache(self, key, payload, window_hours=None, include_deleted=None, limit=None):
-        if window_hours is None or include_deleted is None or limit is None:
-            try:
-                parsed = ast.literal_eval(str(key))
-                if isinstance(parsed, tuple) and len(parsed) == 3:
-                    window_hours, include_deleted, limit = parsed
-                else:
-                    raise ValueError("unexpected key shape")
-            except Exception:
-                window_hours = 0 if window_hours is None else window_hours
-                include_deleted = False if include_deleted is None else include_deleted
-                limit = 50 if limit is None else limit
+    def _write_cache(self, key, payload, **meta):
+        """Persist payload with explicit metadata columns.
+
+        Callers must pass window_hours/include_deleted/limit. We intentionally do
+        not recover those fields from the string form of ``cache_key`` — that
+        would couple row metadata to key encoding and silently mislabel rows if
+        the key shape ever changes.
+        """
+        try:
+            window_hours = meta["window_hours"]
+            include_deleted = meta["include_deleted"]
+            limit = meta["limit"]
+        except KeyError as exc:
+            raise ValueError(
+                "ModelEfficiencyCache._write_cache requires window_hours, "
+                "include_deleted, and limit kwargs from the seed/refresh path"
+            ) from exc
+        limit = max(1, min(int(limit), 500))
         with self._cond:
             now_iso = datetime.now(timezone.utc).isoformat()
             self._conn.execute(

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -29,6 +29,7 @@ import os
 import sqlite3
 import sys
 import threading
+import time
 from datetime import datetime, timedelta, timezone
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -1288,7 +1289,59 @@ def api_error_center(
     }
 
 
+def _model_efficiency_cache_key(window_hours, include_deleted, limit):
+    return (int(_coerce_window_hours(window_hours)), int(bool(include_deleted)), int(limit))
+
+
+_MODEL_EFFICIENCY_CACHE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS model_efficiency_cache (
+    cache_key TEXT PRIMARY KEY,
+    window_hours INTEGER NOT NULL,
+    include_deleted INTEGER NOT NULL,
+    limit_n INTEGER NOT NULL,
+    payload_json TEXT NOT NULL,
+    rows_count INTEGER NOT NULL,
+    built_at TEXT NOT NULL
+)
+"""
+
+
+def _ensure_model_efficiency_cache_table(conn: sqlite3.Connection) -> None:
+    conn.execute(_MODEL_EFFICIENCY_CACHE_SCHEMA)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_me_cache_window ON model_efficiency_cache(window_hours, include_deleted)"
+    )
+
+
 def api_model_efficiency(window_hours=0, limit=50, include_deleted=False):
+    """Return per-model efficiency rows.
+
+    Reads from the in-process SQLite cache when fresh; otherwise computes
+    live and seeds the cache. The cache is refreshed in a background thread
+    every few minutes by `ModelEfficiencyCache`, so dashboard first-paint
+    never waits on the heavy `tool_calls ⨝ llm_calls` join.
+    """
+    return ModelEfficiencyCache.instance().get_rows(
+        window_hours=window_hours, limit=limit, include_deleted=include_deleted
+    )
+
+
+def api_model_efficiency_cache_status():
+    return ModelEfficiencyCache.instance().status()
+
+
+def api_model_efficiency_refresh(window_hours=0, include_deleted=False):
+    """Force an immediate refresh of the cache for the given window."""
+    return ModelEfficiencyCache.instance().refresh(
+        window_hours=window_hours, include_deleted=include_deleted
+    )
+
+
+def _compute_model_efficiency_rows(window_hours, limit, include_deleted):
+    """Live (uncached) computation of model efficiency.
+
+    Kept separate so the cache layer can call it without going through itself.
+    """
     limit = max(1, min(int(limit), 500))
     since_clause = _since_clause(window_hours, "lc.ts")
     visible_sql, visible_params = _visible_sessions_clause("r.session_id", include_deleted)
@@ -2980,6 +3033,9 @@ class Handler(SimpleHTTPRequestHandler):
                     )
                 )
 
+            if path == "/api/model-efficiency/cache/status":
+                return self._json(api_model_efficiency_cache_status())
+
             if path == "/api/tool-failure-heatmap":
                 qs = parse_qs(parsed.query)
                 return self._json(
@@ -3148,6 +3204,19 @@ class Handler(SimpleHTTPRequestHandler):
             status = 200 if result.get("enabled") or "error" not in result else 400
             return self._json(result, status)
 
+        if path == "/api/model-efficiency/refresh":
+            parsed_qs = parse_qs(parsed.query)
+            wh_raw = parsed_qs.get("hours", [None])[0]
+            include_deleted = parsed_qs.get("include_deleted", ["0"])[0] in {"1", "true", "yes"}
+            if wh_raw in (None, "", "all"):
+                return self._json(api_model_efficiency_refresh(include_deleted=include_deleted))
+            return self._json(
+                api_model_efficiency_refresh(
+                    window_hours=int(_parse_window_hours(wh_raw, "hours")),
+                    include_deleted=include_deleted,
+                )
+            )
+
         self.send_response(404)
         self.end_headers()
         self.wfile.write(b"Not Found")
@@ -3232,6 +3301,211 @@ def _warn_if_exposed(host: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# ModelEfficiencyCache
+#
+# Background cache for api_model_efficiency. The underlying query joins
+# tool_calls × llm_calls over the configured window, which can take seconds
+# once telemetry grows. A single slow endpoint used to block the dashboard
+# UI even with ThreadingHTTPServer (because the browser fires ~10 endpoints
+# in parallel and the slow one dominates first-paint). This cache precomputes
+# the result in a background thread every few minutes so the HTTP handler
+# returns a SQLite row instead of recomputing.
+# ---------------------------------------------------------------------------
+class ModelEfficiencyCache:
+    _instance = None
+    _lock = threading.Lock()
+
+    DEFAULT_REFRESH_SECONDS = 300
+    DEFAULT_WINDOWS = (24, 168, 720, 0)  # 1d, 1w, 30d, all
+    DEFAULT_LIMITS = (50,)
+
+    def __init__(self, db_path: Path):
+        self.db_path = Path(db_path)
+        # check_same_thread=False: this connection is touched from both the
+        # background refresh thread and request handlers. We serialize writes
+        # through `_cond` and rely on SQLite's WAL + busy_timeout for reads.
+        self._conn = sqlite3.connect(
+            str(self.db_path), isolation_level=None, check_same_thread=False
+        )
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA busy_timeout=5000")
+        _ensure_model_efficiency_cache_table(self._conn)
+        self._cond = threading.Condition(threading.Lock())
+        self._stop = threading.Event()
+        self._refreshing = False
+        self._last_refresh_at = None
+        self._last_refresh_seconds = 0.0
+        self._thread = threading.Thread(
+            target=self._run, name="model-efficiency-cache", daemon=True
+        )
+
+    @classmethod
+    def instance(cls):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = cls(DB_PATH)
+                cls._instance.start()
+            return cls._instance
+
+    @classmethod
+    def reset_for_tests(cls):
+        """Reset the singleton (used by tests)."""
+        with cls._lock:
+            if cls._instance is not None:
+                cls._instance.stop()
+            cls._instance = None
+
+    def start(self):
+        if not self._thread.is_alive():
+            self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        with self._cond:
+            self._cond.notify_all()
+
+    def _run(self):
+        # Prime the cache once at startup, then refresh on a schedule.
+        try:
+            self._refresh_all()
+        except Exception:
+            logger.exception("initial model-efficiency cache refresh failed")
+        while not self._stop.is_set():
+            with self._cond:
+                self._cond.wait(timeout=self.DEFAULT_REFRESH_SECONDS)
+            if self._stop.is_set():
+                break
+            try:
+                self._refresh_all()
+            except Exception:
+                logger.exception("scheduled model-efficiency cache refresh failed")
+
+    def _cache_rows(self, window_hours, include_deleted, limit):
+        key = _model_efficiency_cache_key(window_hours, include_deleted, limit)
+        row = self._conn.execute(
+            "SELECT payload_json, rows_count, built_at FROM model_efficiency_cache WHERE cache_key = ?",
+            (str(key),),
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "payload": json.loads(row["payload_json"]),
+            "rows_count": row["rows_count"],
+            "built_at": row["built_at"],
+        }
+
+    def _write_cache(self, window_hours, include_deleted, limit, payload):
+        with self._cond:
+            key = _model_efficiency_cache_key(window_hours, include_deleted, limit)
+            now_iso = datetime.now(timezone.utc).isoformat()
+            self._conn.execute(
+                """
+                INSERT INTO model_efficiency_cache (cache_key, window_hours, include_deleted, limit_n, payload_json, rows_count, built_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(cache_key) DO UPDATE SET
+                    payload_json = excluded.payload_json,
+                    rows_count = excluded.rows_count,
+                    built_at = excluded.built_at
+                """,
+                (
+                    str(key),
+                    int(_coerce_window_hours(window_hours)),
+                    int(bool(include_deleted)),
+                    int(limit),
+                    json.dumps(payload, default=str),
+                    len(payload),
+                    now_iso,
+                ),
+            )
+
+    def get_rows(self, window_hours, limit, include_deleted):
+        """Return cached rows, computing and seeding on miss."""
+        limit = max(1, min(int(limit), 500))
+        cached = self._cache_rows(window_hours, include_deleted, limit)
+        if cached is not None:
+            return cached["payload"]
+        rows = _compute_model_efficiency_rows(window_hours, limit, include_deleted)
+        try:
+            self._write_cache(window_hours, include_deleted, limit, rows)
+        except Exception:
+            logger.exception("failed to seed model_efficiency_cache")
+        return rows
+
+    def refresh(self, window_hours=None, include_deleted=False):
+        """Force an immediate refresh of one window (or all windows)."""
+        if window_hours is None:
+            return self._refresh_all()
+        started = time.monotonic()
+        for limit in self.DEFAULT_LIMITS:
+            rows = _compute_model_efficiency_rows(window_hours, limit, include_deleted)
+            self._write_cache(window_hours, include_deleted, limit, rows)
+        elapsed = time.monotonic() - started
+        with self._cond:
+            self._last_refresh_seconds = elapsed
+            self._last_refresh_at = datetime.now(timezone.utc).isoformat()
+            return {
+                "window_hours": int(_coerce_window_hours(window_hours)),
+                "include_deleted": bool(include_deleted),
+                "elapsed_seconds": round(elapsed, 3),
+                "refreshed_at": self._last_refresh_at,
+            }
+
+    def _refresh_all(self):
+        if self._refreshing:
+            return {"skipped": "already refreshing"}
+        self._refreshing = True
+        started = time.monotonic()
+        try:
+            for wh in self.DEFAULT_WINDOWS:
+                for include_deleted in (False, True):
+                    for limit in self.DEFAULT_LIMITS:
+                        try:
+                            rows = _compute_model_efficiency_rows(wh, limit, include_deleted)
+                            self._write_cache(wh, include_deleted, limit, rows)
+                        except Exception:
+                            logger.exception(
+                                "model_efficiency_cache refresh failed (window=%s include_deleted=%s)",
+                                wh,
+                                include_deleted,
+                            )
+            self._last_refresh_seconds = time.monotonic() - started
+            self._last_refresh_at = datetime.now(timezone.utc).isoformat()
+            return {
+                "refreshed_at": self._last_refresh_at,
+                "elapsed_seconds": round(self._last_refresh_seconds, 3),
+                "windows": list(self.DEFAULT_WINDOWS),
+                "limits": list(self.DEFAULT_LIMITS),
+            }
+        finally:
+            self._refreshing = False
+
+    def status(self):
+        keys = []
+        for row in self._conn.execute(
+            "SELECT cache_key, window_hours, include_deleted, limit_n, rows_count, built_at FROM model_efficiency_cache ORDER BY window_hours, include_deleted, limit_n"
+        ).fetchall():
+            keys.append(
+                {
+                    "cache_key": row["cache_key"],
+                    "window_hours": row["window_hours"],
+                    "include_deleted": bool(row["include_deleted"]),
+                    "limit": row["limit_n"],
+                    "rows_count": row["rows_count"],
+                    "built_at": row["built_at"],
+                }
+            )
+        return {
+            "refresh_interval_seconds": self.DEFAULT_REFRESH_SECONDS,
+            "last_refresh_at": self._last_refresh_at,
+            "last_refresh_seconds": (
+                round(self._last_refresh_seconds, 3) if self._last_refresh_seconds else None
+            ),
+            "is_refreshing": self._refreshing,
+            "entries": keys,
+        }
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 def main(argv=None):
@@ -3243,6 +3517,10 @@ def main(argv=None):
         sys.exit(1)
 
     _warn_if_exposed(host)
+
+    # Start the model-efficiency cache in the background so first-paint
+    # never blocks on the heavy tool_calls ⨝ llm_calls join.
+    ModelEfficiencyCache.instance()
 
     server = ThreadingHTTPServer((host, port), Handler)
     display_host = "localhost" if host in ("127.0.0.1", "localhost") else host

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -30,6 +30,7 @@ import sqlite3
 import sys
 import threading
 import time
+import types
 from datetime import datetime, timedelta, timezone
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -66,6 +67,14 @@ DB_PATH = _TELEMETRY_HOME / "telemetry.db"
 STATE_DB_PATH = HERMES_HOME / "state.db"
 CRON_JOBS_PATH = HERMES_HOME / "cron" / "jobs.json"
 CRON_OUTPUT_DIR = HERMES_HOME / "cron" / "output"
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if "hermes_telemetry" not in sys.modules:
+    _pkg = types.ModuleType("hermes_telemetry")
+    _pkg.__path__ = [str(_REPO_ROOT)]
+    _pkg.__package__ = "hermes_telemetry"
+    _pkg.__file__ = str(_REPO_ROOT / "__init__.py")
+    sys.modules["hermes_telemetry"] = _pkg
 
 _local = threading.local()
 
@@ -1305,23 +1314,16 @@ def _endpoint_payload_cache_key(*parts):
     return json.dumps(parts, separators=(",", ":"), default=str)
 
 
-_ENDPOINT_PAYLOAD_CACHE_SCHEMA = """
-CREATE TABLE IF NOT EXISTS endpoint_payload_cache (
-    cache_name TEXT NOT NULL,
-    cache_key TEXT NOT NULL,
-    payload_json TEXT NOT NULL,
-    rows_count INTEGER NOT NULL,
-    built_at TEXT NOT NULL,
-    PRIMARY KEY (cache_name, cache_key)
-)
-"""
+def _telemetry_db_module():
+    import hermes_telemetry.db as telemetry_db
+
+    return telemetry_db
 
 
-def _ensure_endpoint_payload_cache_table(conn: sqlite3.Connection) -> None:
-    conn.execute(_ENDPOINT_PAYLOAD_CACHE_SCHEMA)
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_endpoint_payload_cache_name ON endpoint_payload_cache(cache_name, built_at)"
-    )
+def _ensure_dashboard_cache_schema() -> None:
+    _telemetry_db_module()._get_conn()
+    _telemetry_db_module().close_thread_conn()
+    return None
 
 
 class _BackgroundPayloadCache:
@@ -1334,12 +1336,12 @@ class _BackgroundPayloadCache:
     def __init__(self, db_path: Path):
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        _ensure_dashboard_cache_schema()
         self._conn = sqlite3.connect(
             str(self.db_path), isolation_level=None, check_same_thread=False
         )
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA busy_timeout=5000")
-        _ensure_endpoint_payload_cache_table(self._conn)
+        self._conn.execute("PRAGMA busy_timeout=30000")
         self._cond = threading.Condition(threading.Lock())
         self._stop = threading.Event()
         self._refreshing = False
@@ -1469,7 +1471,9 @@ class ProvidersCache(_BackgroundPayloadCache):
     )
 
     def cache_key(self, **kwargs):
-        return _endpoint_payload_cache_key(int(_coerce_window_hours(kwargs.get("window_hours", 24))))
+        return _endpoint_payload_cache_key(
+            int(_coerce_window_hours(kwargs.get("window_hours", 24)))
+        )
 
     def compute_rows(self, **kwargs):
         return _compute_providers_rows(kwargs.get("window_hours", 24))
@@ -1485,7 +1489,9 @@ class ProviderHealthCache(_BackgroundPayloadCache):
     )
 
     def cache_key(self, **kwargs):
-        return _endpoint_payload_cache_key(int(_coerce_window_hours(kwargs.get("window_hours", 24))))
+        return _endpoint_payload_cache_key(
+            int(_coerce_window_hours(kwargs.get("window_hours", 24)))
+        )
 
     def compute_rows(self, **kwargs):
         return _compute_provider_health(kwargs.get("window_hours", 24))
@@ -1494,10 +1500,34 @@ class ProviderHealthCache(_BackgroundPayloadCache):
 class DailyTokenChartCache(_BackgroundPayloadCache):
     CACHE_NAME = "daily-token-chart"
     DEFAULT_KEYS = (
-        {"window_hours": 24, "limit_days": 26, "include_deleted": True, "granularity": "hour", "tz_name": None},
-        {"window_hours": 168, "limit_days": 14, "include_deleted": True, "granularity": "day", "tz_name": None},
-        {"window_hours": 720, "limit_days": 32, "include_deleted": True, "granularity": "day", "tz_name": None},
-        {"window_hours": 0, "limit_days": 3650, "include_deleted": True, "granularity": "day", "tz_name": None},
+        {
+            "window_hours": 24,
+            "limit_days": 26,
+            "include_deleted": True,
+            "granularity": "hour",
+            "tz_name": None,
+        },
+        {
+            "window_hours": 168,
+            "limit_days": 14,
+            "include_deleted": True,
+            "granularity": "day",
+            "tz_name": None,
+        },
+        {
+            "window_hours": 720,
+            "limit_days": 32,
+            "include_deleted": True,
+            "granularity": "day",
+            "tz_name": None,
+        },
+        {
+            "window_hours": 0,
+            "limit_days": 3650,
+            "include_deleted": True,
+            "granularity": "day",
+            "tz_name": None,
+        },
     )
 
     def cache_key(self, **kwargs):
@@ -1522,10 +1552,34 @@ class DailyTokenChartCache(_BackgroundPayloadCache):
 class DailyModelChartCache(_BackgroundPayloadCache):
     CACHE_NAME = "daily-model-chart"
     DEFAULT_KEYS = (
-        {"window_hours": 24, "limit_days": 26, "top_n": 5, "include_deleted": True, "tz_name": None},
-        {"window_hours": 168, "limit_days": 14, "top_n": 5, "include_deleted": True, "tz_name": None},
-        {"window_hours": 720, "limit_days": 32, "top_n": 5, "include_deleted": True, "tz_name": None},
-        {"window_hours": 0, "limit_days": 3650, "top_n": 5, "include_deleted": True, "tz_name": None},
+        {
+            "window_hours": 24,
+            "limit_days": 26,
+            "top_n": 5,
+            "include_deleted": True,
+            "tz_name": None,
+        },
+        {
+            "window_hours": 168,
+            "limit_days": 14,
+            "top_n": 5,
+            "include_deleted": True,
+            "tz_name": None,
+        },
+        {
+            "window_hours": 720,
+            "limit_days": 32,
+            "top_n": 5,
+            "include_deleted": True,
+            "tz_name": None,
+        },
+        {
+            "window_hours": 0,
+            "limit_days": 3650,
+            "top_n": 5,
+            "include_deleted": True,
+            "tz_name": None,
+        },
     )
 
     def cache_key(self, **kwargs):
@@ -1545,26 +1599,6 @@ class DailyModelChartCache(_BackgroundPayloadCache):
             include_deleted=kwargs.get("include_deleted", False),
             tz_name=kwargs.get("tz_name"),
         )
-
-
-_MODEL_EFFICIENCY_CACHE_SCHEMA = """
-CREATE TABLE IF NOT EXISTS model_efficiency_cache (
-    cache_key TEXT PRIMARY KEY,
-    window_hours INTEGER NOT NULL,
-    include_deleted INTEGER NOT NULL,
-    limit_n INTEGER NOT NULL,
-    payload_json TEXT NOT NULL,
-    rows_count INTEGER NOT NULL,
-    built_at TEXT NOT NULL
-)
-"""
-
-
-def _ensure_model_efficiency_cache_table(conn: sqlite3.Connection) -> None:
-    conn.execute(_MODEL_EFFICIENCY_CACHE_SCHEMA)
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_me_cache_window ON model_efficiency_cache(window_hours, include_deleted)"
-    )
 
 
 def api_model_efficiency(window_hours=0, limit=50, include_deleted=False):
@@ -3603,6 +3637,8 @@ class ModelEfficiencyCache:
 
     def __init__(self, db_path: Path):
         self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        _ensure_dashboard_cache_schema()
         # check_same_thread=False: this connection is touched from both the
         # background refresh thread and request handlers. We serialize writes
         # through `_cond` and rely on SQLite's WAL + busy_timeout for reads.
@@ -3610,8 +3646,7 @@ class ModelEfficiencyCache:
             str(self.db_path), isolation_level=None, check_same_thread=False
         )
         self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA busy_timeout=5000")
-        _ensure_model_efficiency_cache_table(self._conn)
+        self._conn.execute("PRAGMA busy_timeout=30000")
         self._cond = threading.Condition(threading.Lock())
         self._stop = threading.Event()
         self._refreshing = False

--- a/db.py
+++ b/db.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover - db.py loaded standalone (no package co
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 15
+_SCHEMA_VERSION = 16
 _local = threading.local()
 
 # Serializes first-time schema setup across threads. Each thread opens its own
@@ -70,11 +70,14 @@ def _get_conn() -> sqlite3.Connection:
         # 30s gives enough headroom for CI environments with slow or
         # network-backed filesystems where concurrent writes contend.
         conn.execute("PRAGMA busy_timeout=30000")
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA synchronous=NORMAL")
-        _local.conn = conn
+        # Keep WAL initialization in the same critical section as schema setup.
+        # `PRAGMA journal_mode=WAL` takes a database-level lock and can race with
+        # concurrent first connections before the per-process schema lock otherwise.
         with _schema_lock:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
             _ensure_schema(conn)
+        _local.conn = conn
     return _local.conn
 
 
@@ -173,6 +176,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _migrate_v13(conn)
     _migrate_v14(conn)
     _migrate_v15(conn)
+    _migrate_v16(conn)
 
 
 def _migrate_v2(conn: sqlite3.Connection) -> None:
@@ -580,6 +584,48 @@ def _migrate_v15(conn: sqlite3.Connection) -> None:
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (15, ?)",
+        (_utcnow(),),
+    )
+
+
+def _migrate_v16(conn: sqlite3.Connection) -> None:
+    """Add standalone-dashboard cache tables.
+
+    Cache payloads live in the same WAL-backed telemetry database as runtime
+    writes. This is deliberately a new migration: v6 is already deployed for
+    free-paid transitions, so changing it would skip existing installations.
+    """
+    cur = conn.execute("SELECT version FROM schema_version WHERE version = 16")
+    if cur.fetchone() is not None:
+        return
+
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS endpoint_payload_cache (
+            cache_name   TEXT NOT NULL,
+            cache_key    TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            rows_count   INTEGER NOT NULL,
+            built_at     TEXT NOT NULL,
+            PRIMARY KEY (cache_name, cache_key)
+        );
+        CREATE INDEX IF NOT EXISTS idx_endpoint_payload_cache_name
+            ON endpoint_payload_cache(cache_name, built_at);
+
+        CREATE TABLE IF NOT EXISTS model_efficiency_cache (
+            cache_key       TEXT PRIMARY KEY,
+            window_hours    INTEGER NOT NULL,
+            include_deleted INTEGER NOT NULL,
+            limit_n         INTEGER NOT NULL,
+            payload_json    TEXT NOT NULL,
+            rows_count      INTEGER NOT NULL,
+            built_at        TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_me_cache_window
+            ON model_efficiency_cache(window_hours, include_deleted);
+    """)
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (16, ?)",
         (_utcnow(),),
     )
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1200,27 +1200,41 @@ def test_dashboard_cache_refresh_concurrent_with_plugin_writes(serve_module, mon
     db_mod.close_thread_conn()
 
 
-def test_model_efficiency_cache_hits_and_refresh(tmp_path, serve_module):
+def test_model_efficiency_cache_hits_and_refresh(tmp_path, serve_module, monkeypatch):
     """Cache-backed model efficiency: first call seeds cache, second hits cache,
     and POST /api/model-efficiency/refresh rebuilds the cache."""
-    import time
+    serve_module.ModelEfficiencyCache.reset_for_tests()
+    # Keep the background primer quiet so compute-call assertions stay deterministic.
+    monkeypatch.setattr(
+        serve_module.ModelEfficiencyCache,
+        "_refresh_all",
+        lambda self: {"skipped": "test"},
+    )
 
     now = db._utcnow()
     db.start_run("sess-cache-1", model="gpt-5.4", platform="cli")
     db.record_llm_call("sess-cache-1", now, "gpt-5.4", "openai-codex", 1000, 200, 0.01, 120)
     db.end_run("sess-cache-1", "ok")
 
+    compute_calls = {"n": 0}
+    original = serve_module._compute_model_efficiency_rows
+
+    def counting_compute(*args, **kwargs):
+        compute_calls["n"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(serve_module, "_compute_model_efficiency_rows", counting_compute)
+
     # First call: live compute + seed cache (include_deleted=True because
     # sess-cache-1 is not present in Hermes' sessions.json).
     first = serve_module.api_model_efficiency(window_hours=24, include_deleted=True)
     assert any(row["model"] == "gpt-5.4" for row in first), first
+    assert compute_calls["n"] == 1
 
-    # Second call: must hit cache (same payload, served from SQLite cache).
-    started = time.monotonic()
+    # Second call: must hit fresh cache (no recompute).
     second = serve_module.api_model_efficiency(window_hours=24, include_deleted=True)
-    cache_elapsed = time.monotonic() - started
     assert second == first
-    assert cache_elapsed < 0.5, f"cache hit too slow: {cache_elapsed:.3f}s"
+    assert compute_calls["n"] == 1, "fresh cache hit must not recompute"
 
     # Status endpoint reports the cache entry.
     status = serve_module.api_model_efficiency_cache_status()
@@ -1228,11 +1242,75 @@ def test_model_efficiency_cache_hits_and_refresh(tmp_path, serve_module):
     assert status["refresh_interval_seconds"] == 300
 
     # Force-refresh endpoint rebuilds the cache for the same window.
+    # Restore real refresh path for the force-refresh API.
+    monkeypatch.setattr(
+        serve_module.ModelEfficiencyCache,
+        "_refresh_all",
+        serve_module._BackgroundPayloadCache._refresh_all,
+    )
     refreshed = serve_module.api_model_efficiency_refresh(window_hours=24, include_deleted=True)
     assert refreshed["window_hours"] == 24
     assert refreshed["elapsed_seconds"] >= 0
     assert refreshed["refreshed_at"]
+    assert compute_calls["n"] >= 2
 
     # All-windows refresh also works.
     refreshed_all = serve_module.api_model_efficiency_refresh(include_deleted=False)
     assert "refreshed_at" in refreshed_all
+    serve_module.ModelEfficiencyCache.reset_for_tests()
+
+
+def test_payload_cache_ttl_and_stale_refresh(tmp_path, serve_module, monkeypatch):
+    """Non-default windows must not freeze forever after the first seed."""
+    import time
+    from datetime import datetime, timedelta, timezone
+
+    serve_module.ModelEfficiencyCache.reset_for_tests()
+    monkeypatch.setattr(
+        serve_module.ModelEfficiencyCache,
+        "_refresh_all",
+        lambda self: {"skipped": "test"},
+    )
+
+    now = db._utcnow()
+    db.start_run("sess-ttl-1", model="gpt-5.4", platform="cli")
+    db.record_llm_call("sess-ttl-1", now, "gpt-5.4", "openai-codex", 1000, 200, 0.01, 120)
+    db.end_run("sess-ttl-1", "ok")
+
+    cache = serve_module.ModelEfficiencyCache.instance()
+    monkeypatch.setattr(cache, "DEFAULT_REFRESH_SECONDS", 1)
+
+    compute_calls = {"n": 0}
+    original = serve_module._compute_model_efficiency_rows
+
+    def counting_compute(*args, **kwargs):
+        compute_calls["n"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(serve_module, "_compute_model_efficiency_rows", counting_compute)
+
+    first = cache.get_rows(window_hours=3, limit=50, include_deleted=True)
+    assert compute_calls["n"] == 1
+    assert any(row["model"] == "gpt-5.4" for row in first)
+
+    # Fresh hit: no recompute.
+    assert cache.get_rows(window_hours=3, limit=50, include_deleted=True) == first
+    assert compute_calls["n"] == 1
+
+    # Force the entry past TTL.
+    key = cache.cache_key(window_hours=3, include_deleted=True, limit=50)
+    stale_at = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat()
+    with cache._cond:
+        cache._conn.execute(
+            "UPDATE model_efficiency_cache SET built_at = ? WHERE cache_key = ?",
+            (stale_at, str(key)),
+        )
+
+    # Stale hit serves previous payload immediately, then async refresh recompute.
+    stale_served = cache.get_rows(window_hours=3, limit=50, include_deleted=True)
+    assert stale_served == first
+    deadline = time.time() + 2.0
+    while compute_calls["n"] < 2 and time.time() < deadline:
+        time.sleep(0.05)
+    assert compute_calls["n"] >= 2, "stale hit should kick async recompute"
+    serve_module.ModelEfficiencyCache.reset_for_tests()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1012,6 +1012,8 @@ def test_api_budget_forecast_scoped_reads_per_cron_job_budget(serve_module):
     assert out["limit_usd"] == 10.0
     assert out["spent_so_far_usd"] >= 2.0
     assert out["status"] in ("ok", "soft", "hard")
+
+
 def test_daily_token_chart_cache_hits_on_repeat(serve_module, monkeypatch):
     serve_module.DailyTokenChartCache.reset_for_tests()
     calls = {"n": 0}
@@ -1038,7 +1040,9 @@ def test_daily_token_chart_cache_hits_on_repeat(serve_module, monkeypatch):
 def test_providers_cache_hits_on_repeat(serve_module, monkeypatch):
     serve_module.ProvidersCache.reset_for_tests()
     calls = {"n": 0}
-    payload = [{"provider": "openai-codex", "total_calls": 7, "cost_usd": 0.01, "total_tokens": 1000}]
+    payload = [
+        {"provider": "openai-codex", "total_calls": 7, "cost_usd": 0.01, "total_tokens": 1000}
+    ]
 
     def fake_compute(window_hours=24):
         calls["n"] += 1
@@ -1076,7 +1080,10 @@ def test_provider_health_cache_hits_on_repeat(serve_module, monkeypatch):
 def test_daily_model_chart_cache_hits_on_repeat(serve_module, monkeypatch):
     serve_module.DailyModelChartCache.reset_for_tests()
     calls = {"n": 0}
-    payload = {"models": ["gpt-5.4"], "rows": [{"day": "2026-06-10", "models": {"gpt-5.4": 123}, "other": 0}]}
+    payload = {
+        "models": ["gpt-5.4"],
+        "rows": [{"day": "2026-06-10", "models": {"gpt-5.4": 123}, "other": 0}],
+    }
 
     def fake_compute(**kwargs):
         calls["n"] += 1
@@ -1096,6 +1103,103 @@ def test_daily_model_chart_cache_hits_on_repeat(serve_module, monkeypatch):
     serve_module.DailyModelChartCache.reset_for_tests()
 
 
+def test_dashboard_cache_refresh_concurrent_with_plugin_writes(serve_module, monkeypatch):
+    import datetime
+    import threading
+    import time
+
+    import hermes_telemetry.db as db_mod
+
+    for cls_name in (
+        "ProvidersCache",
+        "ProviderHealthCache",
+        "DailyTokenChartCache",
+        "DailyModelChartCache",
+        "ModelEfficiencyCache",
+    ):
+        cls = getattr(serve_module, cls_name)
+        cls.reset_for_tests()
+        monkeypatch.setattr(cls, "start", lambda self: None)
+
+    errors = []
+    n_threads = 4
+    writes_per_thread = 8
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    def writer(thread_idx: int):
+        db_mod._local.conn = None
+        try:
+            for j in range(writes_per_thread):
+                sid = f"cache-race-{thread_idx}-{j}"
+                db_mod.start_run(
+                    sid, model="gpt-5.4", platform="cron", cron_job_id=f"job-{thread_idx}"
+                )
+                db_mod.record_llm_call(sid, now, "gpt-5.4", "openai", 100, 25, 0.001, 120)
+                db_mod.record_tool_call(sid, now, "read_file", True, 10)
+                db_mod.end_run(sid, "ok")
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            db_mod.close_thread_conn()
+
+    def refresher():
+        try:
+            for _ in range(8):
+                serve_module.ProvidersCache.instance().refresh(window_hours=24)
+                serve_module.ProviderHealthCache.instance().refresh(window_hours=24)
+                serve_module.DailyTokenChartCache.instance().refresh(
+                    window_hours=24,
+                    limit_days=26,
+                    include_deleted=True,
+                    granularity="hour",
+                    tz_name=None,
+                )
+                serve_module.DailyModelChartCache.instance().refresh(
+                    window_hours=24,
+                    limit_days=26,
+                    top_n=5,
+                    include_deleted=True,
+                    tz_name=None,
+                )
+                serve_module.ModelEfficiencyCache.instance().refresh(
+                    window_hours=24, include_deleted=True
+                )
+                time.sleep(0.01)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(n_threads)]
+    refresh_thread = threading.Thread(target=refresher)
+    refresh_thread.start()
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    refresh_thread.join()
+
+    assert errors == [], f"concurrent cache/plugin errors: {errors}"
+    db_mod._local.conn = None
+    conn = db_mod._get_conn()
+    expected = n_threads * writes_per_thread
+    assert (
+        conn.execute("SELECT COUNT(*) FROM runs WHERE session_id LIKE 'cache-race-%'").fetchone()[0]
+        == expected
+    )
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM llm_calls WHERE session_id LIKE 'cache-race-%'"
+        ).fetchone()[0]
+        == expected
+    )
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM tool_calls WHERE session_id LIKE 'cache-race-%'"
+        ).fetchone()[0]
+        == expected
+    )
+    db_mod.close_thread_conn()
+
+
 def test_model_efficiency_cache_hits_and_refresh(tmp_path, serve_module):
     """Cache-backed model efficiency: first call seeds cache, second hits cache,
     and POST /api/model-efficiency/refresh rebuilds the cache."""
@@ -1103,9 +1207,7 @@ def test_model_efficiency_cache_hits_and_refresh(tmp_path, serve_module):
 
     now = db._utcnow()
     db.start_run("sess-cache-1", model="gpt-5.4", platform="cli")
-    db.record_llm_call(
-        "sess-cache-1", now, "gpt-5.4", "openai-codex", 1000, 200, 0.01, 120
-    )
+    db.record_llm_call("sess-cache-1", now, "gpt-5.4", "openai-codex", 1000, 200, 0.01, 120)
     db.end_run("sess-cache-1", "ok")
 
     # First call: live compute + seed cache (include_deleted=True because

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1012,6 +1012,48 @@ def test_api_budget_forecast_scoped_reads_per_cron_job_budget(serve_module):
     assert out["limit_usd"] == 10.0
     assert out["spent_so_far_usd"] >= 2.0
     assert out["status"] in ("ok", "soft", "hard")
+def test_daily_token_chart_cache_hits_on_repeat(serve_module, monkeypatch):
+    serve_module.DailyTokenChartCache.reset_for_tests()
+    calls = {"n": 0}
+    payload = [{"day": "2026-06-10", "total_tokens": 123, "api_calls": 1}]
+
+    def fake_compute(**kwargs):
+        calls["n"] += 1
+        return payload
+
+    monkeypatch.setattr(serve_module.DailyTokenChartCache, "start", lambda self: None)
+    monkeypatch.setattr(serve_module, "_compute_daily_token_chart_rows", fake_compute)
+    first = serve_module.api_daily_token_chart(
+        window_hours=24, limit_days=26, include_deleted=True, granularity="hour", tz_name=None
+    )
+    second = serve_module.api_daily_token_chart(
+        window_hours=24, limit_days=26, include_deleted=True, granularity="hour", tz_name=None
+    )
+    assert first == payload
+    assert second == payload
+    assert calls["n"] == 1
+    serve_module.DailyTokenChartCache.reset_for_tests()
+
+
+def test_providers_cache_hits_on_repeat(serve_module, monkeypatch):
+    serve_module.ProvidersCache.reset_for_tests()
+    calls = {"n": 0}
+    payload = [{"provider": "openai-codex", "total_calls": 7, "cost_usd": 0.01, "total_tokens": 1000}]
+
+    def fake_compute(window_hours=24):
+        calls["n"] += 1
+        return payload
+
+    monkeypatch.setattr(serve_module.ProvidersCache, "start", lambda self: None)
+    monkeypatch.setattr(serve_module, "_compute_providers_rows", fake_compute)
+    first = serve_module.api_providers(window_hours=24)
+    second = serve_module.api_providers(window_hours=24)
+    assert first == payload
+    assert second == payload
+    assert calls["n"] == 1
+    serve_module.ProvidersCache.reset_for_tests()
+
+
 def test_model_efficiency_cache_hits_and_refresh(tmp_path, serve_module):
     """Cache-backed model efficiency: first call seeds cache, second hits cache,
     and POST /api/model-efficiency/refresh rebuilds the cache."""

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -284,6 +284,12 @@ def test_operator_followup_api_surfaces(serve_module):
     assert by_model["m2"]["cache_hit_share_pct"] == 50.0
     assert "efficiency_score" in by_model["m2"]
 
+    # Second call must read from the SQLite cache (rows_count > 0 in status).
+    status = serve_module.api_model_efficiency_cache_status()
+    assert any(e["window_hours"] == 24 and e["include_deleted"] for e in status["entries"]), status
+    cached = serve_module.api_model_efficiency(window_hours=24, include_deleted=True)
+    assert cached == efficiency
+
     heatmap = serve_module.api_tool_failure_heatmap(window_hours=24, include_deleted=True)
     terminal_rows = [row for row in heatmap if row["tool_name"] == "terminal"]
     assert terminal_rows
@@ -1006,3 +1012,41 @@ def test_api_budget_forecast_scoped_reads_per_cron_job_budget(serve_module):
     assert out["limit_usd"] == 10.0
     assert out["spent_so_far_usd"] >= 2.0
     assert out["status"] in ("ok", "soft", "hard")
+def test_model_efficiency_cache_hits_and_refresh(tmp_path, serve_module):
+    """Cache-backed model efficiency: first call seeds cache, second hits cache,
+    and POST /api/model-efficiency/refresh rebuilds the cache."""
+    import time
+
+    now = db._utcnow()
+    db.start_run("sess-cache-1", model="gpt-5.4", platform="cli")
+    db.record_llm_call(
+        "sess-cache-1", now, "gpt-5.4", "openai-codex", 1000, 200, 0.01, 120
+    )
+    db.end_run("sess-cache-1", "ok")
+
+    # First call: live compute + seed cache (include_deleted=True because
+    # sess-cache-1 is not present in Hermes' sessions.json).
+    first = serve_module.api_model_efficiency(window_hours=24, include_deleted=True)
+    assert any(row["model"] == "gpt-5.4" for row in first), first
+
+    # Second call: must hit cache (same payload, served from SQLite cache).
+    started = time.monotonic()
+    second = serve_module.api_model_efficiency(window_hours=24, include_deleted=True)
+    cache_elapsed = time.monotonic() - started
+    assert second == first
+    assert cache_elapsed < 0.5, f"cache hit too slow: {cache_elapsed:.3f}s"
+
+    # Status endpoint reports the cache entry.
+    status = serve_module.api_model_efficiency_cache_status()
+    assert any(e["window_hours"] == 24 and e["include_deleted"] is True for e in status["entries"])
+    assert status["refresh_interval_seconds"] == 300
+
+    # Force-refresh endpoint rebuilds the cache for the same window.
+    refreshed = serve_module.api_model_efficiency_refresh(window_hours=24, include_deleted=True)
+    assert refreshed["window_hours"] == 24
+    assert refreshed["elapsed_seconds"] >= 0
+    assert refreshed["refreshed_at"]
+
+    # All-windows refresh also works.
+    refreshed_all = serve_module.api_model_efficiency_refresh(include_deleted=False)
+    assert "refreshed_at" in refreshed_all

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1054,6 +1054,48 @@ def test_providers_cache_hits_on_repeat(serve_module, monkeypatch):
     serve_module.ProvidersCache.reset_for_tests()
 
 
+def test_provider_health_cache_hits_on_repeat(serve_module, monkeypatch):
+    serve_module.ProviderHealthCache.reset_for_tests()
+    calls = {"n": 0}
+    payload = {"window_hours": 24, "rows": [{"provider": "openai-codex", "health": "ok"}]}
+
+    def fake_compute(window_hours=24):
+        calls["n"] += 1
+        return payload
+
+    monkeypatch.setattr(serve_module.ProviderHealthCache, "start", lambda self: None)
+    monkeypatch.setattr(serve_module, "_compute_provider_health", fake_compute)
+    first = serve_module.api_provider_health(window_hours=24)
+    second = serve_module.api_provider_health(window_hours=24)
+    assert first == payload
+    assert second == payload
+    assert calls["n"] == 1
+    serve_module.ProviderHealthCache.reset_for_tests()
+
+
+def test_daily_model_chart_cache_hits_on_repeat(serve_module, monkeypatch):
+    serve_module.DailyModelChartCache.reset_for_tests()
+    calls = {"n": 0}
+    payload = {"models": ["gpt-5.4"], "rows": [{"day": "2026-06-10", "models": {"gpt-5.4": 123}, "other": 0}]}
+
+    def fake_compute(**kwargs):
+        calls["n"] += 1
+        return payload
+
+    monkeypatch.setattr(serve_module.DailyModelChartCache, "start", lambda self: None)
+    monkeypatch.setattr(serve_module, "_compute_daily_model_chart", fake_compute)
+    first = serve_module.api_daily_model_chart(
+        window_hours=24, limit_days=26, top_n=5, include_deleted=True, tz_name=None
+    )
+    second = serve_module.api_daily_model_chart(
+        window_hours=24, limit_days=26, top_n=5, include_deleted=True, tz_name=None
+    )
+    assert first == payload
+    assert second == payload
+    assert calls["n"] == 1
+    serve_module.DailyModelChartCache.reset_for_tests()
+
+
 def test_model_efficiency_cache_hits_and_refresh(tmp_path, serve_module):
     """Cache-backed model efficiency: first call seeds cache, second hits cache,
     and POST /api/model-efficiency/refresh rebuilds the cache."""

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 import threading
 
 import pytest
@@ -909,6 +910,146 @@ def test_unknown_model_is_not_known_free():
 def test_schema_v5_recorded():
     versions = {row[0] for row in db._get_conn().execute("SELECT version FROM schema_version")}
     assert 5 in versions
+
+
+def test_schema_v16_cache_tables_and_indexes():
+    conn = db._get_conn()
+    tables = {r["name"] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "endpoint_payload_cache" in tables
+    assert "model_efficiency_cache" in tables
+    endpoint_cols = {r["name"] for r in conn.execute("PRAGMA table_info(endpoint_payload_cache)")}
+    assert endpoint_cols >= {"cache_name", "cache_key", "payload_json", "rows_count", "built_at"}
+    me_cols = {r["name"] for r in conn.execute("PRAGMA table_info(model_efficiency_cache)")}
+    assert me_cols >= {
+        "cache_key",
+        "window_hours",
+        "include_deleted",
+        "limit_n",
+        "payload_json",
+        "rows_count",
+        "built_at",
+    }
+    indexes = {r["name"] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")}
+    assert "idx_endpoint_payload_cache_name" in indexes
+    assert "idx_me_cache_window" in indexes
+
+
+def test_schema_v16_recorded():
+    versions = {row[0] for row in db._get_conn().execute("SELECT version FROM schema_version")}
+    assert 16 in versions
+
+
+def test_upgrade_v15_to_v16_adds_dashboard_cache_tables():
+    """Existing databases with v6 already occupied must still receive cache tables."""
+    conn = db._get_conn()
+    conn.execute("DROP INDEX IF EXISTS idx_endpoint_payload_cache_name")
+    conn.execute("DROP INDEX IF EXISTS idx_me_cache_window")
+    conn.execute("DROP TABLE IF EXISTS endpoint_payload_cache")
+    conn.execute("DROP TABLE IF EXISTS model_efficiency_cache")
+    conn.execute("DELETE FROM schema_version WHERE version = 16")
+    db.close_thread_conn()
+
+    upgraded = db._get_conn()
+    versions = {row[0] for row in upgraded.execute("SELECT version FROM schema_version")}
+    tables = {
+        r["name"] for r in upgraded.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert 16 in versions
+    assert {"endpoint_payload_cache", "model_efficiency_cache"} <= tables
+
+
+def test_upgrade_path_legacy_schema_to_v16(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import hermes_telemetry.db as db_mod
+
+    tele_dir = tmp_path / "telemetry"
+    tele_dir.mkdir(parents=True, exist_ok=True)
+    db_path = tele_dir / "telemetry.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL
+        );
+        CREATE TABLE runs (
+            session_id TEXT PRIMARY KEY,
+            platform TEXT,
+            cron_job_id TEXT,
+            model TEXT,
+            provider TEXT,
+            started_at TEXT NOT NULL,
+            ended_at TEXT,
+            status TEXT DEFAULT 'running',
+            tokens_in INTEGER DEFAULT 0,
+            tokens_out INTEGER DEFAULT 0,
+            cost_usd REAL DEFAULT 0.0,
+            duration_ms INTEGER,
+            api_calls INTEGER DEFAULT 0,
+            tool_calls INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            estimated_llm_calls INTEGER DEFAULT 0,
+            sender_id TEXT,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0
+        );
+        CREATE TABLE llm_calls (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            ts TEXT NOT NULL,
+            model TEXT,
+            provider TEXT,
+            tokens_in INTEGER DEFAULT 0,
+            tokens_out INTEGER DEFAULT 0,
+            cost_usd REAL DEFAULT 0.0,
+            latency_ms INTEGER,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0,
+            reasoning_tokens INTEGER DEFAULT 0,
+            estimated INTEGER DEFAULT 0
+        );
+        CREATE TABLE tool_calls (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            ts TEXT NOT NULL,
+            tool_name TEXT NOT NULL,
+            ok INTEGER NOT NULL DEFAULT 1,
+            latency_ms INTEGER
+        );
+        CREATE TABLE budget_alerts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            scope TEXT NOT NULL,
+            scope_id TEXT NOT NULL DEFAULT '',
+            window TEXT NOT NULL,
+            period_key TEXT NOT NULL,
+            level TEXT NOT NULL,
+            fired_at TEXT NOT NULL,
+            spent_usd REAL,
+            limit_usd REAL,
+            UNIQUE(scope, scope_id, window, period_key, level)
+        );
+        CREATE TABLE known_free_models (
+            model TEXT NOT NULL,
+            provider TEXT NOT NULL DEFAULT '',
+            first_seen_at TEXT NOT NULL,
+            PRIMARY KEY (model, provider)
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO schema_version(version, applied_at) VALUES (?, '2026-01-01T00:00:00+00:00')",
+        [(1,), (2,), (3,), (4,), (5,)],
+    )
+    conn.commit()
+    conn.close()
+
+    db_mod._local.conn = None
+    upgraded = db_mod._get_conn()
+    versions = {row[0] for row in upgraded.execute("SELECT version FROM schema_version")}
+    assert versions >= set(range(1, 17))
+    tables = {r[0] for r in upgraded.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "endpoint_payload_cache" in tables
+    assert "model_efficiency_cache" in tables
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
1|## Summary
2|
3|Make standalone dashboard endpoints responsive on large telemetry databases by caching heavy payloads in SQLite and refreshing them in the background.
4|
5|## What changed
6|
7|- cache **model efficiency**, providers, provider health, daily token charts, and daily model charts
8|- defer the heavy model-efficiency fetch until the Breakdown page renders
9|- add a forward-only **v16** migration for `endpoint_payload_cache` and `model_efficiency_cache`
10|- serialize `PRAGMA journal_mode=WAL` with schema initialization to eliminate concurrent first-connection lock races
11|- add cache-hit, v15→v16 upgrade, and concurrent cache-refresh/plugin-write regression coverage
12|
13|## Migration safety
14|
15|The old draft used v6 for cache tables, but upstream already uses v6. This refresh keeps upstream v6–v15 intact and introduces **v16**, so existing installations receive the cache tables correctly.
16|
17|## Scope
18|
19|- focused on standalone dashboard performance and SQLite safety
20|- does not change telemetry collection, budgets, pricing, or dashboard access policy
21|
22|## Verification
23|
24|```bash
25|uvx ruff format --check .
26|uvx ruff check .
27|uv run --no-project --with pytest --with watchdog --with pyyaml pytest tests/ -q
28|```
29|
30|Results:
31|- Ruff format + lint: passed
32|- Full suite: **527 passed, 33 skipped**
33|- cache/plugin concurrency regression: **30 consecutive passes**
34|- isolated HTTP smoke: dashboard plus summary/providers/daily-chart/model-efficiency APIs all returned 200; DB migrated to v16 and cache tables populated
35|
36|## Related
37|
38|- refreshes the cache-layer follow-up after #48; #48's independent server/query fixes are already in `main`.
39|