### PR TITLE
feat(dashboard): per-profile filter for the Telemetry tab

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1425,6 +1425,26 @@ code-isolated (`tests/test_dashboard_plugin_isolation.py`), so they replicate th
 inline rather than importing `paths.py`. This PR updated `serve.py` (telemetry DB);
 `plugin_api.py` follows in the dashboard PR.
 
+### Dashboard profile awareness (plugin surface)
+
+`dashboard/plugin_api.py` reads the canonical telemetry home (inline `HERMES_TELEMETRY_HOME`
+precedence — self-contained, no `paths.py` import). Its aggregate endpoints accept an optional
+`profile` query param: `runs`-based endpoints filter `AND profile = ?`; `llm_calls`-based
+endpoints filter `AND session_id IN (SELECT session_id FROM runs WHERE profile = ?)` (a
+correlated subquery — avoids a JOIN and the runs/llm_calls column-name ambiguity). `/profiles`
+returns the distinct non-null profiles. The `dist/index.js` `TelemetryPage` renders a selector
+(shown only when profiles exist) that threads `&profile=` into each panel. Shared-mode only —
+there is no cross-DB reading (consolidate via `HERMES_TELEMETRY_HOME` first). `/budget` and the
+slot widgets are not profile-filtered.
+
+**Gotcha — no `X | None` on FastAPI route params.** The `profile` query param is declared
+`profile: str = ""` (not `str | None = None`). FastAPI evaluates route-parameter annotations at
+decoration time (`get_type_hints`), and `str | None` raises `TypeError` on Python 3.8/3.9 (this
+repo targets `>=3.8`) — even with `from __future__ import annotations`. `Optional[str]` avoids
+that but ruff `UP045` would demand `X | None` back. `str = ""` is annotated, ruff-clean,
+cross-version-safe, and falsy-when-absent (the helpers gate on `if profile:`), so it's the
+correct shape for optional query params in this file.
+
 ---
 
 ## PluginContext API

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ hermes gateway restart
   - `cron:top` — 7-day cron cost and failure badge.
   - `header-right` — 24h spend + global daily budget level (semáforo).
   - `analytics:bottom` — daily cost chart (Chart.js served from a vendored local asset; CDN fallback only).
+- **Profile filter** — when telemetry is consolidated via `HERMES_TELEMETRY_HOME`, a selector in the Telemetry tab filters every view (Summary / Runs / Requests / Providers / Cron) by Hermes profile. Hidden when no profile data is present.
 
 ### How discovery works
 

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -58,12 +58,14 @@
     );
   }
 
-  function SummaryPanel() {
+  const profileQS = (p) => (p ? `&profile=${encodeURIComponent(p)}` : "");
+
+  function SummaryPanel({ profile }) {
     const [data, setData] = useState(null);
     const [err, setErr] = useState(null);
     useEffect(() => {
-      api("/summary?window_hours=24").then(setData).catch((e) => setErr(String(e)));
-    }, []);
+      api(`/summary?window_hours=24${profileQS(profile)}`).then(setData).catch((e) => setErr(String(e)));
+    }, [profile]);
     if (err) return h(Card, null, h(CardContent, { className: "py-4 text-sm" },
       "Backend not reachable: ", err));
     if (!data) return h(Card, null, h(CardContent, { className: "py-4 text-sm" }, "Loading…"));
@@ -102,9 +104,9 @@
     );
   }
 
