### PR TITLE
feat: per-profile cost attribution (slice 1)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -409,6 +409,7 @@ table before applying.
 | v9 | Repair pass — re-adds any column from v2/v3/v4/v7 that was silently skipped by the old blanket `except OperationalError: pass` pattern when an `ALTER TABLE` hit a transient `SQLITE_LOCKED` (cross-process cron contention). Uses `_add_column_if_missing`; idempotent. |
 | v10 | MoA (Mixture-of-Agents) attribution: `llm_calls.moa_preset` (preset name for a MoA aggregator call; NULL otherwise) + `runs.moa_calls` (per-session counter). See `§ Mixture of Agents (MoA)`. |
 | v11 | New table `subagent_edges` (parent→child delegation tree) + `idx_subagent_edges_parent`. Attributes async/nested subagent cost to `per_cron_job` via a recursive CTE at query time. (#49) |
+| v12 | Add `runs.profile` (per-profile cost attribution) + `idx_runs_profile`. Captured from `ctx.profile_name` at `on_session_start`, backfilled in `pre_llm_call` (first non-null wins). Adds the `per_profile` budget scope. |
 
 `_SCHEMA_VERSION` in `db.py` is the latest applied version — keep it in lockstep
 with the highest `_migrate_vN`. `test_schema_idempotent` asserts the count of
@@ -497,6 +498,7 @@ already uses `INSERT OR IGNORE`).
 | `estimated_llm_calls` | Count of calls where provider returned `usage=None`. Used for budget degradation. |
 | `parent_session_id` | Dormant by design — kept in the schema but never populated. Parent→child attribution is handled by the separate `subagent_edges` table (v11) instead; see `§ Subagent Architecture`. |
 | `sender_id` | Set from `pre_llm_call.sender_id`. First non-null wins (`COALESCE(sender_id, ?)`). |
+| `profile` | Set from `ctx.profile_name` (the only profile-identity surface Hermes exposes to plugins — NOT encoded in `session_id`, no `HERMES_PROFILE` env var). Captured at `on_session_start`, backfilled in `pre_llm_call` via `db.set_profile` (`COALESCE(profile, ?)`, first non-null wins). Powers the `per_profile` budget scope. NULL for pre-v12 rows and sessions whose profile could not be resolved. |
 | `model` / `provider` | Set from first `record_llm_call`. `COALESCE(model, ?)` so they're never overwritten. |
 
 ---
