### PR TITLE
fix(db): repair missing subagent_edges via _migrate_v13

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -410,6 +410,7 @@ table before applying.
 | v10 | MoA (Mixture-of-Agents) attribution: `llm_calls.moa_preset` (preset name for a MoA aggregator call; NULL otherwise) + `runs.moa_calls` (per-session counter). See `§ Mixture of Agents (MoA)`. |
 | v11 | New table `subagent_edges` (parent→child delegation tree) + `idx_subagent_edges_parent`. Attributes async/nested subagent cost to `per_cron_job` via a recursive CTE at query time. (#49) |
 | v12 | Add `runs.profile` (per-profile cost attribution) + `idx_runs_profile`. Captured from `ctx.profile_name` at `on_session_start`, backfilled in `pre_llm_call` (first non-null wins). Adds the `per_profile` budget scope. |
+| v13 | Repair pass — re-creates `subagent_edges` (+ `idx_subagent_edges_parent`) via `CREATE TABLE IF NOT EXISTS`. Heals DBs upgraded from a build that numbered a *different* migration as v11: the per-profile branch shipped `runs.profile` as v11 before #56 settled `subagent_edges` on v11, so those DBs have `version=11` applied but no table, and v11's early-return skips creation forever. No-op on clean v11 DBs. |
 
 `_SCHEMA_VERSION` in `db.py` is the latest applied version — keep it in lockstep
 with the highest `_migrate_vN`. `test_schema_idempotent` asserts the count of

--- a/db.py
+++ b/db.py
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 12
+_SCHEMA_VERSION = 13
 _local = threading.local()
 
 # Serializes first-time schema setup across threads. Each thread opens its own
@@ -169,6 +169,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _migrate_v10(conn)
     _migrate_v11(conn)
     _migrate_v12(conn)
+    _migrate_v13(conn)
 
 
 def _migrate_v2(conn: sqlite3.Connection) -> None:
@@ -477,6 +478,45 @@ def _migrate_v12(conn: sqlite3.Connection) -> None:
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (12, ?)",
+        (_utcnow(),),
+    )
+
+
+def _migrate_v13(conn: sqlite3.Connection) -> None:
+    """Repair migration: ensure ``subagent_edges`` exists.
+
+    v11 created ``subagent_edges`` but guards on the v11 marker. A DB upgraded
+    from a build that numbered a *different* migration as v11 (the per-profile
+    branch shipped ``runs.profile`` as v11 before #56 settled subagent_edges on
+    v11) has ``version = 11`` applied yet no ``subagent_edges`` table. On such a
+    DB ``_migrate_v11`` sees the marker and skips forever, so the table is never
+    created and ``record_subagent_start`` / ``spend_by_scope`` silently fail.
+    This forward-only pass re-creates the table (identical DDL to v11, ``IF NOT
+    EXISTS`` so it is a no-op on clean v11 DBs). See ONBOARDING.md § Schema
+    evolution.
+    """
+    cur = conn.execute("SELECT version FROM schema_version WHERE version = 13")
+    if cur.fetchone() is not None:
+        return
+
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS subagent_edges (
+            child_session_id   TEXT PRIMARY KEY,
+            parent_session_id  TEXT NOT NULL,
+            parent_turn_id     TEXT,
+            parent_subagent_id TEXT,
+            child_subagent_id  TEXT,
+            child_role         TEXT,
+            started_at         TEXT NOT NULL,
+            stopped_at         TEXT,
+            child_status       TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_subagent_edges_parent
+            ON subagent_edges(parent_session_id);
+    """)
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (13, ?)",
         (_utcnow(),),
     )
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1531,6 +1531,59 @@ def test_migrate_v12_repairs_missing_column_from_v11():
     assert "profile" in cols, "v12 must re-add runs.profile when it was missing"
 
 
+# ---------------------------------------------------------------------------
+# v13 — repair subagent_edges when v11 was marked without creating the table
+# (cross-branch skew: a build that numbered profile — not subagent_edges — as
+# v11 leaves a DB with version 11 applied but no subagent_edges table. v11's
+# own early-return then skips creation forever, so a plain upgrade to a build
+# where v11 IS subagent_edges never heals it. v13 is the forward-only repair.)
+# ---------------------------------------------------------------------------
+
+
+def test_schema_v13_recorded():
+    versions = {row[0] for row in db._get_conn().execute("SELECT version FROM schema_version")}
+    assert 13 in versions
+
+
+def test_migrate_v13_repairs_subagent_edges_when_v11_marked_without_table():
+    """A DB where subagent_edges is MISSING but version 11 is already marked
+    (profile-as-v11 lineage). _migrate_v11 early-returns on the v11 marker, so it
+    never re-creates the table; only v13 can. The repaired table must match the
+    canonical v11 shape and accept edge writes."""
+    conn = db._get_conn()
+
+    # Canonical (v11-created) shape, captured before we wedge the DB.
+    expected_cols = {r[1] for r in conn.execute("PRAGMA table_info(subagent_edges)")}
+    expected_indexes = {r[1] for r in conn.execute("PRAGMA index_list('subagent_edges')")}
+
+    # Simulate the cross-branch wedge: drop the table but KEEP version 11 marked
+    # (clear only >= 13 so v13 is pending while 11 and 12 stay applied).
+    conn.execute("DROP TABLE IF EXISTS subagent_edges")
+    conn.execute("DELETE FROM schema_version WHERE version >= 13")
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "subagent_edges" not in tables  # wedged state confirmed
+    assert (
+        conn.execute("SELECT version FROM schema_version WHERE version = 11").fetchone() is not None
+    )  # v11 stays marked — v11 alone can NOT heal this
+
+    db._ensure_schema(conn)
+
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "subagent_edges" in tables, "v13 must create subagent_edges when v11 skipped it"
+    assert {r[1] for r in conn.execute("PRAGMA table_info(subagent_edges)")} == expected_cols
+    assert {r[1] for r in conn.execute("PRAGMA index_list('subagent_edges')")} == expected_indexes
+
+    db.record_subagent_start(
+        child_session_id="c-v13",
+        parent_session_id="p-v13",
+        started_at="2026-07-06T00:00:00+00:00",
+    )
+    row = conn.execute(
+        "SELECT parent_session_id FROM subagent_edges WHERE child_session_id='c-v13'"
+    ).fetchone()
+    assert row["parent_session_id"] == "p-v13"
+
+
 def test_start_run_stores_profile():
     db.start_run("s_prof", "m", "cli", profile="coder")
     assert db.get_run("s_prof")["profile"] == "coder"


### PR DESCRIPTION
## Problem

A DB upgraded from a build that numbered `runs.profile` as migration **v11** (the per-profile branch, before #56 settled `subagent_edges` on v11) ends up with `version=11` applied but **no `subagent_edges` table**. Because `_migrate_v11` early-returns on the v11 marker, it never creates the table once the plugin moves to a build where v11 *is* `subagent_edges`. Result: `record_subagent_start` and `spend_by_scope` hit a missing table and **fail silently** — subagent→parent attribution and per-cron subtree cost break with no visible error.

Observed on a live install: `schema_version` max = 11, `runs.profile` present, `subagent_edges` absent.

## Fix

`_migrate_v13` re-creates `subagent_edges` (+ `idx_subagent_edges_parent`) with `CREATE TABLE IF NOT EXISTS` — **identical DDL to v11**. Forward-only, idempotent, no-op on clean v11/v12 DBs. Never edits `_migrate_v11`.

## Tests

- `test_schema_v13_recorded` — fresh DB records v13.
- `test_migrate_v13_repairs_subagent_edges_when_v11_marked_without_table` — reproduces the exact wedge (table dropped, `version=11` **kept marked**) and proves only v13 heals it, that the repaired schema matches the canonical v11 shape (columns + indexes), and that an edge write succeeds end-to-end.
- `test_schema_idempotent` covers the `_SCHEMA_VERSION` 12→13 lockstep.

## Docs

ONBOARDING.md § Schema evolution: added the v13 row.

Full suite green under `TZ=UTC` (377 passed, 6 skipped).