-  function RunsPanel() {
+  function RunsPanel({ profile }) {
     const [data, setData] = useState(null);
-    useEffect(() => { api("/runs?limit=50&window_hours=168").then(setData).catch(() => setData({ rows: [] })); }, []);
+    useEffect(() => { api(`/runs?limit=50&window_hours=168${profileQS(profile)}`).then(setData).catch(() => setData({ rows: [] })); }, [profile]);
     if (!data) return h("p", { className: "text-sm" }, "Loading…");
     return h(RowsTable, {
       rows: data.rows,
@@ -123,9 +125,9 @@
     });
   }
 
-  function RequestsPanel() {
+  function RequestsPanel({ profile }) {
     const [data, setData] = useState(null);
-    useEffect(() => { api("/requests?limit=100&window_hours=168").then(setData).catch(() => setData({ rows: [] })); }, []);
+    useEffect(() => { api(`/requests?limit=100&window_hours=168${profileQS(profile)}`).then(setData).catch(() => setData({ rows: [] })); }, [profile]);
     if (!data) return h("p", { className: "text-sm" }, "Loading…");
     return h(RowsTable, {
       rows: data.rows,
@@ -148,9 +150,9 @@
     });
   }
 
-  function ProvidersPanel() {
+  function ProvidersPanel({ profile }) {
     const [data, setData] = useState(null);
-    useEffect(() => { api("/providers?window_hours=168").then(setData).catch(() => setData({ rows: [] })); }, []);
+    useEffect(() => { api(`/providers?window_hours=168${profileQS(profile)}`).then(setData).catch(() => setData({ rows: [] })); }, [profile]);
     if (!data) return h("p", { className: "text-sm" }, "Loading…");
     return h(RowsTable, {
       rows: data.rows,
@@ -167,9 +169,9 @@
     });
   }
 
-  function CronPanel() {
+  function CronPanel({ profile }) {
     const [data, setData] = useState(null);
-    useEffect(() => { api("/cron?window_hours=720").then(setData).catch(() => setData({ rows: [] })); }, []);
+    useEffect(() => { api(`/cron?window_hours=720${profileQS(profile)}`).then(setData).catch(() => setData({ rows: [] })); }, [profile]);
     if (!data) return h("p", { className: "text-sm" }, "Loading…");
     return h(RowsTable, {
       rows: data.rows,
@@ -238,6 +240,11 @@
 
   function TelemetryPage() {
     const [active, setActive] = useState("summary");
+    const [profile, setProfile] = useState("");        // "" = all profiles
+    const [profiles, setProfiles] = useState([]);
+    useEffect(() => {
+      api("/profiles").then((d) => setProfiles((d && d.profiles) || [])).catch(() => setProfiles([]));
+    }, []);
     const Panel = (TABS.find((t) => t.id === active) || TABS[0]).render;
     return h("div", { className: "flex flex-col gap-4" },
       h(ModelUnavailableWidget, null),
@@ -247,11 +254,21 @@
           h("div", { className: "flex items-center gap-3" },
             h(CardTitle, { className: "text-lg" }, "Telemetry"),
             h(Badge, { variant: "outline" }, "hermes-telemetry"),
+            (profiles.length ? h("select", {
+              className: "ml-auto text-sm border border-border bg-transparent px-2 py-1",
+              value: profile,
+              onChange: (e) => setProfile(e.target.value),
+              title: "Filter by Hermes profile",
+              "aria-label": "Filter by Hermes profile",
+            },
+              h("option", { value: "" }, "All profiles"),
+              profiles.map((p) => h("option", { key: p, value: p }, p)),
+            ) : null),
           ),
         ),
         h(CardContent, { className: "flex flex-col gap-4" },
           h(TabBar, { tabs: TABS, active, onChange: setActive }),
-          h(Panel, null),
+          h(Panel, { profile }),
         ),
       ),
     );

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -119,10 +119,13 @@ def health() -> dict:
 
 
 @router.get("/summary")
-def summary(window_hours: int = 24) -> dict:
+def summary(window_hours: int = 24, profile: str = "") -> dict:
     sc = _since_clause(window_hours, "started_at")
     sc_ts = _since_clause(window_hours, "ts")
-    runs = _one(f"""
+    rp, rp_params = _runs_profile_clause(profile)
+    cp, cp_params = _calls_profile_clause(profile)
+    runs = _one(
+        f"""
         SELECT COUNT(*) AS total_runs,
                SUM(CASE WHEN status='ok' THEN 1 ELSE 0 END) AS ok_runs,
                SUM(CASE WHEN status NOT IN ('ok','running') THEN 1 ELSE 0 END) AS failed_runs,
@@ -131,20 +134,28 @@ def summary(window_hours: int = 24) -> dict:
                ROUND(COALESCE(SUM(cost_usd), 0), 6) AS cost_usd,
                COALESCE(SUM(moa_calls), 0) AS moa_calls,
                AVG(duration_ms) AS avg_duration_ms
-        FROM runs WHERE {sc}
-    """)
-    llm = _one(f"""
+        FROM runs WHERE {sc}{rp}
+    """,
+        rp_params,
+    )
+    llm = _one(
+        f"""
         SELECT COUNT(*) AS api_calls, AVG(latency_ms) AS avg_latency_ms
-        FROM llm_calls WHERE {sc_ts}
-    """)
-    daily = _rows(f"""
+        FROM llm_calls WHERE {sc_ts}{cp}
+    """,
+        cp_params,
+    )
+    daily = _rows(
+        f"""
         SELECT DATE(started_at) AS day,
                ROUND(SUM(cost_usd), 4) AS cost,
                COUNT(*) AS runs
-        FROM runs WHERE {sc}
+        FROM runs WHERE {sc}{rp}
         GROUP BY DATE(started_at)
         ORDER BY day
-    """)
+    """,
+        rp_params,
+    )
     return {
         "window_hours": _coerce_window_hours(window_hours),
         "runs": runs,
@@ -154,9 +165,11 @@ def summary(window_hours: int = 24) -> dict:
 
 
 @router.get("/token-breakdown")
-def token_breakdown(window_hours: int = 24) -> dict:
+def token_breakdown(window_hours: int = 24, profile: str = "") -> dict:
     sc_ts = _since_clause(window_hours, "ts")
-    return _one(f"""
+    cp, cp_params = _calls_profile_clause(profile)
+    return _one(
+        f"""
         SELECT COALESCE(SUM(tokens_in), 0)         AS tokens_in,
                COALESCE(SUM(tokens_out), 0)        AS tokens_out,
                COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
@@ -167,8 +180,10 @@ def token_breakdown(window_hours: int = 24) -> dict:
                  + COALESCE(SUM(cache_read_tokens), 0)
                  + COALESCE(SUM(cache_write_tokens), 0)
                  + COALESCE(SUM(reasoning_tokens), 0) AS total_tokens
-        FROM llm_calls WHERE {sc_ts}
-    """)
+        FROM llm_calls WHERE {sc_ts}{cp}
+    """,
+        cp_params,
+    )
 
 
 @router.get("/profiles")
@@ -185,8 +200,9 @@ def profiles() -> dict:
 # Listings
 # ---------------------------------------------------------------------------
 @router.get("/runs")
-def runs(limit: int = 50, window_hours: int = 0) -> dict:
+def runs(limit: int = 50, window_hours: int = 0, profile: str = "") -> dict:
     sc = _since_clause(window_hours, "started_at")
+    rp, rp_params = _runs_profile_clause(profile)
     rows = _rows(
         f"""
         SELECT session_id, platform, cron_job_id, model, provider,
@@ -194,19 +210,20 @@ def runs(limit: int = 50, window_hours: int = 0) -> dict:
                tokens_in, tokens_out, cache_read_tokens, cache_write_tokens,
                cost_usd, duration_ms, api_calls, tool_calls, estimated_llm_calls
         FROM runs
-        WHERE {sc}
+        WHERE {sc}{rp}
         ORDER BY started_at DESC
         LIMIT ?
         """,
-        (max(1, min(int(limit), 500)),),
+        (*rp_params, max(1, min(int(limit), 500))),
     )
-    total = _one(f"SELECT COUNT(*) AS n FROM runs WHERE {sc}").get("n") or 0
+    total = _one(f"SELECT COUNT(*) AS n FROM runs WHERE {sc}{rp}", rp_params).get("n") or 0
     return {"total_runs": int(total), "rows": rows}
 
 
 @router.get("/requests")
-def requests(limit: int = 100, window_hours: int = 0) -> dict:
+def requests(limit: int = 100, window_hours: int = 0, profile: str = "") -> dict:
     sc_ts = _since_clause(window_hours, "ts")
+    cp, cp_params = _calls_profile_clause(profile, session_col="lc.session_id")
     rows = _rows(
         f"""
         SELECT lc.id, lc.ts, lc.session_id, lc.model, lc.provider,
@@ -217,20 +234,25 @@ def requests(limit: int = 100, window_hours: int = 0) -> dict:
                r.platform, r.cron_job_id, r.status
         FROM llm_calls lc
         LEFT JOIN runs r ON r.session_id = lc.session_id
-        WHERE {sc_ts}
+        WHERE {sc_ts}{cp}
         ORDER BY lc.ts DESC, lc.id DESC
         LIMIT ?
         """,
-        (max(1, min(int(limit), 1000)),),
+        (*cp_params, max(1, min(int(limit), 1000))),
     )
-    total = _one(f"SELECT COUNT(*) AS n FROM llm_calls WHERE {sc_ts}").get("n") or 0
+    cp2, cp2_params = _calls_profile_clause(profile)
+    total = (
+        _one(f"SELECT COUNT(*) AS n FROM llm_calls WHERE {sc_ts}{cp2}", cp2_params).get("n") or 0
+    )
     return {"total_requests": int(total), "rows": rows}
 
 
 @router.get("/providers")
-def providers(window_hours: int = 24) -> dict:
+def providers(window_hours: int = 24, profile: str = "") -> dict:
     sc_ts = _since_clause(window_hours, "ts")
-    rows = _rows(f"""
+    cp, cp_params = _calls_profile_clause(profile)
+    rows = _rows(
+        f"""
         SELECT COALESCE(provider, '—') AS provider,
                COUNT(*) AS total_calls,
                SUM(CASE WHEN estimated=0 THEN 1 ELSE 0 END) AS real_calls,
@@ -243,17 +265,21 @@ def providers(window_hours: int = 24) -> dict:
                COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
                COALESCE(SUM(reasoning_tokens), 0)   AS reasoning_tokens
         FROM llm_calls
-        WHERE {sc_ts}
+        WHERE {sc_ts}{cp}
         GROUP BY COALESCE(provider, '—')
         ORDER BY cost_usd DESC, total_calls DESC
-    """)
+    """,
+        cp_params,
+    )
     return {"rows": rows}
 
 
 @router.get("/cron")
-def cron(window_hours: int = 168) -> dict:
+def cron(window_hours: int = 168, profile: str = "") -> dict:
     sc = _since_clause(window_hours, "started_at")
-    rows = _rows(f"""
+    rp, rp_params = _runs_profile_clause(profile)
+    rows = _rows(
+        f"""
         SELECT cron_job_id,
                COUNT(*) AS runs,
                SUM(CASE WHEN status='ok' THEN 1 ELSE 0 END)    AS ok_runs,
@@ -264,10 +290,12 @@ def cron(window_hours: int = 168) -> dict:
                AVG(duration_ms) AS avg_duration_ms,
                MAX(started_at)  AS last_run
         FROM runs
-        WHERE cron_job_id IS NOT NULL AND {sc}
+        WHERE cron_job_id IS NOT NULL AND {sc}{rp}
         GROUP BY cron_job_id
         ORDER BY last_run DESC
-    """)
+    """,
+        rp_params,
+    )
     return {"rows": rows}
 
 

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -38,8 +38,16 @@ _local = threading.local()
 
 
 def _db_path() -> Path:
-    hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
-    return hermes_home / "telemetry" / "telemetry.db"
+    # Telemetry files honor the opt-in canonical home (HERMES_TELEMETRY_HOME), so a
+    # multi-profile user who consolidated via that var sees every profile's data here.
+    # Replicated inline: plugin_api.py is loaded standalone (self-contained — no import
+    # of paths.py), enforced by tests/test_dashboard_plugin_isolation.py.
+    base = (
+        os.environ.get("HERMES_TELEMETRY_HOME")
+        or os.environ.get("HERMES_HOME")
+        or str(Path.home() / ".hermes")
+    )
+    return Path(base) / "telemetry" / "telemetry.db"
 
 
 def _conn() -> sqlite3.Connection:

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -84,6 +84,27 @@ def _since_clause(window_hours, col: str = "started_at") -> str:
     return f"{col} >= '{cutoff}'"
 
 
+def _runs_profile_clause(profile: str | None) -> tuple[str, tuple]:
+    """AND-clause restricting a `runs` query to one profile (parameterized)."""
+    return (" AND profile = ?", (profile,)) if profile else ("", ())
+
+
+def _calls_profile_clause(
+    profile: str | None, session_col: str = "session_id"
+) -> tuple[str, tuple]:
+    """AND-clause restricting an `llm_calls` query to one profile. Correlates the
+    call's session to runs.profile via a subquery — avoids a JOIN and the
+    column-name ambiguity between runs and llm_calls (both have provider,
+    cost_usd, tokens_in, …). Pass a qualified session_col (e.g. "lc.session_id")
+    when the query already aliases llm_calls."""
+    if not profile:
+        return "", ()
+    return (
+        f" AND {session_col} IN (SELECT session_id FROM runs WHERE profile = ?)",
+        (profile,),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Health & summary
 # ---------------------------------------------------------------------------
@@ -148,6 +169,16 @@ def token_breakdown(window_hours: int = 24) -> dict:
                  + COALESCE(SUM(reasoning_tokens), 0) AS total_tokens
         FROM llm_calls WHERE {sc_ts}
     """)
+
+
+@router.get("/profiles")
+def profiles() -> dict:
+    """Distinct non-null profiles present in runs — feeds the dashboard filter."""
+    rows = _rows(
+        "SELECT DISTINCT profile FROM runs "
+        "WHERE profile IS NOT NULL AND profile != '' ORDER BY profile"
+    )
+    return {"profiles": [r["profile"] for r in rows]}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard_plugin_api.py
+++ b/tests/test_dashboard_plugin_api.py
@@ -341,3 +341,114 @@ def test_profiles_lists_distinct_non_null(plugin_api):
     )
     out = plugin_api.profiles()
     assert out["profiles"] == ["coder", "ops"]
+
+
+def _seed_two_profiles():
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).isoformat()
+    _seed(
+        rows_runs=[
+            {
+                "session_id": "c1",
+                "model": "m",
+                "platform": "cli",
+                "profile": "coder",
+                "cron_job_id": "job_a",
+            },
+            {
+                "session_id": "o1",
+                "model": "m",
+                "platform": "cli",
+                "profile": "ops",
+                "cron_job_id": "job_b",
+            },
+        ],
+        rows_llm=[
+            {
+                "session_id": "c1",
+                "ts": now,
+                "model": "m",
+                "provider": "nous",
+                "tokens_in": 100,
+                "tokens_out": 10,
+                "cost_usd": 1.0,
+                "latency_ms": 5,
+            },
+            {
+                "session_id": "o1",
+                "ts": now,
+                "model": "m",
+                "provider": "openai",
+                "tokens_in": 200,
+                "tokens_out": 20,
+                "cost_usd": 2.0,
+                "latency_ms": 9,
+            },
+        ],
+    )
+
+
+def test_summary_filters_by_profile(plugin_api):
+    _seed_two_profiles()
+    out = plugin_api.summary(window_hours=24, profile="coder")
+    assert out["runs"]["total_runs"] == 1
+    assert out["runs"]["tokens_in"] == 100
+    assert out["llm"]["api_calls"] == 1
+
+
+def test_runs_filters_by_profile(plugin_api):
+    _seed_two_profiles()
+    out = plugin_api.runs(limit=50, window_hours=24, profile="ops")
+    assert out["total_runs"] == 1
+    assert [r["session_id"] for r in out["rows"]] == ["o1"]
+
+
+def test_requests_filters_by_profile(plugin_api):
+    _seed_two_profiles()
+    out = plugin_api.requests(limit=100, window_hours=24, profile="coder")
+    assert out["total_requests"] == 1
+    assert all(r["provider"] == "nous" for r in out["rows"])
+
+
+def test_providers_filters_by_profile(plugin_api):
+    _seed_two_profiles()
+    out = plugin_api.providers(window_hours=24, profile="ops")
+    assert {r["provider"] for r in out["rows"]} == {"openai"}
+
+
+def test_cron_filters_by_profile(plugin_api):
+    _seed_two_profiles()
+    out = plugin_api.cron(window_hours=168, profile="coder")
+    assert [r["cron_job_id"] for r in out["rows"]] == ["job_a"]
+
+
+def test_token_breakdown_filters_by_profile(plugin_api):
+    _seed_two_profiles()
+    out = plugin_api.token_breakdown(window_hours=24, profile="ops")
+    assert out["tokens_in"] == 200
+
+
+def test_no_profile_returns_all(plugin_api):
+    _seed_two_profiles()
+    assert plugin_api.summary(window_hours=24)["runs"]["total_runs"] == 2
+    assert plugin_api.runs(limit=50, window_hours=24)["total_runs"] == 2
+
+
+def test_summary_http_query_param_filters_by_profile(plugin_api):
+    """FastAPI wires ?profile= as an optional query param (direct-call tests
+    bypass this layer, so lock the HTTP wiring here)."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    _seed_two_profiles()
+    app = FastAPI()
+    app.include_router(plugin_api.router)
+    client = TestClient(app)
+
+    filtered = client.get("/summary", params={"profile": "coder"}).json()
+    assert filtered["runs"]["total_runs"] == 1
+    assert filtered["runs"]["tokens_in"] == 100
+
+    unfiltered = client.get("/summary").json()
+    assert unfiltered["runs"]["total_runs"] == 2

--- a/tests/test_dashboard_plugin_api.py
+++ b/tests/test_dashboard_plugin_api.py
@@ -321,3 +321,10 @@ def test_db_connection_is_read_only(plugin_api):
     conn = plugin_api._conn()
     with pytest.raises(sqlite3.OperationalError):
         conn.execute("INSERT INTO runs (session_id, started_at) VALUES ('x', 'y')")
+
+
+def test_db_path_honors_telemetry_home(plugin_api, tmp_path, monkeypatch):
+    """_db_path resolves the consolidated DB when HERMES_TELEMETRY_HOME is set."""
+    monkeypatch.setenv("HERMES_TELEMETRY_HOME", str(tmp_path / "shared"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+    assert plugin_api._db_path() == tmp_path / "shared" / "telemetry" / "telemetry.db"

--- a/tests/test_dashboard_plugin_api.py
+++ b/tests/test_dashboard_plugin_api.py
@@ -328,3 +328,16 @@ def test_db_path_honors_telemetry_home(plugin_api, tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_TELEMETRY_HOME", str(tmp_path / "shared"))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
     assert plugin_api._db_path() == tmp_path / "shared" / "telemetry" / "telemetry.db"
+
+
+def test_profiles_lists_distinct_non_null(plugin_api):
+    _seed(
+        rows_runs=[
+            {"session_id": "p1", "model": "m", "platform": "cli", "profile": "coder"},
+            {"session_id": "p2", "model": "m", "platform": "cli", "profile": "ops"},
+            {"session_id": "p3", "model": "m", "platform": "cli", "profile": "coder"},
+            {"session_id": "p4", "model": "m", "platform": "cli"},  # NULL profile
+        ]
+    )
+    out = plugin_api.profiles()
+    assert out["profiles"] == ["coder", "ops"]


### PR DESCRIPTION
## Summary

Per-profile cost center — **Slice 2 / PR 2** (builds on PR #61's canonical telemetry home). Makes the plugin-in-shell dashboard profile-aware, so a consolidated (`HERMES_TELEMETRY_HOME`) telemetry DB can be sliced per Hermes profile. **Shared-mode filtering only** — no cross-DB reading (consolidate via `HERMES_TELEMETRY_HOME` first).

- **`plugin_api.py` reads the canonical telemetry home** — `_db_path()` honors `HERMES_TELEMETRY_HOME` (> `HERMES_HOME` > `~/.hermes`), replicated inline (the dashboard surfaces stay code-isolated — no `paths.py` import, enforced by `test_dashboard_plugin_isolation.py`).
- **Optional `profile` filter on the aggregate endpoints** (`/summary`, `/token-breakdown`, `/runs`, `/requests`, `/providers`, `/cron`). `runs`-based queries filter `AND profile = ?`; `llm_calls`-based queries filter `AND session_id IN (SELECT session_id FROM runs WHERE profile = ?)` — a correlated subquery that avoids a JOIN and the `runs`/`llm_calls` column-name ambiguity. `profile` is always a **bound `?` param** (never interpolated).
- **New `/profiles` endpoint** returning the distinct non-null profiles.
- **Frontend selector** in `TelemetryPage` (`dist/index.js`): shown only when profiles exist, "All profiles" default (sends no param), threads `&profile=` into the five data panels. Budgets and slot widgets are not profile-filtered.
- **Docs**: README (plugin dashboard feature) + ONBOARDING (dashboard profile-awareness + the FastAPI `profile: str = ""` gotcha — `str | None` on a route param crashes FastAPI on Python 3.8/3.9).

**No schema change** (`_SCHEMA_VERSION` untouched, no migration); no version bump. `_db_path`/query behavior is byte-identical when no profile is selected.

## Test Plan

- [x] `ruff format --check . && ruff check .` — clean
- [x] `TZ=UTC pytest tests/ -v` — 399 passed, 6 skipped
- [x] `node --check dashboard/dist/index.js` — valid
- [x] Backend: per-endpoint profile-filter tests (runs-based + subquery-based), `/profiles` distinct/non-null, `_db_path` honors `HERMES_TELEMETRY_HOME`, no-profile-returns-all, and a `TestClient` HTTP test that locks the FastAPI `?profile=` query-param wiring
- [x] `test_dashboard_plugin_isolation.py` still green (no cross-surface import added)
- [ ] **Manual (no JS test harness):** load the Telemetry tab against a DB with ≥2 profiles → selector appears; switching re-fetches all five panels with `&profile=`; "All profiles" clears the filter; selector hidden when no profile data; dropdown readable in light/dark shell themes