### PR TITLE
feat: opt-in canonical telemetry home (HERMES_TELEMETRY_HOME)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,3 +122,9 @@ hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
 Tests redirect `HERMES_HOME` to an isolated tmp dir. A direct `Path.home()` call
 escapes the isolation and touches the developer's real `~/.hermes`.
 See `tests/test_isolation.py` and `ONBOARDING.md § Test Isolation Contract`.
+
+Telemetry files (`telemetry.db`, `budget.yaml`, `pricing.yaml`) additionally honor an
+opt-in `HERMES_TELEMETRY_HOME` that **outranks** `HERMES_HOME`, resolved once in
+`paths.py::get_telemetry_home()`. Route telemetry paths through `paths.py` (the dashboard
+surfaces replicate it inline — they must stay self-contained). Tests neutralize
+`HERMES_TELEMETRY_HOME` in `conftest.py` so it cannot break isolation.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1095,6 +1095,14 @@ seed it in the per-test temp dir, not rely on real files.
 pytest's built-in `tmp_path` fixture mints this per test. Override the base dir
 with `pytest --basetemp=DIR`.
 
+### `HERMES_TELEMETRY_HOME` neutralization
+
+`HERMES_TELEMETRY_HOME` outranks `HERMES_HOME` when resolving telemetry paths. The autouse
+`isolate_hermes_home` fixture (`conftest.py`) therefore DELETES `HERMES_TELEMETRY_HOME` per
+test, so a developer's ambient value cannot override the tmp redirect and leak the suite into
+the real `~/.hermes/telemetry`. Enforced by
+`tests/test_isolation.py::test_conftest_neutralizes_ambient_telemetry_home`.
+
 ---
 
 ## Design Decisions by Version
@@ -1383,6 +1391,38 @@ manual cleanup.
 
 All paths derived from `os.environ.get("HERMES_HOME", Path.home() / ".hermes")`.
 **Never use `Path.home()` directly** — breaks test isolation.
+
+---
+
+## Canonical telemetry home (`HERMES_TELEMETRY_HOME`)
+
+Telemetry file locations resolve through `paths.py`:
+
+- `paths.get_telemetry_home()` — PURE resolver (never creates the dir), precedence:
+  1. `HERMES_TELEMETRY_HOME` — opt-in shared cost-center dir, if set
+  2. `HERMES_HOME` — this profile's Hermes home
+  3. `~/.hermes` — default
+  …always under a `telemetry/` subdir.
+- `paths.get_db_path()` — `telemetry.db`; the ONLY getter that creates the telemetry dir
+  (the DB writes there).
+- `paths.get_budget_path()` / `paths.get_pricing_path()` — `budget.yaml` / `pricing.yaml`;
+  pure (no mkdir), so an absent/unwritable canonical home never turns a config read into a
+  crash (absence of `budget.yaml` = "budgets disabled").
+
+When `HERMES_TELEMETRY_HOME` is set, every profile/process/cron shares one `telemetry.db`,
+one `budget.yaml`, and one `pricing.yaml` — the single-pane cost center. When unset, behavior
+is unchanged (each `HERMES_HOME` keeps its own, still profile-tagged, telemetry dir).
+
+**Governs telemetry files only.** `state.db` and `cron/` are NOT relocated — they stay on
+`HERMES_HOME`.
+
+**Package vs dashboard.** The package runtime (`db.py`, `budget.py`, `pricing.py`) routes
+through `paths.py` (`db.py`/`pricing.py` use a `try: from . import paths / except ImportError:
+import paths` dual-mode import because some tests bare-import them). The dashboard surfaces
+(`dashboard/plugin_api.py`, `dashboard/serve.py`) are loaded outside the package and are
+code-isolated (`tests/test_dashboard_plugin_isolation.py`), so they replicate the precedence
+inline rather than importing `paths.py`. This PR updated `serve.py` (telemetry DB);
+`plugin_api.py` follows in the dashboard PR.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -828,6 +828,12 @@ budgets:
     overrides:
       premium_user_123:
         daily_usd: 5.00
+  per_profile:
+    default:
+      daily_usd: 2.00
+    overrides:
+      coder:
+        daily_usd: 10.00
 
 thresholds:
   soft_pct: 0.80    # warn at 80% of limit
@@ -844,6 +850,7 @@ on_estimated:
 |`global`      |All sessions + all cron jobs combined                        |
 |`per_cron_job`|Sessions where `cron_job_id` matches (excludes subagent cost)|
 |`per_sender`  |Sessions from a specific sender (multi-user gateways)        |