@@ -733,6 +735,7 @@ timestamp is converted back to UTC ISO before querying the DB (the DB stores UTC
 | `global` | All `runs` rows in the window |
 | `per_cron_job` | `runs WHERE cron_job_id = ?`, plus every descendant reachable through `subagent_edges` (recursive CTE) — includes delegated subagent spend |
 | `per_sender` | `runs WHERE sender_id = ?` |
+| `per_profile` | `runs WHERE profile = ?` — NULL-profile runs excluded |
 
 `per_cron_job` seeds from the cron job's own root session(s) and walks
 `subagent_edges` down to every descendant, so delegated (async/nested)
@@ -740,6 +743,17 @@ subagent spend is now attributed back to the cron job that started the
 chain (schema v11, issue #49). `global` still sums every `runs` row
 unconditionally, so `per_cron_job` only *regroups* the same cost rows —
 there is no double counting. See `§ Subagent Architecture`.
+
+**Profile attribution — known limitations**
+- **Multiplexed-gateway accuracy:** `profile` is captured from `ctx.profile_name`,
+  which the core derives from the `HERMES_HOME` ContextVar. In a multiplexed gateway
+  (one process serving many profiles), the value is correct only if the core
+  propagated that ContextVar into the thread that fires the hook. If it did not, a run
+  may be tagged with the wrong profile (typically `default`). Dedicated per-profile
+  processes (per-profile gateway/cron) are not affected — they resolve the profile
+  from the process's own `HERMES_HOME`.
+- **NULL profile:** pre-v12 rows and any session whose profile could not be resolved
+  keep `profile = NULL`; these are excluded from `per_profile` spend and budgets.
 
 ---
 

--- a/__init__.py
+++ b/__init__.py
@@ -189,7 +189,11 @@ def register(ctx) -> None:  # noqa: ANN001
         try:
             cron_job_id = _extract_cron_job_id(session_id, platform)
             db.start_run(
-                session_id=session_id, model=model, platform=platform, cron_job_id=cron_job_id
+                session_id=session_id,
+                model=model,
+                platform=platform,
+                cron_job_id=cron_job_id,
+                profile=getattr(ctx, "profile_name", None),
             )
             tele_log.debug(
                 "session_start session=%s platform=%s cron_job=%s",
@@ -634,6 +638,7 @@ def register(ctx) -> None:  # noqa: ANN001
         try:
             if sender_id:
                 db.set_sender(session_id, sender_id)
+            db.set_profile(session_id, getattr(ctx, "profile_name", None))
             run = db.get_run(session_id)
             if not run:
                 return None

--- a/budget.example.yaml
+++ b/budget.example.yaml
@@ -7,6 +7,7 @@
 #   global        — all spend, every platform
 #   per_cron_job  — keyed by cron job id (the {job_id} in cron_{job_id}_{ts})
 #   per_sender    — keyed by sender_id (gateway multi-user setups)
+#   per_profile   — keyed by Hermes profile name (from ctx.profile_name)
 #
 # Windows: daily_usd and monthly_usd, evaluated in your LOCAL timezone.
 #
@@ -38,6 +39,12 @@ budgets:
       daily_usd: 2.00
     # overrides:
     #   "telegram:123456": { daily_usd: 10.00 }
+
+  per_profile:
+    default:
+      daily_usd: 2.00
+    # overrides:
+    #   "coder": { daily_usd: 10.00 }
 
 thresholds:
   soft_pct: 0.80          # warn at 80% of a limit

--- a/budget.py
+++ b/budget.py
@@ -194,7 +194,7 @@ def _period_key(window: str) -> str:
 
 @dataclass
 class BudgetVerdict:
-    scope: str  # global | cron_job | sender
+    scope: str  # global | cron_job | sender | profile
     scope_id: str  # "" for global
     window: str  # daily | monthly
     status: str  # ok | soft | hard
@@ -218,6 +218,8 @@ class BudgetVerdict:
             return f"Cron job '{self.scope_id}'"
         if self.scope == "sender":
             return f"Sender '{self.scope_id}'"
+        if self.scope == "profile":
+            return f"Profile '{self.scope_id}'"
         return self.scope
 
 
@@ -234,6 +236,10 @@ def _resolve_limits(scope: str, scope_id: str) -> dict[str, float]:
         node = overrides.get(scope_id) or per.get("default") or {}
     elif scope == "sender":
         per = budgets.get("per_sender") or {}
+        overrides = per.get("overrides") or {}
+        node = overrides.get(scope_id) or per.get("default") or {}
+    elif scope == "profile":
+        per = budgets.get("per_profile") or {}
         overrides = per.get("overrides") or {}
         node = overrides.get(scope_id) or per.get("default") or {}
 
@@ -330,6 +336,11 @@ def evaluate_run(run_row: dict) -> list[BudgetVerdict]:
     sender_id = run_row.get("sender_id")
     if sender_id:
         v = check("sender", sender_id)
+        if v:
+            verdicts.append(v)
+    profile = run_row.get("profile")
+    if profile:
+        v = check("profile", profile)
         if v:
             verdicts.append(v)
     return verdicts

--- a/db.py
+++ b/db.py
@@ -520,15 +520,16 @@ def start_run(
     platform: str,
     cron_job_id: str | None = None,
     parent_session_id: str | None = None,
+    profile: str | None = None,
 ) -> None:
     conn = _get_conn()
     conn.execute(
         """
         INSERT OR IGNORE INTO runs
-            (session_id, model, platform, cron_job_id, parent_session_id, started_at, status)
-        VALUES (?, ?, ?, ?, ?, ?, 'running')
+            (session_id, model, platform, cron_job_id, parent_session_id, profile, started_at, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, 'running')
         """,
-        (session_id, model, platform, cron_job_id, parent_session_id, _utcnow()),
+        (session_id, model, platform, cron_job_id, parent_session_id, profile, _utcnow()),
     )
 
 
@@ -645,6 +646,20 @@ def set_sender(session_id: str, sender_id: str) -> None:
     conn.execute(
         "UPDATE runs SET sender_id = COALESCE(sender_id, ?) WHERE session_id = ?",
         (sender_id, session_id),
+    )
+
+
+def set_profile(session_id: str, profile: str | None) -> None:
+    """Attach a profile to a run (first non-null wins). profile is exposed only
+    via ctx.profile_name inside hook callbacks, not as a hook kwarg — captured
+    at session start and backfilled here for sessions where on_session_start
+    did not fire."""
+    if not profile:
+        return
+    conn = _get_conn()
+    conn.execute(
+        "UPDATE runs SET profile = COALESCE(profile, ?) WHERE session_id = ?",
+        (profile, session_id),
     )
 
 
@@ -954,9 +969,9 @@ def recent_runs(
 def spend_by_scope(scope: str, scope_id: str, since_iso: str) -> dict[str, Any]:
     """Aggregate spend for a budget scope since an ISO-8601 UTC timestamp.
 
-    scope ∈ {"global", "cron_job", "sender"}. For "global", scope_id is
-    ignored. Returns spent_usd plus an estimated_pct so callers can tell when
-    a verdict rests on estimated (usage=None) rows.
+    scope ∈ {"global", "cron_job", "sender", "profile"}. For "global", scope_id
+    is ignored. Returns spent_usd plus an estimated_pct so callers can tell
+    when a verdict rests on estimated (usage=None) rows.
     """
     conn = _get_conn()
     if scope == "cron_job":
@@ -989,6 +1004,9 @@ def spend_by_scope(scope: str, scope_id: str, since_iso: str) -> dict[str, Any]:
         params: list[Any] = [since_iso]
         if scope == "sender":
             where.append("sender_id = ?")
+            params.append(scope_id)
+        elif scope == "profile":
+            where.append("profile = ?")
             params.append(scope_id)
         # "global": no extra filter
         row = conn.execute(
@@ -1231,6 +1249,9 @@ def estimated_price_share(scope: str, scope_id: str, since_iso: str) -> float:
         params: list[Any] = [since_iso]
         if scope == "sender":
             where.append("r.sender_id = ?")
+            params.append(scope_id)
+        elif scope == "profile":
+            where.append("r.profile = ?")
             params.append(scope_id)
 
         row = conn.execute(

--- a/db.py
+++ b/db.py
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 11
+_SCHEMA_VERSION = 12
 _local = threading.local()
 
 # Serializes first-time schema setup across threads. Each thread opens its own
@@ -168,6 +168,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _migrate_v9(conn)
     _migrate_v10(conn)
     _migrate_v11(conn)
+    _migrate_v12(conn)
 
 
 def _migrate_v2(conn: sqlite3.Connection) -> None:
@@ -454,6 +455,28 @@ def _migrate_v11(conn: sqlite3.Connection) -> None:
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (11, ?)",
+        (_utcnow(),),
+    )
+
+
+def _migrate_v12(conn: sqlite3.Connection) -> None:
+    """Add v12 schema: profile on runs (per-profile cost attribution).
+
+    profile is captured from ``ctx.profile_name`` at session start and
+    backfilled in ``pre_llm_call`` (first non-null wins). Nullable: pre-v12
+    rows and sessions whose profile could not be resolved stay NULL. An index
+    supports the per-profile budget scope's ``WHERE profile = ?`` filter
+    (mirrors ``idx_runs_sender``)."""
+    cur = conn.execute("SELECT version FROM schema_version WHERE version = 12")
+    if cur.fetchone() is not None:
+        return
+
+    _add_column_if_missing(conn, "runs", "profile", "TEXT")
+
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_runs_profile ON runs(profile)")
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (12, ?)",
         (_utcnow(),),
     )
 

--- a/tests/test_budget_per_profile.py
+++ b/tests/test_budget_per_profile.py
@@ -1,0 +1,81 @@
+"""per_profile budget scope: limit resolution, verdict labeling, and that
+evaluate_run emits a profile verdict when a run carries a profile."""
+
+import hermes_telemetry.budget as budget
+import hermes_telemetry.db as db
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_db_and_caches():
+    db._local.conn = None
+    # Budget engine caches config + verdicts at module scope; clear both so
+    # each test starts clean.
+    with budget._config_lock:
+        budget._config_cache = None
+    with budget._verdict_lock:
+        budget._verdict_cache.clear()
+    yield
+    if getattr(db._local, "conn", None):
+        db._local.conn.close()
+        db._local.conn = None
+    with budget._config_lock:
+        budget._config_cache = None
+    with budget._verdict_lock:
+        budget._verdict_cache.clear()
+
+
+def _set_config(cfg):
+    with budget._config_lock:
+        budget._config_cache = cfg
+
+
+def test_resolve_limits_profile_override_and_default():
+    _set_config(
+        {
+            "budgets": {
+                "per_profile": {
+                    "default": {"daily_usd": 2.0},
+                    "overrides": {"coder": {"daily_usd": 10.0}},
+                }
+            },
+            "thresholds": {"soft_pct": 0.8, "hard_pct": 1.0},
+            "on_estimated": {"mode": "warn_only"},
+        }
+    )
+    assert budget._resolve_limits("profile", "coder")["daily_usd"] == 10.0
+    assert budget._resolve_limits("profile", "other")["daily_usd"] == 2.0
+
+
+def test_scope_label_profile():
+    v = budget.BudgetVerdict(
+        scope="profile",
+        scope_id="coder",
+        window="daily",
+        status="soft",
+        spent=1.0,
+        limit=2.0,
+        pct=0.5,
+        based_on_estimates=False,
+        degraded=False,
+        period_key="2026-07-03",
+    )
+    assert v.scope_label() == "Profile 'coder'"
+
+
+def test_evaluate_run_includes_profile_scope():
+    _set_config(
+        {
+            "budgets": {"per_profile": {"default": {"daily_usd": 1.0}}},
+            "thresholds": {"soft_pct": 0.8, "hard_pct": 1.0},
+            "on_estimated": {"mode": "enforce"},
+        }
+    )
+    db.start_run("br1", "m", "cli", profile="coder")
+    db._get_conn().execute("UPDATE runs SET cost_usd = 5.0 WHERE session_id = 'br1'")
+
+    verdicts = budget.evaluate_run(db.get_run("br1"))
+    profile_verdicts = [v for v in verdicts if v.scope == "profile"]
+    assert len(profile_verdicts) == 1
+    assert profile_verdicts[0].scope_id == "coder"
+    assert profile_verdicts[0].status == "hard"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1472,3 +1472,60 @@ def test_unattributed_child_cost_zero_when_parent_present():
     d = db.unattributed_child_cost("2000-01-01T00:00:00+00:00")
     assert d["edges"] == 0
     assert d["unattributed_usd"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# v12 — runs.profile (per-profile cost attribution)
+# ---------------------------------------------------------------------------
+
+
+def test_schema_v12_columns():
+    """v12 adds the profile column on runs."""
+    conn = db._get_conn()
+    runs_cols = {row[1] for row in conn.execute("PRAGMA table_info(runs)").fetchall()}
+    assert "profile" in runs_cols
+
+
+def test_schema_v12_recorded():
+    versions = {row[0] for row in db._get_conn().execute("SELECT version FROM schema_version")}
+    assert 12 in versions
+
+
+def test_migrate_v12_repairs_missing_column_from_v11():
+    """If a v11 DB lacks runs.profile (e.g. the v12 ALTER was swallowed by a
+    transient SQLITE_LOCKED), the next connect must self-heal via v12 — not
+    leave the column missing while marking version 12 applied.
+
+    The previous shipped version is v11 (subagent_edges; MoA at v10), so the
+    simulated wedged state keeps every v11 column (including runs.moa_calls) and
+    only drops profile. Rebuild runs from the live schema minus profile so this
+    stays correct as the runs shape evolves. SQLite pre-3.35 has no DROP COLUMN,
+    so we rebuild."""
+    conn = db._get_conn()
+
+    runs_info = [r for r in conn.execute("PRAGMA table_info(runs)") if r[1] != "profile"]
+    col_defs = []
+    for _cid, name, ctype, notnull, dflt, pk in runs_info:
+        piece = f"{name} {ctype}"
+        if pk:
+            piece += " PRIMARY KEY"
+        elif notnull:
+            piece += " NOT NULL"
+        if dflt is not None:
+            piece += f" DEFAULT {dflt}"
+        col_defs.append(piece)
+    kept = ", ".join(r[1] for r in runs_info)
+    conn.execute("ALTER TABLE runs RENAME TO _runs_old")
+    conn.execute(f"CREATE TABLE runs ({', '.join(col_defs)})")
+    conn.execute(f"INSERT INTO runs ({kept}) SELECT {kept} FROM _runs_old")
+    conn.execute("DROP TABLE _runs_old")
+    conn.execute("DELETE FROM schema_version WHERE version = 12")
+
+    cols = {r[0] for r in conn.execute("SELECT name FROM pragma_table_info('runs')")}
+    assert "profile" not in cols  # wedged state confirmed
+    assert "moa_calls" in cols  # v10/v11 columns preserved
+
+    db._ensure_schema(conn)
+
+    cols = {r[0] for r in conn.execute("SELECT name FROM pragma_table_info('runs')")}
+    assert "profile" in cols, "v12 must re-add runs.profile when it was missing"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1529,3 +1529,39 @@ def test_migrate_v12_repairs_missing_column_from_v11():
 
     cols = {r[0] for r in conn.execute("SELECT name FROM pragma_table_info('runs')")}
     assert "profile" in cols, "v12 must re-add runs.profile when it was missing"
+
+
+def test_start_run_stores_profile():
+    db.start_run("s_prof", "m", "cli", profile="coder")
+    assert db.get_run("s_prof")["profile"] == "coder"
+
+
+def test_start_run_profile_defaults_none():
+    db.start_run("s_noprof", "m", "cli")
+    assert db.get_run("s_noprof")["profile"] is None
+
+
+def test_set_profile_first_non_null_wins():
+    db.start_run("s_bf", "m", "cli")  # no profile
+    db.set_profile("s_bf", "coder")
+    assert db.get_run("s_bf")["profile"] == "coder"
+    db.set_profile("s_bf", "ops")  # must NOT overwrite
+    assert db.get_run("s_bf")["profile"] == "coder"
+
+
+def test_set_profile_ignores_empty():
+    db.start_run("s_empty", "m", "cli")
+    db.set_profile("s_empty", "")
+    db.set_profile("s_empty", None)
+    assert db.get_run("s_empty")["profile"] is None
+
+
+def test_spend_by_scope_profile_filters():
+    db.start_run("s_coder", "m", "cli", profile="coder")
+    db.start_run("s_ops", "m", "cli", profile="ops")
+    conn = db._get_conn()
+    conn.execute("UPDATE runs SET cost_usd = 1.50 WHERE session_id = 's_coder'")
+    conn.execute("UPDATE runs SET cost_usd = 0.25 WHERE session_id = 's_ops'")
+
+    result = db.spend_by_scope("profile", "coder", "2000-01-01T00:00:00+00:00")
+    assert result["spent_usd"] == 1.50

--- a/tests/test_profile_capture.py
+++ b/tests/test_profile_capture.py
@@ -1,0 +1,67 @@
+"""Profile capture: on_session_start stores ctx.profile_name; pre_llm_call
+backfills it (first non-null wins)."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+_spec = importlib.util.spec_from_file_location("hermes_telemetry", str(_ROOT / "__init__.py"))
+_init_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_init_mod)
+
+
+class MockPluginContext:
+    """Minimal stand-in for Hermes PluginContext, with a profile_name."""
+
+    def __init__(self, profile_name="default"):
+        self.hooks: dict = {}
+        self.commands: dict = {}
+        self.profile_name = profile_name
+
+    def register_hook(self, name, fn):
+        self.hooks[name] = fn
+
+    def register_command(self, name, fn, description="", args_hint=""):
+        self.commands[name] = fn
+
+    def register_cli_command(self, *a, **k):
+        pass
+
+    def fire(self, hook_name, **kwargs):
+        fn = self.hooks.get(hook_name)
+        return fn(**kwargs) if fn else None
+
+
+@pytest.fixture(autouse=True)
+def isolated_db():
+    import hermes_telemetry.db as db_mod
+
+    db_mod._local.conn = None
+    yield
+    if getattr(db_mod._local, "conn", None):
+        db_mod._local.conn.close()
+        db_mod._local.conn = None
+
+
+def test_on_session_start_captures_profile():
+    import hermes_telemetry.db as db
+
+    ctx = MockPluginContext(profile_name="coder")
+    _init_mod.register(ctx)
+    ctx.fire("on_session_start", session_id="cap1", model="m", platform="cli")
+    assert db.get_run("cap1")["profile"] == "coder"
+
+
+def test_pre_llm_call_backfills_profile():
+    import hermes_telemetry.db as db
+
+    # Run exists without a profile (e.g. on_session_start never fired for it).
+    db.start_run("cap2", "m", "cli")
+    assert db.get_run("cap2")["profile"] is None
+
+    ctx = MockPluginContext(profile_name="ops")
+    _init_mod.register(ctx)
+    ctx.fire("pre_llm_call", session_id="cap2")
+    assert db.get_run("cap2")["profile"] == "ops"


### PR DESCRIPTION
## Summary

Slice 1 of the per-profile cost center: makes `profile` a first-class attribution axis so cost can be managed per Hermes profile ("tagging, always on" — fixes attribution in every execution mode).

- **Schema (migration v11):** adds nullable `runs.profile` + `idx_runs_profile`. Forward-only on top of v10 (MoA); the migration is a no-op re-run guard and uses `_add_column_if_missing`. A wedged-upgrade repair test simulates a v10-with-MoA DB that is missing `profile` and asserts the next connect self-heals via v11 (preserving `runs.moa_calls`).
- **Attribution:** captures `ctx.profile_name` in `on_session_start` and backfills it in `pre_llm_call` (first non-null wins, mirroring the `sender_id` pattern). Verified against the live hermes-agent source — `PluginContext.profile_name` is a property derived from `HERMES_HOME`, so it works across CLI, gateway, and worker sessions.
- **DB helpers:** `start_run(profile=…)`, new `set_profile` (`COALESCE(profile, ?)`), and a `profile` branch in `spend_by_scope` + `estimated_price_share`.
- **Budgets:** new `per_profile` scope reusing the existing `check`/`evaluate_run` machinery and `_resolve_limits` overrides; `budget.example.yaml` documents the scope and an override example.
- **Docs:** ONBOARDING.md gains the v11 schema-evolution row, the `runs.profile` column note, the `per_profile` scope-resolution row, and a "known limitations" note (multiplexed-gateway ContextVar accuracy; NULL-profile exclusion from per-profile spend/budgets).

Out of scope (their own slices): canonical `HERMES_TELEMETRY_HOME` (slice 2), `sync-profiles` propagation (slice 3), and the dashboard profile dimension.

## Test plan

- `ruff format --check . && ruff check .` — clean
- `TZ=UTC pytest tests/ -q` — **360 passed, 6 skipped**
- New tests: `tests/test_profile_capture.py` (hook capture + backfill), `tests/test_budget_per_profile.py` (limit resolution, verdict labeling, `evaluate_run` emits a profile verdict), and in `tests/test_db.py` the v11 schema/recorded tests, per-profile spend query, and the wedged-upgrade repair from a v10-with-MoA DB.

> Note: the migration is numbered v11 because v10 is already taken by the MoA attribution work on `main`. Forward-only — no existing migration was edited.
