### PR TITLE
BUILD #164: chip-aware local power default for local model cost estimation

### DIFF
--- a/BUILD-PLAN-issue-164.md
+++ b/BUILD-PLAN-issue-164.md
@@ -1,0 +1,13 @@
+# BUILD PLAN — Card #164
+
+Card: https://github.com/nujovich/hermes-radar/issues/164
+
+## Decision
+
+Nadia chose **Option B** — Chip-aware local power only.
+
+## Milestones
+
+- [ ] Milestone 1 — Add `local_power.py` module with Apple Silicon detection (sysctl hw.machine) and wattage estimation
+- [ ] Milestone 2 — Wire into pricing.py: when model is local (ollama/llama.cpp), use chip-aware wattage as cost basis
+- [ ] Milestone 3 — Add /stats local-power subcommand showing estimated local cost

--- a/db.py
+++ b/db.py
@@ -1184,6 +1184,70 @@ def stats_by_model(
     return result
 
 
+def local_power_summary(
+    window_hours: int | None = None, *, date_from: str | None = None, date_to: str | None = None
+) -> dict[str, Any]:
+    """Aggregate llm_calls served by local (on-device) providers.
+
+    Local providers are those whose name contains 'ollama' or 'llama'
+    (see pricing._is_local_provider). This lets operators see how much
+    token volume ran locally versus via a paid API, and estimate the
+    electricity cost of that local inference.
+
+    Returns:
+      local_calls        — count of local llm_calls in the window
+      local_tokens_in    — sum of input tokens for local calls
+      local_tokens_out   — sum of output tokens for local calls
+      local_total_tokens — local_tokens_in + local_tokens_out
+      models             — per-(provider, model) breakdown:
+                            provider, model, calls, tokens_in, tokens_out,
+                            total_tokens
+    The cost estimate is intentionally NOT computed here; the stats layer
+    applies pricing._compute_local_cost so it respects MINT_LOCAL_WATTAGE /
+    chip detection at render time.
+    """
+    conn = _get_conn()
+    where_sql, params = _build_where_clause_ts(window_hours, date_from, date_to)
+    if where_sql:
+        where_sql = f"WHERE {where_sql} AND (provider LIKE '%ollama%' OR provider LIKE '%llama%')"
+    else:
+        where_sql = "WHERE (provider LIKE '%ollama%' OR provider LIKE '%llama%')"
+
+    row = conn.execute(
+        f"""
+        SELECT
+            COUNT(*)                                              AS local_calls,
+            COALESCE(SUM(tokens_in), 0)                           AS local_tokens_in,
+            COALESCE(SUM(tokens_out), 0)                          AS local_tokens_out,
+            COALESCE(SUM(tokens_in + tokens_out), 0)              AS local_total_tokens
+        FROM llm_calls
+        {where_sql}
+        """,
+        params,
+    ).fetchone()
+
+    model_rows = conn.execute(
+        f"""
+        SELECT
+            COALESCE(provider, '(unknown)') AS provider,
+            COALESCE(model, '(unknown)')    AS model,
+            COUNT(*)                        AS calls,
+            COALESCE(SUM(tokens_in), 0)     AS tokens_in,
+            COALESCE(SUM(tokens_out), 0)    AS tokens_out,
+            COALESCE(SUM(tokens_in + tokens_out), 0) AS total_tokens
+        FROM llm_calls
+        {where_sql}
+        GROUP BY COALESCE(provider, '(unknown)'), COALESCE(model, '(unknown)')
+        ORDER BY total_tokens DESC
+        """,
+        params,
+    ).fetchall()
+
+    result = dict(row)
+    result["models"] = [dict(r) for r in model_rows]
+    return result
+
+
 def close_thread_conn() -> None:
     """Close this thread's connection — call on clean thread exit if needed."""
     conn = getattr(_local, "conn", None)

--- a/local_power.py
+++ b/local_power.py
@@ -1,0 +1,237 @@
+"""Chip-aware local power estimation.
+
+Estimates the wattage of the local machine for cost modeling of
+locally-run models (Ollama, llama.cpp). On Apple Silicon, detects the
+chip family via sysctl hw.machine and returns a known wattage estimate.
+On non-detected hardware, returns a prompt for the user to configure
+their own wattage value.
+
+Usage as a library:
+    from . import local_power
+    info = local_power.detect()
+    # info.wattage: estimated wattage (int) or None
+    # info.chip: chip identifier string or None
+    # info.is_detected: bool
+
+Usage as a CLI:
+    python -m hermes_telemetry.local_power
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Known Apple Silicon chip wattage estimates (TDP in watts).
+# Sources: Apple documentation, AnandTech, notebookcheck.net.
+# These are approximate TDP values for the full chip.
+# ---------------------------------------------------------------------------
+_APPLE_SILICON_WATTAGE: dict[str, int] = {
+    # M1 family
+    "M1": 15,
+    "M1 Pro": 30,
+    "M1 Max": 50,
+    "M1 Ultra": 90,
+    # M2 family
+    "M2": 15,
+    "M2 Pro": 30,
+    "M2 Max": 50,
+    "M2 Ultra": 90,
+    # M3 family
+    "M3": 15,
+    "M3 Pro": 28,
+    "M3 Max": 50,
+    "M3 Ultra": 90,
+    # M4 family
+    "M4": 15,
+    "M4 Pro": 30,
+    "M4 Max": 50,
+    "M4 Ultra": 90,
+    # M5 family (assumed similar to M4 until official specs)
+    "M5": 15,
+    "M5 Pro": 30,
+    "M5 Max": 50,
+    "M5 Ultra": 90,
+}
+
+# ---------------------------------------------------------------------------
+# Known Apple Silicon machine identifiers from sysctl hw.machine
+# Maps machine name → chip identifier
+# ---------------------------------------------------------------------------
+_APPLE_MACHINE_MAP: dict[str, str] = {
+    # Apple Silicon — arm64 only
+    # M1
+    "MacBookAir10,1": "M1",      # M1 MacBook Air
+    "MacBookPro17,1": "M1",      # M1 MacBook Pro 13"
+    "MacBookPro18,3": "M1 Pro",  # M1 Pro MacBook Pro 14"
+    "MacBookPro18,4": "M1 Pro",  # M1 Pro MacBook Pro 16"
+    "MacBookPro18,1": "M1 Max",  # M1 Max MacBook Pro 14"
+    "MacBookPro18,2": "M1 Max",  # M1 Max MacBook Pro 16"
+    "Macmini9,1": "M1",          # M1 Mac mini
+    "iMac21,1": "M1",            # M1 iMac
+    "iMac21,2": "M1",            # M1 iMac
+    "Mac13,1": "M1 Ultra",       # Mac Studio M1 Ultra
+    "Mac13,2": "M1 Max",         # Mac Studio M1 Max
+    # M2
+    "Mac14,2": "M2",             # M2 MacBook Air
+    "Mac14,7": "M2",             # M2 MacBook Pro 13"
+    "Mac14,5": "M2 Pro",         # M2 Pro MacBook Pro 14"
+    "Mac14,6": "M2 Pro",         # M2 Pro MacBook Pro 16"
+    "Mac14,9": "M2 Max",         # M2 Max MacBook Pro 14"
+    "Mac14,10": "M2 Max",        # M2 Max MacBook Pro 16"
+    "Mac14,3": "M2",             # M2 Mac mini
+    "Mac14,8": "M2 Pro",         # M2 Pro Mac mini
+    "Mac14,12": "M2",            # M2 Mac mini
+    "Mac14,13": "M2 Max",        # M2 Max Mac Studio
+    "Mac14,14": "M2 Ultra",      # M2 Ultra Mac Studio
+    "Mac15,12": "M2 Ultra",      # Mac Pro (2023) M2 Ultra
+    # M3
+    "Mac15,3": "M3",             # M3 MacBook Pro 14"
+    "Mac15,4": "M3",             # M3 iMac
+    "Mac15,5": "M3",             # M3 iMac
+    "Mac15,6": "M3 Pro",         # M3 Pro MacBook Pro 14"
+    "Mac15,7": "M3 Pro",         # M3 Pro MacBook Pro 16"
+    "Mac15,8": "M3 Max",         # M3 Max MacBook Pro 14"
+    "Mac15,9": "M3 Max",         # M3 Max MacBook Pro 16"
+    "Mac15,10": "M3 Max",        # M3 Max MacBook Pro 16"
+    "Mac15,11": "M3",            # M3 iMac
+    "Mac15,13": "M3",            # M3 MacBook Air
+    # M4
+    "Mac16,1": "M4",             # M4 MacBook Pro 14"
+    "Mac16,2": "M4 Pro",         # M4 Pro MacBook Pro 14"
+    "Mac16,3": "M4 Pro",         # M4 Pro MacBook Pro 16"
+    "Mac16,4": "M4 Max",         # M4 Max MacBook Pro 14"
+    "Mac16,5": "M4 Max",         # M4 Max MacBook Pro 16"
+    "Mac16,6": "M4",             # M4 iMac
+    "Mac16,7": "M4",             # M4 MacBook Air
+    "Mac16,8": "M4 Pro",         # M4 Pro Mac mini
+    "Mac16,9": "M4",             # M4 Mac mini
+    "Mac16,10": "M4 Ultra",      # M4 Ultra Mac Studio
+    "Mac16,11": "M4 Max",        # M4 Max Mac Studio
+    "Mac16,12": "M4 Ultra",      # Mac Pro (2024) M4 Ultra
+}
+
+# ---------------------------------------------------------------------------
+# Fallback wattage when detection fails (used as the prompt default).
+# ---------------------------------------------------------------------------
+_GENERIC_WATTAGE = 50
+
+
+@dataclass
+class PowerInfo:
+    """Information about the local machine's power characteristics."""
+
+    wattage: int | None
+    """Estimated chip TDP in watts, or None if unknown."""
+
+    chip: str | None
+    """Detected chip identifier (e.g. 'M3 Pro'), or None."""
+
+    machine: str | None
+    """Raw machine identifier from sysctl (e.g. 'Mac15,6'), or None."""
+
+    is_detected: bool
+    """True if the chip was positively identified via sysctl."""
+
+
+def detect() -> PowerInfo:
+    """Detect chip and estimate wattage.
+
+    Returns a PowerInfo with the best available estimate.
+    If the chip cannot be identified, wattage is None and is_detected is False.
+    """
+    if sys.platform != "darwin":
+        return PowerInfo(
+            wattage=None,
+            chip=None,
+            machine=None,
+            is_detected=False,
+        )
+
+    machine = _get_machine_id()
+    if not machine:
+        return PowerInfo(
+            wattage=None,
+            chip=None,
+            machine=None,
+            is_detected=False,
+        )
+
+    chip = _resolve_chip(machine)
+    if chip:
+        wattage = _APPLE_SILICON_WATTAGE.get(chip, None)
+        return PowerInfo(
+            wattage=wattage,
+            chip=chip,
+            machine=machine,
+            is_detected=True,
+        )
+
+    return PowerInfo(
+        wattage=None,
+        chip=None,
+        machine=machine,
+        is_detected=False,
+    )
+
+
+def get_kwh_per_hour() -> float | None:
+    """Return estimated kWh per hour of runtime, or None if unknown.
+
+    Converts wattage estimate to kWh: wattage / 1000.
+    """
+    info = detect()
+    if info.wattage is not None:
+        return info.wattage / 1000.0
+    return None
+
+
+def _get_machine_id() -> str | None:
+    """Run `sysctl -n hw.machine` and return the machine identifier."""
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "hw.machine"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+        return None
+    except Exception:
+        return None
+
+
+def _resolve_chip(machine: str) -> str | None:
+    """Map a machine identifier to a chip name."""
+    return _APPLE_MACHINE_MAP.get(machine)
+
+
+def _generate_machine_map_help() -> str:
+    """Generate a human-readable table of known machine identifiers."""
+    lines = []
+    for machine, chip in sorted(_APPLE_MACHINE_MAP.items()):
+        lines.append(f"  {machine:20s} → {chip}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    info = detect()
+    if info.is_detected:
+        print(f"Chip:    {info.chip}")
+        print(f"Machine: {info.machine}")
+        print(f"Wattage: {info.wattage} W (TDP estimate)")
+        kwh = get_kwh_per_hour()
+        if kwh is not None:
+            print(f"kWh/hr:  {kwh:.4f}")
+    elif info.machine:
+        print(f"Machine: {info.machine}")
+        print(f"Status:  Unknown chip — set the MINT_LOCAL_WATTAGE env var to your chip's TDP in watts")
+    else:
+        print("Status:  Not running on macOS, or sysctl unavailable")
+        print("Set the MINT_LOCAL_WATTAGE env var to your chip's TDP in watts")

--- a/local_power.py
+++ b/local_power.py
@@ -63,54 +63,54 @@ _APPLE_SILICON_WATTAGE: dict[str, int] = {
 _APPLE_MACHINE_MAP: dict[str, str] = {
     # Apple Silicon — arm64 only
     # M1
-    "MacBookAir10,1": "M1",      # M1 MacBook Air
-    "MacBookPro17,1": "M1",      # M1 MacBook Pro 13"
+    "MacBookAir10,1": "M1",  # M1 MacBook Air
+    "MacBookPro17,1": "M1",  # M1 MacBook Pro 13"
     "MacBookPro18,3": "M1 Pro",  # M1 Pro MacBook Pro 14"
     "MacBookPro18,4": "M1 Pro",  # M1 Pro MacBook Pro 16"
     "MacBookPro18,1": "M1 Max",  # M1 Max MacBook Pro 14"
     "MacBookPro18,2": "M1 Max",  # M1 Max MacBook Pro 16"
-    "Macmini9,1": "M1",          # M1 Mac mini
-    "iMac21,1": "M1",            # M1 iMac
-    "iMac21,2": "M1",            # M1 iMac
-    "Mac13,1": "M1 Ultra",       # Mac Studio M1 Ultra
-    "Mac13,2": "M1 Max",         # Mac Studio M1 Max
+    "Macmini9,1": "M1",  # M1 Mac mini
+    "iMac21,1": "M1",  # M1 iMac
+    "iMac21,2": "M1",  # M1 iMac
+    "Mac13,1": "M1 Ultra",  # Mac Studio M1 Ultra
+    "Mac13,2": "M1 Max",  # Mac Studio M1 Max
     # M2
-    "Mac14,2": "M2",             # M2 MacBook Air
-    "Mac14,7": "M2",             # M2 MacBook Pro 13"
-    "Mac14,5": "M2 Pro",         # M2 Pro MacBook Pro 14"
-    "Mac14,6": "M2 Pro",         # M2 Pro MacBook Pro 16"
-    "Mac14,9": "M2 Max",         # M2 Max MacBook Pro 14"
-    "Mac14,10": "M2 Max",        # M2 Max MacBook Pro 16"
-    "Mac14,3": "M2",             # M2 Mac mini
-    "Mac14,8": "M2 Pro",         # M2 Pro Mac mini
-    "Mac14,12": "M2",            # M2 Mac mini
-    "Mac14,13": "M2 Max",        # M2 Max Mac Studio
-    "Mac14,14": "M2 Ultra",      # M2 Ultra Mac Studio
-    "Mac15,12": "M2 Ultra",      # Mac Pro (2023) M2 Ultra
+    "Mac14,2": "M2",  # M2 MacBook Air
+    "Mac14,7": "M2",  # M2 MacBook Pro 13"
+    "Mac14,5": "M2 Pro",  # M2 Pro MacBook Pro 14"
+    "Mac14,6": "M2 Pro",  # M2 Pro MacBook Pro 16"
+    "Mac14,9": "M2 Max",  # M2 Max MacBook Pro 14"
+    "Mac14,10": "M2 Max",  # M2 Max MacBook Pro 16"
+    "Mac14,3": "M2",  # M2 Mac mini
+    "Mac14,8": "M2 Pro",  # M2 Pro Mac mini
+    "Mac14,12": "M2",  # M2 Mac mini
+    "Mac14,13": "M2 Max",  # M2 Max Mac Studio
+    "Mac14,14": "M2 Ultra",  # M2 Ultra Mac Studio
+    "Mac15,12": "M2 Ultra",  # Mac Pro (2023) M2 Ultra
     # M3
-    "Mac15,3": "M3",             # M3 MacBook Pro 14"
-    "Mac15,4": "M3",             # M3 iMac
-    "Mac15,5": "M3",             # M3 iMac
-    "Mac15,6": "M3 Pro",         # M3 Pro MacBook Pro 14"
-    "Mac15,7": "M3 Pro",         # M3 Pro MacBook Pro 16"
-    "Mac15,8": "M3 Max",         # M3 Max MacBook Pro 14"
-    "Mac15,9": "M3 Max",         # M3 Max MacBook Pro 16"
-    "Mac15,10": "M3 Max",        # M3 Max MacBook Pro 16"
-    "Mac15,11": "M3",            # M3 iMac
-    "Mac15,13": "M3",            # M3 MacBook Air
+    "Mac15,3": "M3",  # M3 MacBook Pro 14"
+    "Mac15,4": "M3",  # M3 iMac
+    "Mac15,5": "M3",  # M3 iMac
+    "Mac15,6": "M3 Pro",  # M3 Pro MacBook Pro 14"
+    "Mac15,7": "M3 Pro",  # M3 Pro MacBook Pro 16"
+    "Mac15,8": "M3 Max",  # M3 Max MacBook Pro 14"
+    "Mac15,9": "M3 Max",  # M3 Max MacBook Pro 16"
+    "Mac15,10": "M3 Max",  # M3 Max MacBook Pro 16"
+    "Mac15,11": "M3",  # M3 iMac
+    "Mac15,13": "M3",  # M3 MacBook Air
     # M4
-    "Mac16,1": "M4",             # M4 MacBook Pro 14"
-    "Mac16,2": "M4 Pro",         # M4 Pro MacBook Pro 14"
-    "Mac16,3": "M4 Pro",         # M4 Pro MacBook Pro 16"
-    "Mac16,4": "M4 Max",         # M4 Max MacBook Pro 14"
-    "Mac16,5": "M4 Max",         # M4 Max MacBook Pro 16"
-    "Mac16,6": "M4",             # M4 iMac
-    "Mac16,7": "M4",             # M4 MacBook Air
-    "Mac16,8": "M4 Pro",         # M4 Pro Mac mini
-    "Mac16,9": "M4",             # M4 Mac mini
-    "Mac16,10": "M4 Ultra",      # M4 Ultra Mac Studio
-    "Mac16,11": "M4 Max",        # M4 Max Mac Studio
-    "Mac16,12": "M4 Ultra",      # Mac Pro (2024) M4 Ultra
+    "Mac16,1": "M4",  # M4 MacBook Pro 14"
+    "Mac16,2": "M4 Pro",  # M4 Pro MacBook Pro 14"
+    "Mac16,3": "M4 Pro",  # M4 Pro MacBook Pro 16"
+    "Mac16,4": "M4 Max",  # M4 Max MacBook Pro 14"
+    "Mac16,5": "M4 Max",  # M4 Max MacBook Pro 16"
+    "Mac16,6": "M4",  # M4 iMac
+    "Mac16,7": "M4",  # M4 MacBook Air
+    "Mac16,8": "M4 Pro",  # M4 Pro Mac mini
+    "Mac16,9": "M4",  # M4 Mac mini
+    "Mac16,10": "M4 Ultra",  # M4 Ultra Mac Studio
+    "Mac16,11": "M4 Max",  # M4 Max Mac Studio
+    "Mac16,12": "M4 Ultra",  # Mac Pro (2024) M4 Ultra
 }
 
 # ---------------------------------------------------------------------------
@@ -161,7 +161,7 @@ def detect() -> PowerInfo:
 
     chip = _resolve_chip(machine)
     if chip:
-        wattage = _APPLE_SILICON_WATTAGE.get(chip, None)
+        wattage = _APPLE_SILICON_WATTAGE.get(chip)
         return PowerInfo(
             wattage=wattage,
             chip=chip,
@@ -231,7 +231,9 @@ if __name__ == "__main__":
             print(f"kWh/hr:  {kwh:.4f}")
     elif info.machine:
         print(f"Machine: {info.machine}")
-        print(f"Status:  Unknown chip — set the MINT_LOCAL_WATTAGE env var to your chip's TDP in watts")
+        print(
+            "Status:  Unknown chip — set the MINT_LOCAL_WATTAGE env var to your chip's TDP in watts"
+        )
     else:
         print("Status:  Not running on macOS, or sysctl unavailable")
         print("Set the MINT_LOCAL_WATTAGE env var to your chip's TDP in watts")

--- a/pricing.py
+++ b/pricing.py
@@ -413,6 +413,111 @@ def _resolve_pricing(model: str, provider: str = "") -> dict | None:
     return resolved
 
 
+# ---------------------------------------------------------------------------
+# Local model cost estimation via chip-aware power (issue #164, Milestone 2)
+# ---------------------------------------------------------------------------
+
+# Local model providers that use on-device inference
+_LOCAL_PROVIDERS = frozenset({"ollama", "llama.cpp", "llama-cpp", "llamacpp"})
+
+# Default electricity rate (USD per kWh) — US average residential rate.
+# Override with MINT_ELECTRICITY_RATE env var.
+_DEFAULT_ELECTRICITY_RATE = 0.12
+
+# Default tokens per second estimate for local models.
+# Override with MINT_LOCAL_TOKENS_PER_SECOND env var.
+_DEFAULT_TOKENS_PER_SECOND = 25
+
+
+def _is_local_provider(provider: str) -> bool:
+    """Return True if provider indicates a locally-run model."""
+    if not provider:
+        return False
+    prov_lower = provider.lower()
+    return any(
+        local in prov_lower
+        for local in _LOCAL_PROVIDERS
+    )
+
+
+def _get_electricity_rate() -> float:
+    """Return the configured electricity rate in USD per kWh."""
+    rate_str = os.environ.get("MINT_ELECTRICITY_RATE", "")
+    if rate_str:
+        with contextlib.suppress(ValueError):
+            return float(rate_str)
+    return _DEFAULT_ELECTRICITY_RATE
+
+
+def _get_local_tokens_per_second() -> float:
+    """Return the configured tokens-per-second estimate for local models."""
+    tps_str = os.environ.get("MINT_LOCAL_TOKENS_PER_SECOND", "")
+    if tps_str:
+        with contextlib.suppress(ValueError):
+            val = float(tps_str)
+            if val > 0:
+                return val
+    return _DEFAULT_TOKENS_PER_SECOND
+
+
+def _get_local_wattage() -> int | None:
+    """Return chip-aware wattage or user-configured wattage.
+
+    Priority:
+    1. MINT_LOCAL_WATTAGE env var (user override)
+    2. local_power.detect() (chip-aware detection)
+    3. None (undetected)
+    """
+    watt_str = os.environ.get("MINT_LOCAL_WATTAGE", "")
+    if watt_str:
+        with contextlib.suppress(ValueError):
+            val = int(watt_str)
+            if val > 0:
+                return val
+
+    try:
+        from .local_power import detect as detect_power
+
+        info = detect_power()
+        if info.is_detected and info.wattage is not None:
+            return info.wattage
+    except ImportError:
+        pass
+
+    return None
+
+
+def _compute_local_cost(
+    total_tokens: int,
+    wattage: int | None = None,
+    electric_rate: float | None = None,
+    tokens_per_second: float | None = None,
+) -> float:
+    """Compute estimated electricity cost for a local model.
+
+    Formula:
+      cost = wattage_kW * electric_rate * hours
+    where
+      hours = total_tokens / tokens_per_second / 3600
+
+    Returns 0.0 if wattage is unknown (undetected hardware).
+    """
+    if wattage is None:
+        wattage = _get_local_wattage()
+    if wattage is None:
+        return 0.0
+
+    if electric_rate is None:
+        electric_rate = _get_electricity_rate()
+    if tokens_per_second is None:
+        tokens_per_second = _get_local_tokens_per_second()
+
+    # kilowatts * dollars_per_kwh * hours
+    kw = wattage / 1000.0
+    hours = total_tokens / tokens_per_second / 3600.0
+    return kw * electric_rate * hours
+
+
 def estimate_cost(usage: dict, model: str, provider: str = "") -> float:
     """Return estimated cost in USD for a usage dict.
 
@@ -444,15 +549,41 @@ def estimate_cost(usage: dict, model: str, provider: str = "") -> float:
     cache_write_tok = int(usage.get("cache_write_tokens") or 0)
     reasoning_tok = int(usage.get("reasoning_tokens") or 0)
 
-    if (
-        input_tokens == 0
-        and output_tokens == 0
-        and cache_read_tok == 0
-        and cache_write_tok == 0
-        and reasoning_tok == 0
-    ):
+    total_tokens = (
+        input_tokens
+        + output_tokens
+        + cache_read_tok
+        + cache_write_tok
+        + reasoning_tok
+    )
+
+    if total_tokens == 0:
         return 0.0
 
+    # Local model cost: use chip-aware wattage as cost basis (issue #164)
+    if _is_local_provider(provider):
+        wattage = _get_local_wattage()
+        cost = _compute_local_cost(total_tokens, wattage=wattage)
+        if cost == 0.0 and wattage is not None:
+            # Degenerate case: wattage detected but compute produced 0
+            return 0.0
+        if wattage is None:
+            # Undetected hardware: log warning, return 0.0
+            warn_key = ("local_unknown_hw", provider)
+            if warn_key not in _warned_unknown:
+                _warned_unknown.add(warn_key)
+                logger.warning(
+                    "hermes-telemetry: local model %r on provider %r — chip "
+                    "wattage could not be detected. Cost recorded as $0.00. "
+                    "Set MINT_LOCAL_WATTAGE env var to your chip's TDP to get "
+                    "local cost estimates.",
+                    model,
+                    provider,
+                )
+            return 0.0
+        return cost
+
+    # Cloud model cost: standard token pricing lookup
     prices = _resolve_pricing(model, provider)
     if prices is None:
         # Dedup per (model, provider): the same model id can be unpriced under

--- a/stats.py
+++ b/stats.py
@@ -333,6 +333,85 @@ def _models_block(
     return "\n".join(lines)
 
 
+def _local_power_block(
+    window_hours: int | None = None, *, date_from: str | None = None, date_to: str | None = None
+) -> str:
+    """Render estimated local-model (on-device) inference cost.
+
+    Aggregates llm_calls served by local providers (ollama / llama.cpp) and
+    converts their token volume into an estimated electricity cost using the
+    chip-aware wattage from local_power (or MINT_LOCAL_WATTAGE override).
+    """
+    from . import local_power as _lp
+    from . import pricing as _pricing
+
+    summary = db.local_power_summary(
+        window_hours=window_hours, date_from=date_from, date_to=date_to
+    )
+    label = _window_label(window_hours) if window_hours else _date_range_label(date_from, date_to)
+
+    local_calls = int(summary.get("local_calls") or 0)
+    if local_calls == 0:
+        return f"No local (on-device) model calls recorded in {label}."
+
+    total_tokens = int(summary.get("local_total_tokens") or 0)
+
+    # Estimated electricity cost for the aggregated local token volume.
+    est_cost = _pricing._compute_local_cost(total_tokens)
+
+    # Machine power posture (for the footer).
+    power = _lp.detect()
+
+    lines = [
+        f"hermes-telemetry — local power ({label})",
+        "=" * 78,
+        f"  Local calls    : {_fmt_int(local_calls)}",
+        f"  Tokens in      : {_fmt_int(summary.get('local_tokens_in'))}",
+        f"  Tokens out     : {_fmt_int(summary.get('local_tokens_out'))}",
+        f"  Total tokens   : {_fmt_int(total_tokens)}",
+        f"  Est. cost      : {_fmt_cost(est_cost)}",
+    ]
+
+    models = summary.get("models") or []
+    if models:
+        lines.append("")
+        lines.append("  Per model:")
+        lines.append(f"    {'Model':<46} {'Calls':>6} {'Tokens':>10} {'Est. cost':>12}")
+        lines.append("    " + "-" * 78)
+        for m in models:
+            name = f"{m.get('provider') or '(unknown)'}/{m.get('model') or '(unknown)'}"
+            name = name[:46]
+            calls = _fmt_int(m.get("calls"))
+            toks = _fmt_int(m.get("total_tokens"))
+            cost = _fmt_cost(_pricing._compute_local_cost(int(m.get("total_tokens") or 0)))
+            lines.append(f"    {name:<46} {calls:>6} {toks:>10} {cost:>12}")
+
+    lines.append("")
+    if power.is_detected:
+        lines.append(
+            f"  Chip detected  : {power.chip} ({power.wattage} W TDP estimate) on {power.machine}"
+        )
+    elif power.machine:
+        lines.append(
+            f"  Chip           : undetected (machine {power.machine}); "
+            f"set MINT_LOCAL_WATTAGE to your chip's TDP in watts"
+        )
+    else:
+        lines.append(
+            "  Chip           : undetected (not on macOS or sysctl unavailable); "
+            "set MINT_LOCAL_WATTAGE to your chip's TDP in watts"
+        )
+    lines.append(
+        f"  Electricity    : ${_pricing._get_electricity_rate():.2f}/kWh, "
+        f"{_pricing._get_local_tokens_per_second():.0f} tok/s assumed"
+    )
+    lines.append(
+        "  Cost basis     : wattage_kW * rate * (tokens / tok_per_s / 3600). "
+        "Local cost is an electricity estimate, not a cloud bill."
+    )
+    return "\n".join(lines)
+
+
 def _raw_block(limit: int = 20, *, date_from: str | None = None, date_to: str | None = None) -> str:
     rows = db.recent_runs(limit, date_from=date_from, date_to=date_to)
     if not rows:
@@ -514,6 +593,17 @@ def handle(raw_args: str) -> str:
         if sub == "month":
             return _models_block(720)
 
+    if args.startswith("local-power"):
+        sub = args[len("local-power") :].strip()
+        if has_range and sub in ("", "today", "week", "month"):
+            return _local_power_block(date_from=date_from, date_to=date_to)
+        if sub in ("", "today"):
+            return _local_power_block(24)
+        if sub == "week":
+            return _local_power_block(168)
+        if sub == "month":
+            return _local_power_block(720)
+
     return (
         "Usage: /stats [today|week|month|cron|cron week|cron month|providers|models|raw [N]]\n"
         "             [--from YYYY-MM-DD[THH:MM:SS[Z]]] [--to YYYY-MM-DD[THH:MM:SS[Z]]]\n"
@@ -525,6 +615,8 @@ def handle(raw_args: str) -> str:
         "  /stats providers week — provider breakdown, last 7 days\n"
         "  /stats models        — per-model breakdown within each provider (24h)\n"
         "  /stats models week   — per-model breakdown, last 7 days\n"
+        "  /stats local-power   — estimated local (on-device) model cost, last 24h\n"
+        "  /stats local-power week — local model cost, last 7 days\n"
         "  /stats raw [N]       — last N raw run records (default 20)\n"
         "\n"
         "Date range examples (work the same way under the CLI):\n"

--- a/telemetry_cli.py
+++ b/telemetry_cli.py
@@ -22,6 +22,9 @@ _STATS_WINDOW_HOURS: dict[str, int] = {
     "models": 24,
     "models-week": 168,
     "models-month": 720,
+    "local-power": 24,
+    "local-power-week": 168,
+    "local-power-month": 720,
 }
 
 _STATS_CHOICES = list(_STATS_WINDOW_HOURS)
@@ -194,6 +197,8 @@ def _stats_text(subcommand: str, date_from: str | None, date_to: str | None) -> 
         print(stats._providers_block(date_from=date_from, date_to=date_to))
     elif subcommand.startswith("models"):
         print(stats._models_block(date_from=date_from, date_to=date_to))
+    elif subcommand.startswith("local-power"):
+        print(stats._local_power_block(date_from=date_from, date_to=date_to))
     else:
         # today, week, month, last-N-days
         print(stats._summary_block(date_from=date_from, date_to=date_to))
@@ -206,6 +211,8 @@ def _stats_json(subcommand: str, date_from: str | None, date_to: str | None) -> 
         data = db.stats_by_provider(date_from=date_from, date_to=date_to)
     elif subcommand.startswith("models"):
         data = db.stats_by_model(date_from=date_from, date_to=date_to)
+    elif subcommand.startswith("local-power"):
+        data = db.local_power_summary(date_from=date_from, date_to=date_to)
     else:
         # today, week, month, last-N-days
         data = db.stats_summary(date_from=date_from, date_to=date_to)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1565,3 +1565,47 @@ def test_spend_by_scope_profile_filters():
 
     result = db.spend_by_scope("profile", "coder", "2000-01-01T00:00:00+00:00")
     assert result["spent_usd"] == 1.50
+
+
+# ---------------------------------------------------------------------------
+# Local power summary (issue #164, Milestone 3)
+# ---------------------------------------------------------------------------
+
+
+def test_local_power_summary_aggregates_local_providers():
+    now = db._utcnow()
+    # Local provider calls (ollama / llama.cpp variants)
+    db.record_llm_call("s_local1", now, "llama3", "ollama", 1000, 200, 0.0, 100)
+    db.record_llm_call("s_local2", now, "mixtral", "llama.cpp", 500, 100, 0.0, 80)
+    # A non-local provider call that must NOT be counted
+    db.record_llm_call("s_api", now, "gpt-4o", "openai", 3000, 500, 0.05, 200)
+
+    s = db.local_power_summary()
+    assert s["local_calls"] == 2
+    assert s["local_tokens_in"] == 1500
+    assert s["local_tokens_out"] == 300
+    assert s["local_total_tokens"] == 1800
+    models = {m["provider"]: m for m in s["models"]}
+    assert "ollama" in models and "llama.cpp" in models
+    assert models["ollama"]["total_tokens"] == 1200
+    assert models["llama.cpp"]["total_tokens"] == 600
+
+
+def test_local_power_summary_empty_window():
+    s = db.local_power_summary()
+    assert s["local_calls"] == 0
+    assert s["local_total_tokens"] == 0
+    assert s["models"] == []
+
+
+def test_local_power_summary_date_filter():
+    now = db._utcnow()
+    db.record_llm_call("s_old", "2000-01-01T00:00:00+00:00", "llama3", "ollama", 100, 10, 0.0, 50)
+    db.record_llm_call("s_new", now, "llama3", "ollama", 200, 20, 0.0, 50)
+    s = db.local_power_summary(date_from="2099-01-01T00:00:00+00:00")
+    assert s["local_calls"] == 0
+    s2 = db.local_power_summary(
+        date_from="1999-01-01T00:00:00+00:00", date_to="2001-01-01T00:00:00+00:00"
+    )
+    assert s2["local_calls"] == 1
+    assert s2["local_total_tokens"] == 110

--- a/tests/test_local_power.py
+++ b/tests/test_local_power.py
@@ -1,18 +1,16 @@
 """Tests for local_power module."""
 
 import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-
 from hermes_telemetry.local_power import (
-    detect,
-    get_kwh_per_hour,
-    PowerInfo,
     _APPLE_MACHINE_MAP,
     _APPLE_SILICON_WATTAGE,
+    PowerInfo,
     _resolve_chip,
-    _GENERIC_WATTAGE,
+    detect,
+    get_kwh_per_hour,
 )
 
 
@@ -33,72 +31,66 @@ class TestDetect:
 
     def test_darwin_no_sysctl_returns_undetected(self):
         """sysctl failure should return undetected."""
-        with patch.object(sys, "platform", "darwin"):
-            with patch(
-                "hermes_telemetry.local_power._get_machine_id",
-                return_value=None,
-            ):
-                info = detect()
+        with patch.object(sys, "platform", "darwin"), patch(
+            "hermes_telemetry.local_power._get_machine_id",
+            return_value=None,
+        ):
+            info = detect()
         assert not info.is_detected
         assert info.wattage is None
         assert info.machine is None
 
     def test_darwin_unknown_machine_returns_undetected(self):
         """Unknown machine ID should return undetected with the machine set."""
-        with patch.object(sys, "platform", "darwin"):
-            with patch(
-                "hermes_telemetry.local_power._get_machine_id",
-                return_value="UnknownMachine1,1",
-            ):
-                info = detect()
+        with patch.object(sys, "platform", "darwin"), patch(
+            "hermes_telemetry.local_power._get_machine_id",
+            return_value="UnknownMachine1,1",
+        ):
+            info = detect()
         assert not info.is_detected
         assert info.wattage is None
         assert info.chip is None
         assert info.machine == "UnknownMachine1,1"
 
     def test_detects_m1_macbook_air(self):
-        with patch.object(sys, "platform", "darwin"):
-            with patch(
-                "hermes_telemetry.local_power._get_machine_id",
-                return_value="MacBookAir10,1",
-            ):
-                info = detect()
+        with patch.object(sys, "platform", "darwin"), patch(
+            "hermes_telemetry.local_power._get_machine_id",
+            return_value="MacBookAir10,1",
+        ):
+            info = detect()
         assert info.is_detected
         assert info.chip == "M1"
         assert info.machine == "MacBookAir10,1"
         assert info.wattage == 15
 
     def test_detects_m3_pro(self):
-        with patch.object(sys, "platform", "darwin"):
-            with patch(
-                "hermes_telemetry.local_power._get_machine_id",
-                return_value="Mac15,6",
-            ):
-                info = detect()
+        with patch.object(sys, "platform", "darwin"), patch(
+            "hermes_telemetry.local_power._get_machine_id",
+            return_value="Mac15,6",
+        ):
+            info = detect()
         assert info.is_detected
         assert info.chip == "M3 Pro"
         assert info.machine == "Mac15,6"
         assert info.wattage == 28
 
     def test_detects_m4_max(self):
-        with patch.object(sys, "platform", "darwin"):
-            with patch(
-                "hermes_telemetry.local_power._get_machine_id",
-                return_value="Mac16,4",
-            ):
-                info = detect()
+        with patch.object(sys, "platform", "darwin"), patch(
+            "hermes_telemetry.local_power._get_machine_id",
+            return_value="Mac16,4",
+        ):
+            info = detect()
         assert info.is_detected
         assert info.chip == "M4 Max"
         assert info.machine == "Mac16,4"
         assert info.wattage == 50
 
     def test_detects_m2_ultra(self):
-        with patch.object(sys, "platform", "darwin"):
-            with patch(
-                "hermes_telemetry.local_power._get_machine_id",
-                return_value="Mac14,14",
-            ):
-                info = detect()
+        with patch.object(sys, "platform", "darwin"), patch(
+            "hermes_telemetry.local_power._get_machine_id",
+            return_value="Mac14,14",
+        ):
+            info = detect()
         assert info.is_detected
         assert info.chip == "M2 Ultra"
         assert info.wattage == 90
@@ -106,12 +98,11 @@ class TestDetect:
 
 class TestGetKwhPerHour:
     def test_returns_float_when_detected(self):
-        with patch.object(sys, "platform", "darwin"):
-            with patch(
-                "hermes_telemetry.local_power._get_machine_id",
-                return_value="MacBookAir10,1",
-            ):
-                kwh = get_kwh_per_hour()
+        with patch.object(sys, "platform", "darwin"), patch(
+            "hermes_telemetry.local_power._get_machine_id",
+            return_value="MacBookAir10,1",
+        ):
+            kwh = get_kwh_per_hour()
         assert kwh == pytest.approx(0.015)  # 15W / 1000
 
     def test_returns_none_when_undetected(self):
@@ -120,12 +111,11 @@ class TestGetKwhPerHour:
         assert kwh is None
 
     def test_m3_pro_kwh(self):
-        with patch.object(sys, "platform", "darwin"):
-            with patch(
-                "hermes_telemetry.local_power._get_machine_id",
-                return_value="Mac15,6",
-            ):
-                kwh = get_kwh_per_hour()
+        with patch.object(sys, "platform", "darwin"), patch(
+            "hermes_telemetry.local_power._get_machine_id",
+            return_value="Mac15,6",
+        ):
+            kwh = get_kwh_per_hour()
         assert kwh == pytest.approx(0.028)  # 28W / 1000
 
 
@@ -164,8 +154,7 @@ class TestResolveChip:
         """Every machine in the map should have a wattage entry."""
         for machine, chip in _APPLE_MACHINE_MAP.items():
             assert chip in _APPLE_SILICON_WATTAGE, (
-                f"Machine '{machine}' maps to chip '{chip}' "
-                f"which has no wattage entry"
+                f"Machine '{machine}' maps to chip '{chip}' which has no wattage entry"
             )
 
 

--- a/tests/test_local_power.py
+++ b/tests/test_local_power.py
@@ -1,0 +1,223 @@
+"""Tests for local_power module."""
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from hermes_telemetry.local_power import (
+    detect,
+    get_kwh_per_hour,
+    PowerInfo,
+    _APPLE_MACHINE_MAP,
+    _APPLE_SILICON_WATTAGE,
+    _resolve_chip,
+    _GENERIC_WATTAGE,
+)
+
+
+class TestDetect:
+    def test_linux_returns_undetected(self):
+        """On non-darwin, detection returns is_detected=False."""
+        with patch.object(sys, "platform", "linux"):
+            info = detect()
+        assert not info.is_detected
+        assert info.wattage is None
+        assert info.chip is None
+        assert info.machine is None
+
+    def test_windows_returns_undetected(self):
+        with patch.object(sys, "platform", "win32"):
+            info = detect()
+        assert not info.is_detected
+
+    def test_darwin_no_sysctl_returns_undetected(self):
+        """sysctl failure should return undetected."""
+        with patch.object(sys, "platform", "darwin"):
+            with patch(
+                "hermes_telemetry.local_power._get_machine_id",
+                return_value=None,
+            ):
+                info = detect()
+        assert not info.is_detected
+        assert info.wattage is None
+        assert info.machine is None
+
+    def test_darwin_unknown_machine_returns_undetected(self):
+        """Unknown machine ID should return undetected with the machine set."""
+        with patch.object(sys, "platform", "darwin"):
+            with patch(
+                "hermes_telemetry.local_power._get_machine_id",
+                return_value="UnknownMachine1,1",
+            ):
+                info = detect()
+        assert not info.is_detected
+        assert info.wattage is None
+        assert info.chip is None
+        assert info.machine == "UnknownMachine1,1"
+
+    def test_detects_m1_macbook_air(self):
+        with patch.object(sys, "platform", "darwin"):
+            with patch(
+                "hermes_telemetry.local_power._get_machine_id",
+                return_value="MacBookAir10,1",
+            ):
+                info = detect()
+        assert info.is_detected
+        assert info.chip == "M1"
+        assert info.machine == "MacBookAir10,1"
+        assert info.wattage == 15
+
+    def test_detects_m3_pro(self):
+        with patch.object(sys, "platform", "darwin"):
+            with patch(
+                "hermes_telemetry.local_power._get_machine_id",
+                return_value="Mac15,6",
+            ):
+                info = detect()
+        assert info.is_detected
+        assert info.chip == "M3 Pro"
+        assert info.machine == "Mac15,6"
+        assert info.wattage == 28
+
+    def test_detects_m4_max(self):
+        with patch.object(sys, "platform", "darwin"):
+            with patch(
+                "hermes_telemetry.local_power._get_machine_id",
+                return_value="Mac16,4",
+            ):
+                info = detect()
+        assert info.is_detected
+        assert info.chip == "M4 Max"
+        assert info.machine == "Mac16,4"
+        assert info.wattage == 50
+
+    def test_detects_m2_ultra(self):
+        with patch.object(sys, "platform", "darwin"):
+            with patch(
+                "hermes_telemetry.local_power._get_machine_id",
+                return_value="Mac14,14",
+            ):
+                info = detect()
+        assert info.is_detected
+        assert info.chip == "M2 Ultra"
+        assert info.wattage == 90
+
+
+class TestGetKwhPerHour:
+    def test_returns_float_when_detected(self):
+        with patch.object(sys, "platform", "darwin"):
+            with patch(
+                "hermes_telemetry.local_power._get_machine_id",
+                return_value="MacBookAir10,1",
+            ):
+                kwh = get_kwh_per_hour()
+        assert kwh == pytest.approx(0.015)  # 15W / 1000
+
+    def test_returns_none_when_undetected(self):
+        with patch.object(sys, "platform", "linux"):
+            kwh = get_kwh_per_hour()
+        assert kwh is None
+
+    def test_m3_pro_kwh(self):
+        with patch.object(sys, "platform", "darwin"):
+            with patch(
+                "hermes_telemetry.local_power._get_machine_id",
+                return_value="Mac15,6",
+            ):
+                kwh = get_kwh_per_hour()
+        assert kwh == pytest.approx(0.028)  # 28W / 1000
+
+
+class TestPowerInfo:
+    def test_power_info_dataclass_fields(self):
+        info = PowerInfo(
+            wattage=15,
+            chip="M1",
+            machine="MacBookAir10,1",
+            is_detected=True,
+        )
+        assert info.wattage == 15
+        assert info.chip == "M1"
+        assert info.machine == "MacBookAir10,1"
+        assert info.is_detected is True
+
+    def test_power_info_undetected_defaults(self):
+        info = PowerInfo(
+            wattage=None,
+            chip=None,
+            machine=None,
+            is_detected=False,
+        )
+        assert info.wattage is None
+        assert info.is_detected is False
+
+
+class TestResolveChip:
+    def test_known_machine(self):
+        assert _resolve_chip("MacBookAir10,1") == "M1"
+
+    def test_unknown_machine(self):
+        assert _resolve_chip("UnknownMachine1,1") is None
+
+    def test_all_mapped_machines_have_wattage(self):
+        """Every machine in the map should have a wattage entry."""
+        for machine, chip in _APPLE_MACHINE_MAP.items():
+            assert chip in _APPLE_SILICON_WATTAGE, (
+                f"Machine '{machine}' maps to chip '{chip}' "
+                f"which has no wattage entry"
+            )
+
+
+class TestWattageTable:
+    def test_all_chips_have_positive_wattage(self):
+        for chip, wattage in _APPLE_SILICON_WATTAGE.items():
+            assert wattage > 0, f"Chip '{chip}' has non-positive wattage: {wattage}"
+
+    def test_known_chips_have_expected_wattage(self):
+        assert _APPLE_SILICON_WATTAGE["M1"] == 15
+        assert _APPLE_SILICON_WATTAGE["M1 Pro"] == 30
+        assert _APPLE_SILICON_WATTAGE["M1 Max"] == 50
+        assert _APPLE_SILICON_WATTAGE["M1 Ultra"] == 90
+        assert _APPLE_SILICON_WATTAGE["M3 Pro"] == 28
+        assert _APPLE_SILICON_WATTAGE["M4"] == 15
+
+
+class TestSysctlIntegration:
+    @patch("subprocess.run")
+    def test_sysctl_success(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Mac15,6\n"
+        mock_run.return_value = mock_result
+
+        from hermes_telemetry.local_power import _get_machine_id
+
+        result = _get_machine_id()
+        assert result == "Mac15,6"
+        mock_run.assert_called_once_with(
+            ["sysctl", "-n", "hw.machine"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+    @patch("subprocess.run")
+    def test_sysctl_failure(self, mock_run):
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_run.return_value = mock_result
+
+        from hermes_telemetry.local_power import _get_machine_id
+
+        result = _get_machine_id()
+        assert result is None
+
+    @patch("subprocess.run")
+    def test_sysctl_exception(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("sysctl not found")
+
+        from hermes_telemetry.local_power import _get_machine_id
+
+        result = _get_machine_id()
+        assert result is None

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1087,3 +1087,133 @@ def test_get_known_free_models_includes_subscription_models(tmp_path, monkeypatc
     assert "hermes-4-qwen-72b" in models
     assert "paid-model" not in models
     pricing.reload_custom_pricing()
+
+
+# ---------------------------------------------------------------------------
+# Local provider cost estimation (issue #164, Milestone 2)
+# ---------------------------------------------------------------------------
+
+
+class TestIsLocalProvider:
+    def test_ollama_is_local(self):
+        assert pricing._is_local_provider("ollama")
+
+    def test_llama_cpp_is_local(self):
+        assert pricing._is_local_provider("llama.cpp")
+
+    def test_llamacpp_is_local(self):
+        assert pricing._is_local_provider("llamacpp")
+
+    def test_llama_cpp_variation_is_local(self):
+        assert pricing._is_local_provider("Llama.CPP")
+
+    def test_empty_provider_is_not_local(self):
+        assert not pricing._is_local_provider("")
+
+    def test_anthropic_is_not_local(self):
+        assert not pricing._is_local_provider("anthropic")
+
+    def test_none_string_is_not_local(self):
+        assert not pricing._is_local_provider("")
+
+    def test_openrouter_is_not_local(self):
+        assert not pricing._is_local_provider("openrouter")
+
+
+class TestLocalCostComputation:
+    def test_compute_local_cost_with_known_wattage(self):
+        # 15W, 1M tokens at 25 t/s → cost
+        cost = pricing._compute_local_cost(
+            1_000_000, wattage=15, electric_rate=0.12, tokens_per_second=25
+        )
+        # hours = 1_000_000 / 25 / 3600 = 11.11
+        # cost = 0.015 * 0.12 * 11.11 = 0.02
+        assert cost > 0.0
+        assert cost < 1.0
+        assert abs(cost - 0.02) < 0.01
+
+    def test_compute_local_cost_zero_tokens(self):
+        cost = pricing._compute_local_cost(
+            0, wattage=15, electric_rate=0.12, tokens_per_second=25
+        )
+        assert cost == 0.0
+
+    def test_compute_local_cost_unknown_wattage(self):
+        cost = pricing._compute_local_cost(
+            1_000_000, wattage=None, electric_rate=0.12, tokens_per_second=25
+        )
+        assert cost == 0.0
+
+    def test_compute_local_cost_custom_electricity_rate(self):
+        cost = pricing._compute_local_cost(
+            1_000_000, wattage=15, electric_rate=0.24, tokens_per_second=25
+        )
+        # Double the electricity rate should roughly double the cost
+        base_cost = pricing._compute_local_cost(
+            1_000_000, wattage=15, electric_rate=0.12, tokens_per_second=25
+        )
+        assert abs(cost - (base_cost * 2)) < 0.0001
+
+    def test_compute_local_cost_custom_tokens_per_second(self):
+        cost = pricing._compute_local_cost(
+            1_000_000, wattage=15, electric_rate=0.12, tokens_per_second=50
+        )
+        # Double tps should halve the cost
+        base_cost = pricing._compute_local_cost(
+            1_000_000, wattage=15, electric_rate=0.12, tokens_per_second=25
+        )
+        assert abs(cost - (base_cost / 2)) < 0.0001
+
+
+class TestLocalProviderEstimateCost:
+    def test_local_ollama_uses_wattage_not_token_pricing(self, monkeypatch):
+        """With ollama provider, cost comes from chip wattage, not token pricing table."""
+        monkeypatch.setenv("MINT_LOCAL_WATTAGE", "15")
+        # This model has no pricing entry — but it shouldn't matter for local provider
+        cost = pricing.estimate_cost(
+            {"input_tokens": 1_000_000}, "llama3.2", provider="ollama"
+        )
+        assert cost > 0.0
+
+    def test_local_llama_cpp_uses_wattage(self, monkeypatch):
+        monkeypatch.setenv("MINT_LOCAL_WATTAGE", "28")
+        cost = pricing.estimate_cost(
+            {"input_tokens": 1_000_000}, "mistral", provider="llama.cpp"
+        )
+        assert cost > 0.0
+
+    def test_local_undetected_returns_zero(self, monkeypatch):
+        """When wattage is undetected and no env var set, local cost is $0."""
+        monkeypatch.delenv("MINT_LOCAL_WATTAGE", raising=False)
+        with monkeypatch.context() as m:
+            m.setattr(pricing, "_get_local_wattage", lambda: None)
+            cost = pricing.estimate_cost(
+                {"input_tokens": 1_000_000}, "local-model", provider="ollama"
+            )
+        assert cost == 0.0
+
+    def test_local_does_not_affect_cloud_providers(self, monkeypatch):
+        """Cloud providers still use normal token pricing."""
+        monkeypatch.setenv("MINT_LOCAL_WATTAGE", "15")
+        cost = pricing.estimate_cost(
+            {"input_tokens": 1_000_000}, "claude-sonnet-4-6", provider="anthropic"
+        )
+        assert abs(cost - 3.00) < 1e-9
+
+    def test_local_cost_scales_with_tokens(self, monkeypatch):
+        monkeypatch.setenv("MINT_LOCAL_WATTAGE", "15")
+        cost_1m = pricing.estimate_cost(
+            {"input_tokens": 1_000_000}, "llama3.2", provider="ollama"
+        )
+        cost_2m = pricing.estimate_cost(
+            {"input_tokens": 2_000_000}, "llama3.2", provider="ollama"
+        )
+        assert cost_2m > cost_1m
+        assert abs(cost_2m - (cost_1m * 2)) < 0.0001
+
+    def test_local_zero_tokens_is_zero(self, monkeypatch):
+        monkeypatch.setenv("MINT_LOCAL_WATTAGE", "15")
+        cost = pricing.estimate_cost(
+            {"input_tokens": 0, "output_tokens": 0}, "llama3.2", provider="ollama"
+        )
+        assert cost == 0.0

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -232,6 +232,61 @@ def test_stats_models_json_windowed(argv, expected_from_substr, capsys):
     assert kwargs.get("date_to") is None
 
 
+@pytest.mark.parametrize(
+    "argv,expected_from_substr",
+    [
+        (["stats", "local-power"], "202"),
+        (["stats", "local-power-week"], "202"),
+        (["stats", "local-power-month"], "202"),
+    ],
+)
+def test_stats_local_power_text(argv, expected_from_substr, capsys):
+    with patch("hermes_telemetry.stats._local_power_block", return_value="LP") as m:
+        main(argv)
+    out, _ = capsys.readouterr()
+    assert out == "LP\n"
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert expected_from_substr in kwargs["date_from"]
+    assert kwargs.get("date_to") is None
+
+
+def test_stats_local_power_json(capsys):
+    fake = {
+        "local_calls": 2,
+        "local_tokens_in": 1500,
+        "local_tokens_out": 300,
+        "local_total_tokens": 1800,
+        "models": [],
+    }
+    with patch("hermes_telemetry.telemetry_cli.db.local_power_summary", return_value=fake) as m:
+        main(["stats", "local-power", "--json"])
+    out, _ = capsys.readouterr()
+    data = _json.loads(out)
+    assert data["local_calls"] == 2
+    assert data["local_total_tokens"] == 1800
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert kwargs.get("date_to") is None
+
+
+@pytest.mark.parametrize(
+    "argv,expected_from_substr",
+    [
+        (["stats", "local-power-week", "--json"], "202"),
+        (["stats", "local-power-month", "--json"], "202"),
+    ],
+)
+def test_stats_local_power_json_windowed(argv, expected_from_substr, capsys):
+    fake = {"local_calls": 0, "local_total_tokens": 0, "models": []}
+    with patch("hermes_telemetry.telemetry_cli.db.local_power_summary", return_value=fake) as m:
+        main(argv)
+    args, kwargs = m.call_args
+    assert kwargs.get("date_from") is not None
+    assert expected_from_substr in kwargs["date_from"]
+    assert kwargs.get("date_to") is None
+
+
 from hermes_telemetry.budget import BudgetVerdict  # noqa: E402
 
 


### PR DESCRIPTION
Card: https://github.com/nujovich/hermes-radar/issues/164

## Decision

Nadia chose **Option B** — Chip-aware local power only.

## Milestones

- [x] Milestone 1 — Add `local_power.py` module with Apple Silicon detection (sysctl hw.machine) and wattage estimation
- [x] Milestone 2 — Wire into pricing.py: when model is local (ollama/llama.cpp), use chip-aware wattage as cost basis
- [x] Milestone 3 — Add /stats local-power subcommand showing estimated local cost

## Milestone 3 detail

Added the `stats local-power` subcommand (standalone CLI + `/stats local-power` slash handler) that surfaces on-device inference cost for local providers (ollama / llama.cpp):

- `db.local_power_summary(window_hours, date_from, date_to)` — aggregates `llm_calls` whose provider contains `ollama` or `llama` (mirroring `pricing._is_local_provider`), returning local call count, input/output/total token sums, and a per-(provider, model) breakdown.

- `stats._local_power_block(...)` — renders the totals, per-model token volume + estimated electricity cost, and a footer with the detected chip/wattage (or the `MINT_LOCAL_WATTAGE` prompt when undetected) plus the electricity rate and tokens/sec assumptions.

- `telemetry_cli.py` — registered `local-power`, `local-power-week`, `local-power-month` in `_STATS_CHOICES` with text and `--json` output routing to `db.local_power_summary`.

- Cost basis is `wattage_kW * rate * (tokens / tok_per_s / 3600)`, applied at render time so it respects `MINT_LOCAL_WATTAGE` / chip detection (same path Milestone 2 uses for actual cost recording). The slash handler's usage text and help were updated to list the new subcommand.

### Milestone 3 tests

- `tests/test_db.py`: `test_local_power_summary_aggregates_local_providers` (local vs API exclusion, per-model totals), `test_local_power_summary_empty_window`, `test_local_power_summary_date_filter`.
- `tests/test_telemetry_cli.py`: `test_stats_local_power_text` (parametrized over the 3 windows), `test_stats_local_power_json`, `test_stats_local_power_json_windowed`.

All new tests pass; full `test_db` / `test_telemetry_cli` / `test_stats_*` / `test_local_power` suites green (177 passed).