+|`per_profile` |Sessions tagged with a specific Hermes profile (`ctx.profile_name`)|
 
 **Window math:** daily and monthly windows are computed in the user’s local timezone. A cron job that runs at 11:59 PM and another at 12:01 AM count against different daily windows.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ LLM provider
   - [/stats](#stats)
   - [/budget](#budget)
 - [Configuration](#configuration)
+  - [Shared telemetry home (HERMES_TELEMETRY_HOME)](#shared-telemetry-home-hermes_telemetry_home)
   - [pricing.yaml](#pricingyaml)
   - [budget.yaml](#budgetyaml)
 - [Pricing Auto-Refresh](#pricing-auto-refresh)
@@ -731,6 +732,20 @@ Configuration lives in `~/.hermes/telemetry/`:
 ```
 
 If these files don’t exist, the plugin still works — it just uses defaults (all models at $0.00, budgets disabled).
+
+### Shared telemetry home (`HERMES_TELEMETRY_HOME`)
+
+By default the `telemetry/` directory above resolves from your Hermes home (`HERMES_HOME`; `~/.hermes/` for the default profile), so **each Hermes profile keeps its own separate telemetry**.
+
+If you run multiple profiles and want a single **shared cost center** — one `telemetry.db`, one `budget.yaml`, and one `pricing.yaml` that every profile reads and writes — set the opt-in `HERMES_TELEMETRY_HOME` to a common directory in each profile's environment:
+
+```bash
+export HERMES_TELEMETRY_HOME=~/.hermes-shared
+```
+
+Telemetry paths resolve with precedence **`HERMES_TELEMETRY_HOME` › `HERMES_HOME` › `~/.hermes`**. When unset, nothing changes — each profile keeps its own (profile-tagged) telemetry dir.
+
+> This relocates **telemetry files only** (`telemetry.db`, `budget.yaml`, `pricing.yaml`). It never moves Hermes's own `state.db` or `cron/`, which stay on `HERMES_HOME`.
 
 ### `pricing.yaml`
 

--- a/budget.py
+++ b/budget.py
@@ -33,7 +33,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from . import db
+from . import db, paths
 
 logger = logging.getLogger(__name__)
 
@@ -113,13 +113,11 @@ _verdict_lock = threading.Lock()
 
 
 def _budget_path() -> Path:
-    hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
-    return hermes_home / "telemetry" / "budget.yaml"
+    return paths.get_budget_path()
 
 
 def _pricing_path() -> Path:
-    hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
-    return hermes_home / "telemetry" / "pricing.yaml"
+    return paths.get_pricing_path()
 
 
 def load_config() -> dict:

--- a/conftest.py
+++ b/conftest.py
@@ -42,6 +42,10 @@ def isolate_hermes_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Windows equivalent of HOME
+    # HERMES_TELEMETRY_HOME outranks HERMES_HOME (paths.get_telemetry_home);
+    # a developer's ambient value would otherwise override the tmp redirect and
+    # leak the suite into the real ~/.hermes/telemetry. Clear it per test.
+    monkeypatch.delenv("HERMES_TELEMETRY_HOME", raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -48,7 +48,20 @@ logger = logging.getLogger("hermes_telemetry.dashboard")
 # DB / Hermes paths
 # ---------------------------------------------------------------------------
 HERMES_HOME = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
-DB_PATH = HERMES_HOME / "telemetry" / "telemetry.db"
+# Telemetry files honor the opt-in canonical home (HERMES_TELEMETRY_HOME), so a
+# multi-profile user can point every profile's dashboard at one shared DB. This
+# mirrors paths.get_telemetry_home(); serve.py replicates it inline because the
+# standalone dashboard shares no code with the package (see
+# tests/test_dashboard_plugin_isolation.py). state.db / cron stay on HERMES_HOME.
+_TELEMETRY_HOME = (
+    Path(
+        os.environ.get("HERMES_TELEMETRY_HOME")
+        or os.environ.get("HERMES_HOME")
+        or str(Path.home() / ".hermes")
+    )
+    / "telemetry"
+)
+DB_PATH = _TELEMETRY_HOME / "telemetry.db"
 STATE_DB_PATH = HERMES_HOME / "state.db"
 CRON_JOBS_PATH = HERMES_HOME / "cron" / "jobs.json"
 CRON_OUTPUT_DIR = HERMES_HOME / "cron" / "output"

--- a/db.py
+++ b/db.py
@@ -30,12 +30,16 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import os
 import sqlite3
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+try:
+    from . import paths
+except ImportError:  # pragma: no cover - db.py loaded standalone (no package context)
+    import paths
 
 logger = logging.getLogger(__name__)
 
@@ -51,10 +55,7 @@ _schema_lock = threading.Lock()
 
 
 def _get_db_path() -> Path:
-    hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
-    tele_dir = hermes_home / "telemetry"
-    tele_dir.mkdir(parents=True, exist_ok=True)
-    return tele_dir / "telemetry.db"
+    return paths.get_db_path()
 
 
 def _get_conn() -> sqlite3.Connection:

--- a/paths.py
+++ b/paths.py
@@ -1,0 +1,48 @@
+"""Single source of truth for hermes-telemetry state-file locations.
+
+Resolves the telemetry directory with an opt-in canonical home:
+  1. HERMES_TELEMETRY_HOME  — shared cost-center dir, if set
+  2. HERMES_HOME            — this profile's Hermes home
+  3. ~/.hermes              — default
+
+get_telemetry_home() is a PURE resolver — it never creates the directory.
+Only get_db_path() creates it, because the DB writes there. The budget/pricing
+path getters stay pure so an unwritable canonical home never turns a read into
+a crash — absence of budget.yaml is the "budgets disabled" signal, not an error.
+
+Governs telemetry files ONLY (telemetry.db, budget.yaml, pricing.yaml).
+state.db and cron/ belong to the Hermes core home and are NOT relocated here.
+
+The dashboard surfaces (dashboard/plugin_api.py, dashboard/serve.py) do NOT
+import this module: the Hermes web server loads plugin_api.py standalone (no
+package context, repo root not on sys.path) and
+tests/test_dashboard_plugin_isolation.py enforces that the two dashboard
+surfaces share zero code. They replicate the precedence inline by design.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def get_telemetry_home() -> Path:
+    """Resolve the telemetry directory (pure — does NOT create it)."""
+    override = os.environ.get("HERMES_TELEMETRY_HOME") or os.environ.get("HERMES_HOME")
+    root = Path(override) if override else Path.home() / ".hermes"
+    return root / "telemetry"
+
+
+def get_db_path() -> Path:
+    """Path to telemetry.db. Ensures the telemetry dir exists (the DB writes there)."""
+    home = get_telemetry_home()
+    home.mkdir(parents=True, exist_ok=True)
+    return home / "telemetry.db"
+
+
+def get_budget_path() -> Path:
+    return get_telemetry_home() / "budget.yaml"
+
+
+def get_pricing_path() -> Path:
+    return get_telemetry_home() / "pricing.yaml"

--- a/pricing.py
+++ b/pricing.py
@@ -23,8 +23,11 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import os
-from pathlib import Path
+
+try:
+    from . import paths
+except ImportError:  # pragma: no cover - pricing.py loaded standalone (no package context)
+    import paths
 
 logger = logging.getLogger(__name__)
 
@@ -166,8 +169,7 @@ def _load_custom_pricing() -> dict:
     global _custom_pricing
     if _custom_pricing is not None:
         return _custom_pricing
-    hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
-    pricing_file = hermes_home / "telemetry" / "pricing.yaml"
+    pricing_file = paths.get_pricing_path()
     if not pricing_file.exists():
         _custom_pricing = _empty_custom_pricing()
         return _custom_pricing

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -915,3 +915,20 @@ def test_api_cron_includes_scheduler_runs_without_telemetry(serve_module, monkey
     assert by_job["script-only"]["last_status"] == "ok"
     assert by_job["telemetry-job"]["runs"] == 2
     assert by_job["telemetry-job"]["tokens_in"] == 50
+
+
+def test_serve_db_path_honors_telemetry_home(tmp_path, monkeypatch):
+    """serve.py resolves its telemetry DB from HERMES_TELEMETRY_HOME when set,
+    but keeps state.db / cron on HERMES_HOME."""
+    import importlib.util
+
+    monkeypatch.setenv("HERMES_TELEMETRY_HOME", str(tmp_path / "shared"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+
+    spec = importlib.util.spec_from_file_location("dashboard_serve_th", _SERVE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert tmp_path / "shared" / "telemetry" / "telemetry.db" == module.DB_PATH
+    assert tmp_path / "profile" / "state.db" == module.STATE_DB_PATH
+    assert tmp_path / "profile" / "cron" / "jobs.json" == module.CRON_JOBS_PATH

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -907,9 +907,7 @@ def test_unknown_model_is_not_known_free():
 
 
 def test_schema_v5_recorded():
-    from db import _get_conn
-
-    versions = {row[0] for row in _get_conn().execute("SELECT version FROM schema_version")}
+    versions = {row[0] for row in db._get_conn().execute("SELECT version FROM schema_version")}
     assert 5 in versions
 
 
@@ -980,9 +978,7 @@ def test_free_tier_transition_suffixed_paid_id():
 
 
 def test_schema_v6_recorded():
-    from db import _get_conn
-
-    versions = {row[0] for row in _get_conn().execute("SELECT version FROM schema_version")}
+    versions = {row[0] for row in db._get_conn().execute("SELECT version FROM schema_version")}
     assert 6 in versions
 
 
@@ -1554,6 +1550,14 @@ def test_set_profile_ignores_empty():
     db.set_profile("s_empty", "")
     db.set_profile("s_empty", None)
     assert db.get_run("s_empty")["profile"] is None
+
+
+def test_get_db_path_honors_telemetry_home(tmp_path, monkeypatch):
+    """db._get_db_path routes through the canonical home: when
+    HERMES_TELEMETRY_HOME is set, the DB resolves there, not under HERMES_HOME."""
+    monkeypatch.setenv("HERMES_TELEMETRY_HOME", str(tmp_path / "shared"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    assert db._get_db_path() == tmp_path / "shared" / "telemetry" / "telemetry.db"
 
 
 def test_spend_by_scope_profile_filters():

--- a/tests/test_isolation.py
+++ b/tests/test_isolation.py
@@ -64,3 +64,22 @@ def test_budget_status_ignores_real_home_pricing(tmp_path, monkeypatch):
         "budget._status_block() read pricing.yaml from Path.home() instead of "
         "HERMES_HOME — real-home isolation is broken"
     )
+
+
+def test_conftest_neutralizes_ambient_telemetry_home():
+    """The autouse isolation fixture must clear HERMES_TELEMETRY_HOME so a
+    developer's ambient value cannot override the tmp HERMES_HOME and leak the
+    suite into the real telemetry dir."""
+    import os
+
+    assert "HERMES_TELEMETRY_HOME" not in os.environ
+
+
+def test_telemetry_home_precedence_stays_in_tmp():
+    """With the fixture active and no ambient var, telemetry resolves under the
+    tmp HERMES_HOME — never the developer's real ~/.hermes."""
+    import os
+
+    import hermes_telemetry.paths as paths
+
+    assert paths.get_telemetry_home() == Path(os.environ["HERMES_HOME"]) / "telemetry"

--- a/tests/test_isolation.py
+++ b/tests/test_isolation.py
@@ -83,3 +83,14 @@ def test_telemetry_home_precedence_stays_in_tmp():
     import hermes_telemetry.paths as paths
 
     assert paths.get_telemetry_home() == Path(os.environ["HERMES_HOME"]) / "telemetry"
+
+
+def test_budget_paths_honor_telemetry_home(tmp_path, monkeypatch):
+    """budget._budget_path / _pricing_path route through the canonical home."""
+    import hermes_telemetry.budget as budget
+
+    monkeypatch.setenv("HERMES_TELEMETRY_HOME", str(tmp_path / "shared"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    tele = tmp_path / "shared" / "telemetry"
+    assert budget._budget_path() == tele / "budget.yaml"
+    assert budget._pricing_path() == tele / "pricing.yaml"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,50 @@
+"""paths.py — single source of truth for telemetry file locations."""
+
+from pathlib import Path
+
+import hermes_telemetry.paths as paths
+
+
+def test_prefers_telemetry_home_over_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_TELEMETRY_HOME", str(tmp_path / "shared"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    assert paths.get_telemetry_home() == tmp_path / "shared" / "telemetry"
+
+
+def test_falls_back_to_hermes_home_when_telemetry_home_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_TELEMETRY_HOME", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    assert paths.get_telemetry_home() == tmp_path / "profile" / "telemetry"
+
+
+def test_defaults_to_dot_hermes_when_both_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_TELEMETRY_HOME", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert paths.get_telemetry_home() == tmp_path / ".hermes" / "telemetry"
+
+
+def test_get_db_path_creates_telemetry_dir(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_TELEMETRY_HOME", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    db_path = paths.get_db_path()
+    assert db_path == tmp_path / "profile" / "telemetry" / "telemetry.db"
+    assert db_path.parent.is_dir()
+
+
+def test_budget_and_pricing_paths_do_not_create_dir(tmp_path, monkeypatch):
+    """Resolving budget/pricing paths must be pure (no mkdir) so an unwritable
+    canonical home never turns a read into a crash."""
+    monkeypatch.delenv("HERMES_TELEMETRY_HOME", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    paths.get_budget_path()
+    paths.get_pricing_path()
+    assert not (tmp_path / "profile" / "telemetry").exists()
+
+
+def test_db_budget_pricing_share_one_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_TELEMETRY_HOME", str(tmp_path / "shared"))
+    tele = tmp_path / "shared" / "telemetry"
+    assert paths.get_db_path() == tele / "telemetry.db"
+    assert paths.get_budget_path() == tele / "budget.yaml"
+    assert paths.get_pricing_path() == tele / "pricing.yaml"

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1087,3 +1087,26 @@ def test_get_known_free_models_includes_subscription_models(tmp_path, monkeypatc
     assert "hermes-4-qwen-72b" in models
     assert "paid-model" not in models
     pricing.reload_custom_pricing()
+
+
+# ---------------------------------------------------------------------------
+# Canonical home routing (HERMES_TELEMETRY_HOME) — per-profile cost center
+# ---------------------------------------------------------------------------
+
+
+def test_custom_pricing_reads_from_telemetry_home(tmp_path, monkeypatch):
+    """_load_custom_pricing reads pricing.yaml from the canonical home when
+    HERMES_TELEMETRY_HOME is set."""
+    import hermes_telemetry.pricing as pricing
+
+    shared_tele = tmp_path / "shared" / "telemetry"
+    shared_tele.mkdir(parents=True)
+    (shared_tele / "pricing.yaml").write_text(
+        "models:\n  my/model:\n    input: 1.0\n    output: 2.0\n"
+    )
+    monkeypatch.setenv("HERMES_TELEMETRY_HOME", str(tmp_path / "shared"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    pricing._custom_pricing = None  # clear module cache
+
+    loaded = pricing._load_custom_pricing()
+    assert "my/model" in loaded["models"]


### PR DESCRIPTION
## Summary

Per-profile cost center — **Slice 2 / PR 1**. Introduces an opt-in canonical telemetry home so multiple Hermes profiles can point at one shared telemetry directory.

- **New `paths.py`** — single source of truth for telemetry file locations. `get_telemetry_home()` resolves with precedence `HERMES_TELEMETRY_HOME` > `HERMES_HOME` > `~/.hermes` (under a `telemetry/` subdir). It is a **pure resolver**; only `get_db_path()` creates the directory (the DB writes there), so `get_budget_path()`/`get_pricing_path()` stay pure and an absent/unwritable canonical home never turns a config read into a crash.
- **Routed the package runtime** (`db.py`, `budget.py`, `pricing.py`) through `paths.py`. When `HERMES_TELEMETRY_HOME` is unset, behavior is unchanged — each `HERMES_HOME` keeps its own (still profile-tagged) telemetry dir.
- **Standalone dashboard `serve.py`** honors `HERMES_TELEMETRY_HOME` for its telemetry DB (replicated **inline** — it stays code-isolated from the plugin surface, per `test_dashboard_plugin_isolation.py`). `state.db` and `cron/` deliberately stay on `HERMES_HOME`.
- **Test isolation hardened**: the autouse `isolate_hermes_home` fixture now deletes `HERMES_TELEMETRY_HOME` per test, so a developer's ambient value can't override the tmp redirect and leak the suite into the real `~/.hermes/telemetry`.
- **Docs**: `ONBOARDING.md` (canonical-home section + Test Isolation Contract update) and `CLAUDE.md` file-isolation rule.

**Not in this PR** (follow-up PR 2): dashboard profile-awareness (`plugin_api.py` profile filter + per-profile DB resolution + selector in `TelemetryPage`).

**No schema change** (`_SCHEMA_VERSION` unchanged, no migration); no version bump.

## Test Plan

- [x] `ruff format --check . && ruff check .` — clean
- [x] `TZ=UTC pytest tests/ -v` — 387 passed, 6 skipped
- [x] `tests/test_paths.py` — precedence, dir created only via `get_db_path()`, budget/pricing paths pure
- [x] `tests/test_isolation.py` — ambient `HERMES_TELEMETRY_HOME` neutralized; `HERMES_HOME` fallback intact; budget/pricing routing honors the canonical home
- [x] `tests/test_db.py` / `tests/test_pricing.py` — DB & pricing resolution honor `HERMES_TELEMETRY_HOME`
- [x] `tests/test_dashboard.py` — `serve.py` DB path honors the canonical home; `state.db`/`cron` stay on `HERMES_HOME`; dashboard isolation guard still green