### PR TITLE
feat: add telemetry sync-profiles command

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1598,7 +1598,8 @@ hermes telemetry sync-profiles --apply    # RUN FROM THE DEFAULT PROFILE (shared
 ```
 
 - The ONLY file mutated is each profile's `.env` — a single `HERMES_TELEMETRY_HOME` line,
-  comment/format-preserving, written atomically (tmp + `os.replace`). Idempotent.
+  written atomically (tmp + `os.replace`). Idempotent; other lines and comments are kept and an
+  existing `export ` prefix on the key is preserved (line endings are normalized to `\n`).
 - `config.yaml` is **read-only**: the command warns when a profile has not enabled the plugin
   (`plugins.enabled`) but NEVER edits it. Auto-enable and plugin-symlinking were deliberately
   dropped — the repo has no comment-preserving YAML writer, and enabling is a one-line manual
@@ -1606,7 +1607,9 @@ hermes telemetry sync-profiles --apply    # RUN FROM THE DEFAULT PROFILE (shared
 - **Non-default guard:** enumeration is default `~/.hermes` + `~/.hermes/profiles/*/`; the target
   defaults to the current resolved home (`HERMES_TELEMETRY_HOME` > `HERMES_HOME` > `~/.hermes`).
   If run from a named profile, `--apply` refuses unless `--yes` is passed — review the dry-run
-  first. The profile that already *is* the shared home is skipped.
+  first. The profile that already *is* the shared home is skipped. (Enumeration is always rooted
+  at the invoking home, so running from a named profile only ever sees that profile's own
+  subtree — another reason to run from the default profile.)
 - Flags: `--telemetry-home PATH` overrides the shared home; `[names...]` limits to specific
   profiles; `--json` emits a machine-readable report.
 - Going-forward only: it does not backfill telemetry rows already siloed in a profile's own

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1579,6 +1579,39 @@ that but ruff `UP045` would demand `X | None` back. `str = ""` is annotated, ruf
 cross-version-safe, and falsy-when-absent (the helpers gate on `if profile:`), so it's the
 correct shape for optional query params in this file.
 
+### Command: `telemetry sync-profiles`
+
+Points every Hermes profile at one shared telemetry home so all profiles read the same
+`pricing.yaml` / `budget.yaml` and write to the same `telemetry.db` (the consolidation
+`HERMES_TELEMETRY_HOME` enables). Lives in `sync_profiles.py` (self-contained, no intra-package
+imports) + a subcommand in `telemetry_cli.py` (`_handle_sync_profiles`). No schema change.
+
+Verified per-profile model (source: `NousResearch/hermes-agent@main`, 2026-07-08): each profile
+is an independent `HERMES_HOME` at `~/.hermes/profiles/<name>/` (the `default` profile is
+`~/.hermes`), with its own `config.yaml`, `.env`, and `plugins/`. Hermes core loads `<home>/.env`
+via python-dotenv (`override=True`) after resolving the profile and BEFORE loading plugins, so
+`HERMES_TELEMETRY_HOME` written there reaches that profile's process — no user-side sourcing.
+
+```bash
+hermes telemetry sync-profiles            # dry-run (default): shows the plan, mutates nothing
+hermes telemetry sync-profiles --apply    # RUN FROM THE DEFAULT PROFILE (shared home = ~/.hermes)
+```
+
+- The ONLY file mutated is each profile's `.env` — a single `HERMES_TELEMETRY_HOME` line,
+  comment/format-preserving, written atomically (tmp + `os.replace`). Idempotent.
+- `config.yaml` is **read-only**: the command warns when a profile has not enabled the plugin
+  (`plugins.enabled`) but NEVER edits it. Auto-enable and plugin-symlinking were deliberately
+  dropped — the repo has no comment-preserving YAML writer, and enabling is a one-line manual
+  step (`hermes plugins enable hermes-telemetry --profile <name>`).
+- **Non-default guard:** enumeration is default `~/.hermes` + `~/.hermes/profiles/*/`; the target
+  defaults to the current resolved home (`HERMES_TELEMETRY_HOME` > `HERMES_HOME` > `~/.hermes`).
+  If run from a named profile, `--apply` refuses unless `--yes` is passed — review the dry-run
+  first. The profile that already *is* the shared home is skipped.
+- Flags: `--telemetry-home PATH` overrides the shared home; `[names...]` limits to specific
+  profiles; `--json` emits a machine-readable report.
+- Going-forward only: it does not backfill telemetry rows already siloed in a profile's own
+  pre-consolidation DB.
+
 ---
 
 ## PluginContext API

--- a/sync_profiles.py
+++ b/sync_profiles.py
@@ -1,0 +1,257 @@
+"""Point every Hermes profile at one shared telemetry home.
+
+Each Hermes profile is an independent HERMES_HOME (``~/.hermes`` for the default
+profile, ``~/.hermes/profiles/<name>/`` for named ones), with its own
+``config.yaml``, ``.env`` and ``plugins/``. Telemetry files (``telemetry.db``,
+``pricing.yaml``, ``budget.yaml``) resolve under ``<HERMES_TELEMETRY_HOME>/
+telemetry/`` (precedence ``HERMES_TELEMETRY_HOME`` > ``HERMES_HOME`` >
+``~/.hermes``). Writing the same ``HERMES_TELEMETRY_HOME`` into every profile's
+``.env`` therefore makes all profiles read the same pricing/budget and write to
+the same DB.
+
+This module is self-contained (no intra-package imports) so it can be unit
+tested against a tmp HERMES_HOME. The ONLY file it ever writes is each profile's
+``.env``; ``config.yaml`` is read-only (drift warning), never edited.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+PLUGIN_NAME = "hermes-telemetry"
+ENV_KEY = "HERMES_TELEMETRY_HOME"
+
+
+def default_base_home() -> Path:
+    """The home to enumerate profiles from (HERMES_HOME, or ~/.hermes)."""
+    return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+
+
+def resolve_target_home() -> Path:
+    """Shared home ROOT to write into each profile's .env. Mirrors the
+    precedence of paths.get_telemetry_home() (HERMES_TELEMETRY_HOME >
+    HERMES_HOME > ~/.hermes) but returns the root (paths appends /telemetry)."""
+    override = os.environ.get("HERMES_TELEMETRY_HOME") or os.environ.get("HERMES_HOME")
+    return Path(override) if override else Path.home() / ".hermes"
+
+
+def is_default_profile(base_home: Path) -> bool:
+    """True when base_home is NOT a named profile (~/.hermes/profiles/<name>).
+    Mirrors Hermes' own path-shape inference of the active profile."""
+    return base_home.resolve().parent.name != "profiles"
+
+
+def iter_profiles(base_home: Path) -> list[tuple[str, Path]]:
+    """(name, home) for the default profile + every ~/.hermes/profiles/<name>/.
+    'default' first, then named profiles sorted by name."""
+    out: list[tuple[str, Path]] = [("default", base_home)]
+    profiles_root = base_home / "profiles"
+    if profiles_root.is_dir():
+        for child in sorted(profiles_root.iterdir()):
+            if child.is_dir():
+                out.append((child.name, child))
+    return out
+
+
+def _is_assignment(stripped: str, key: str) -> bool:
+    if stripped.startswith("#"):
+        return False
+    return stripped.startswith(f"{key}=") or stripped.startswith(f"export {key}=")
+
+
+def read_env_var(env_path: Path, key: str) -> str | None:
+    """Value of KEY from a line-based .env (last assignment wins), or None."""
+    if not env_path.is_file():
+        return None
+    value: str | None = None
+    for line in env_path.read_text().splitlines():
+        stripped = line.strip()
+        if _is_assignment(stripped, key):
+            value = stripped.split("=", 1)[1]
+    return value
+
+
+def upsert_env_var(env_path: Path, key: str, value: str) -> bool:
+    """Idempotently set KEY=value in a line-based .env, preserving every other
+    line and comment. Replaces the first assignment, drops later duplicates,
+    else appends. Returns True if the file changed. Atomic write (tmp +
+    os.replace); creates the file (and parents) if absent."""
+    new_line = f"{key}={value}"
+    existing = env_path.read_text().splitlines() if env_path.is_file() else []
+    out: list[str] = []
+    replaced = False
+    changed = False
+    for line in existing:
+        if _is_assignment(line.strip(), key):
+            if not replaced:
+                replaced = True
+                if line != new_line:
+                    changed = True
+                out.append(new_line)
+            else:
+                changed = True  # dropping a later duplicate
+            continue
+        out.append(line)
+    if not replaced:
+        out.append(new_line)
+        changed = True
+    if not changed:
+        return False
+    text = "\n".join(out) + "\n"
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = env_path.parent / (env_path.name + ".tmp")
+    tmp.write_text(text)
+    os.replace(tmp, env_path)
+    return True
+
+
+def plugin_status(home: Path) -> tuple[str, bool]:
+    """(enabled_state, installed), read-only. enabled_state is one of
+    "enabled" | "not-enabled" | "no-config" | "unreadable". installed = the
+    plugin dir/symlink exists under <home>/plugins/ (symlinks followed)."""
+    installed = (home / "plugins" / PLUGIN_NAME).exists()
+    config_path = home / "config.yaml"
+    if not config_path.is_file():
+        return "no-config", installed
+    try:
+        data = yaml.safe_load(config_path.read_text()) or {}
+    except Exception:
+        return "unreadable", installed
+    enabled = ((data.get("plugins") or {}).get("enabled")) or []
+    state = "enabled" if PLUGIN_NAME in enabled else "not-enabled"
+    return state, installed
+
+
+@dataclass
+class ProfileStatus:
+    name: str
+    home: Path
+    is_target: bool
+    env_state: str  # "ok" | "missing" | "mismatch"
+    env_current: str | None
+    plugin_enabled: str  # "enabled" | "not-enabled" | "no-config" | "unreadable"
+    plugin_installed: bool
+
+
+@dataclass
+class ProfileResult:
+    name: str
+    action: str  # "env-written" | "skipped" | "error"
+    detail: str
+
+
+def _env_state(current: str | None, target: Path) -> str:
+    if current is None:
+        return "missing"
+    return "ok" if Path(current).expanduser() == target else "mismatch"
+
+
+def detect(base_home: Path, target: Path, only: list[str] | None = None) -> list[ProfileStatus]:
+    """Read-only per-profile status of the env leg and the plugin leg."""
+    target = target.expanduser()
+    statuses: list[ProfileStatus] = []
+    for name, home in iter_profiles(base_home):
+        if only and name not in only:
+            continue
+        current = read_env_var(home / ".env", ENV_KEY)
+        enabled, installed = plugin_status(home)
+        statuses.append(
+            ProfileStatus(
+                name=name,
+                home=home,
+                is_target=(home.resolve() == target.resolve()),
+                env_state=_env_state(current, target),
+                env_current=current,
+                plugin_enabled=enabled,
+                plugin_installed=installed,
+            )
+        )
+    return statuses
+
+
+def apply(statuses: list[ProfileStatus], target: Path) -> list[ProfileResult]:
+    """Perform the .env upserts for profiles that need them. Per-profile error
+    isolation: one failure is recorded and the run continues. Never touches
+    config.yaml or plugins/."""
+    results: list[ProfileResult] = []
+    for st in statuses:
+        if st.is_target:
+            results.append(ProfileResult(st.name, "skipped", "is the shared telemetry home"))
+            continue
+        if st.env_state == "ok":
+            results.append(ProfileResult(st.name, "skipped", "already points at the shared home"))
+            continue
+        try:
+            changed = upsert_env_var(st.home / ".env", ENV_KEY, str(target))
+        except OSError as exc:
+            results.append(ProfileResult(st.name, "error", str(exc)))
+            continue
+        if changed:
+            results.append(ProfileResult(st.name, "env-written", f"set {ENV_KEY}={target}"))
+        else:
+            results.append(ProfileResult(st.name, "skipped", "already set"))
+    return results
+
+
+def _env_note(st: ProfileStatus, result: ProfileResult | None) -> str:
+    if result is not None:
+        return f"{result.action}: {result.detail}"
+    if st.is_target:
+        return "is the shared home"
+    if st.env_state == "ok":
+        return "ok"
+    if st.env_state == "missing":
+        return "would set HERMES_TELEMETRY_HOME"
+    return f"would change from {st.env_current}"
+
+
+def render(
+    statuses: list[ProfileStatus],
+    target: Path,
+    results: list[ProfileResult] | None = None,
+) -> str:
+    by_name = {r.name: r for r in results} if results else {}
+    lines = [f"Shared telemetry home: {target}", ""]
+    for st in statuses:
+        note = _env_note(st, by_name.get(st.name))
+        plugin = (
+            "plugin ok" if st.plugin_enabled == "enabled" else f"plugin WARN: {st.plugin_enabled}"
+        )
+        lines.append(f"  {st.name:<20} env: {note:<40} {plugin}")
+    warn = [st.name for st in statuses if st.plugin_enabled != "enabled"]
+    if warn:
+        lines.append("")
+        lines.append("WARN: plugin not enabled in: " + ", ".join(warn))
+        for name in warn:
+            lines.append(f"  hermes plugins enable {PLUGIN_NAME} --profile {name}")
+    return "\n".join(lines)
+
+
+def to_json(
+    statuses: list[ProfileStatus],
+    target: Path,
+    results: list[ProfileResult] | None = None,
+) -> str:
+    by_name = {r.name: {"action": r.action, "detail": r.detail} for r in results} if results else {}
+    payload = {
+        "target": str(target),
+        "profiles": [
+            {
+                "name": st.name,
+                "home": str(st.home),
+                "is_target": st.is_target,
+                "env_state": st.env_state,
+                "env_current": st.env_current,
+                "plugin_enabled": st.plugin_enabled,
+                "plugin_installed": st.plugin_installed,
+                "result": by_name.get(st.name),
+            }
+            for st in statuses
+        ],
+    }
+    return json.dumps(payload, indent=2)

--- a/sync_profiles.py
+++ b/sync_profiles.py
@@ -77,10 +77,11 @@ def read_env_var(env_path: Path, key: str) -> str | None:
 
 
 def upsert_env_var(env_path: Path, key: str, value: str) -> bool:
-    """Idempotently set KEY=value in a line-based .env, preserving every other
-    line and comment. Replaces the first assignment, drops later duplicates,
-    else appends. Returns True if the file changed. Atomic write (tmp +
-    os.replace); creates the file (and parents) if absent."""
+    """Idempotently set KEY=value in a line-based .env, keeping every other line
+    and comment (an existing `export ` prefix on the key is preserved). Replaces
+    the first assignment, drops later duplicates, else appends. Returns True if
+    the file changed. Atomic write (tmp + os.replace); creates the file (and
+    parents) if absent. Note: line endings are normalized to `\\n`."""
     new_line = f"{key}={value}"
     existing = env_path.read_text().splitlines() if env_path.is_file() else []
     out: list[str] = []
@@ -90,9 +91,11 @@ def upsert_env_var(env_path: Path, key: str, value: str) -> bool:
         if _is_assignment(line.strip(), key):
             if not replaced:
                 replaced = True
-                if line != new_line:
+                prefix = "export " if line.strip().startswith("export ") else ""
+                candidate = f"{prefix}{new_line}"
+                if line != candidate:
                     changed = True
-                out.append(new_line)
+                out.append(candidate)
             else:
                 changed = True  # dropping a later duplicate
             continue

--- a/telemetry_cli.py
+++ b/telemetry_cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import sys
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 from . import db, stats
 
@@ -156,6 +157,24 @@ def _build_parser_into(sub) -> None:
     bf.add_argument("scope_id", nargs="?", default="")
     bf.add_argument("--json", action="store_true", help="Output as JSON")
 
+    spp = sub.add_parser(
+        "sync-profiles",
+        help="Point all profiles at one shared telemetry home (pricing/budget/db)",
+    )
+    spp.add_argument("names", nargs="*", help="Limit to these profile names")
+    spp.add_argument("--apply", action="store_true", help="Write changes (default: dry-run)")
+    spp.add_argument("--yes", action="store_true", help="Confirm a non-default target home")
+    spp.add_argument(
+        "--telemetry-home",
+        dest="telemetry_home",
+        default=None,
+        help=(
+            "Shared home root to write into each profile's .env "
+            "(default: the current resolved home). Run from the default profile."
+        ),
+    )
+    spp.add_argument("--json", action="store_true", help="Output as JSON")
+
 
 def main(argv: list[str] | None = None) -> None:
     parser = _build_parser()
@@ -168,6 +187,8 @@ def _dispatch(args: argparse.Namespace, parser: argparse.ArgumentParser | None =
         _handle_stats(args)
     elif args.command == "budget":
         _handle_budget(args)
+    elif args.command == "sync-profiles":
+        _handle_sync_profiles(args)
     else:
         if parser:
             parser.print_help()
@@ -299,6 +320,38 @@ def _budget_json(subcommand: str) -> None:
         result["senders"][sid] = _dc.asdict(v) if v is not None else None
 
     print(json.dumps(result, default=str))
+
+
+def _handle_sync_profiles(args: argparse.Namespace) -> None:
+    from . import sync_profiles as sp
+
+    base_home = sp.default_base_home()
+    if args.telemetry_home:
+        target = Path(args.telemetry_home).expanduser()
+    else:
+        target = sp.resolve_target_home()
+    only = args.names or None
+    statuses = sp.detect(base_home, target, only)
+
+    if not args.apply:
+        print(sp.to_json(statuses, target) if args.json else sp.render(statuses, target))
+        return
+
+    # Non-default guard: refuse to mutate when not run from the default profile,
+    # unless the user explicitly confirms with --yes.
+    if not sp.is_default_profile(base_home) and not args.yes:
+        print(sp.render(statuses, target))
+        print(
+            f"\nRefusing to apply: not running from the default profile "
+            f"(HERMES_HOME={base_home}).\n"
+            f"Re-run from the default profile, or pass --yes to confirm target {target}."
+        )
+        return
+
+    results = sp.apply(statuses, target)
+    print(
+        sp.to_json(statuses, target, results) if args.json else sp.render(statuses, target, results)
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_sync_profiles.py
+++ b/tests/test_sync_profiles.py
@@ -1,0 +1,239 @@
+import json
+
+import hermes_telemetry.sync_profiles as sp
+
+# --- Task 1: path/env helpers ---
+
+
+def test_default_base_home_reads_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "h"))
+    assert sp.default_base_home() == tmp_path / "h"
+
+
+def test_resolve_target_prefers_telemetry_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_TELEMETRY_HOME", str(tmp_path / "shared"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "h"))
+    assert sp.resolve_target_home() == tmp_path / "shared"
+
+
+def test_resolve_target_falls_back_to_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_TELEMETRY_HOME", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "h"))
+    assert sp.resolve_target_home() == tmp_path / "h"
+
+
+def test_is_default_profile_true_for_plain_home(tmp_path):
+    assert sp.is_default_profile(tmp_path) is True
+
+
+def test_is_default_profile_false_for_named_profile(tmp_path):
+    named = tmp_path / "profiles" / "coder"
+    named.mkdir(parents=True)
+    assert sp.is_default_profile(named) is False
+
+
+# --- Task 2: profile enumeration ---
+
+
+def test_iter_profiles_default_only(tmp_path):
+    assert sp.iter_profiles(tmp_path) == [("default", tmp_path)]
+
+
+def test_iter_profiles_lists_named_sorted(tmp_path):
+    (tmp_path / "profiles" / "b").mkdir(parents=True)
+    (tmp_path / "profiles" / "a").mkdir(parents=True)
+    (tmp_path / "profiles" / "note.txt").write_text("x")
+    result = sp.iter_profiles(tmp_path)
+    assert result == [
+        ("default", tmp_path),
+        ("a", tmp_path / "profiles" / "a"),
+        ("b", tmp_path / "profiles" / "b"),
+    ]
+
+
+# --- Task 3: .env read + comment-preserving atomic upsert ---
+
+
+def test_read_env_var_absent_file(tmp_path):
+    assert sp.read_env_var(tmp_path / ".env", sp.ENV_KEY) is None
+
+
+def test_read_env_var_last_wins_ignores_comments(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text(
+        "# HERMES_TELEMETRY_HOME=/commented\nHERMES_TELEMETRY_HOME=/a\nHERMES_TELEMETRY_HOME=/b\n"
+    )
+    assert sp.read_env_var(env, sp.ENV_KEY) == "/b"
+
+
+def test_upsert_creates_file(tmp_path):
+    env = tmp_path / ".env"
+    changed = sp.upsert_env_var(env, sp.ENV_KEY, "/shared")
+    assert changed is True
+    assert env.read_text() == "HERMES_TELEMETRY_HOME=/shared\n"
+
+
+def test_upsert_preserves_other_lines_and_comments(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("# my config\nFOO=1\nHERMES_TELEMETRY_HOME=/old\nBAR=2\n")
+    changed = sp.upsert_env_var(env, sp.ENV_KEY, "/shared")
+    assert changed is True
+    assert env.read_text() == "# my config\nFOO=1\nHERMES_TELEMETRY_HOME=/shared\nBAR=2\n"
+
+
+def test_upsert_idempotent_returns_false(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("HERMES_TELEMETRY_HOME=/shared\n")
+    assert sp.upsert_env_var(env, sp.ENV_KEY, "/shared") is False
+
+
+def test_upsert_drops_later_duplicates(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("HERMES_TELEMETRY_HOME=/a\nKEEP=1\nHERMES_TELEMETRY_HOME=/b\n")
+    sp.upsert_env_var(env, sp.ENV_KEY, "/shared")
+    assert env.read_text() == "HERMES_TELEMETRY_HOME=/shared\nKEEP=1\n"
+
+
+# --- Task 4: read-only plugin status ---
+
+
+def _write_config(home, enabled):
+    import yaml
+
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(yaml.safe_dump({"plugins": {"enabled": enabled}}))
+
+
+def test_plugin_status_no_config(tmp_path):
+    assert sp.plugin_status(tmp_path) == ("no-config", False)
+
+
+def test_plugin_status_enabled(tmp_path):
+    _write_config(tmp_path, ["hermes-telemetry", "other"])
+    assert sp.plugin_status(tmp_path) == ("enabled", False)
+
+
+def test_plugin_status_not_enabled(tmp_path):
+    _write_config(tmp_path, ["other"])
+    assert sp.plugin_status(tmp_path) == ("not-enabled", False)
+
+
+def test_plugin_status_detects_install_via_symlink(tmp_path):
+    _write_config(tmp_path, ["hermes-telemetry"])
+    real = tmp_path / "real_plugin"
+    real.mkdir()
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    (plugins / "hermes-telemetry").symlink_to(real, target_is_directory=True)
+    state, installed = sp.plugin_status(tmp_path)
+    assert (state, installed) == ("enabled", True)
+
+
+def test_plugin_status_unreadable_config(tmp_path):
+    (tmp_path / "config.yaml").write_text("plugins: [unbalanced\n")
+    state, _ = sp.plugin_status(tmp_path)
+    assert state == "unreadable"
+
+
+# --- Task 5: detect() ---
+
+
+def test_detect_marks_target_and_env_states(tmp_path):
+    named = tmp_path / "profiles" / "coder"
+    _write_config(named, ["hermes-telemetry"])
+    statuses = sp.detect(tmp_path, target=tmp_path)
+    by_name = {s.name: s for s in statuses}
+    assert by_name["default"].is_target is True
+    assert by_name["coder"].is_target is False
+    assert by_name["coder"].env_state == "missing"
+    assert by_name["coder"].plugin_enabled == "enabled"
+
+
+def test_detect_env_ok_and_mismatch(tmp_path):
+    ok = tmp_path / "profiles" / "ok"
+    ok.mkdir(parents=True)
+    (ok / ".env").write_text(f"HERMES_TELEMETRY_HOME={tmp_path}\n")
+    bad = tmp_path / "profiles" / "bad"
+    bad.mkdir(parents=True)
+    (bad / ".env").write_text("HERMES_TELEMETRY_HOME=/somewhere/else\n")
+    by_name = {s.name: s for s in sp.detect(tmp_path, target=tmp_path)}
+    assert by_name["ok"].env_state == "ok"
+    assert by_name["bad"].env_state == "mismatch"
+    assert by_name["bad"].env_current == "/somewhere/else"
+
+
+def test_detect_honors_only_filter(tmp_path):
+    (tmp_path / "profiles" / "a").mkdir(parents=True)
+    (tmp_path / "profiles" / "b").mkdir(parents=True)
+    names = {s.name for s in sp.detect(tmp_path, target=tmp_path, only=["a"])}
+    assert names == {"a"}
+
+
+# --- Task 6: apply() ---
+
+
+def test_apply_writes_missing_skips_target_and_ok(tmp_path):
+    ok = tmp_path / "profiles" / "ok"
+    ok.mkdir(parents=True)
+    (ok / ".env").write_text(f"HERMES_TELEMETRY_HOME={tmp_path}\n")
+    miss = tmp_path / "profiles" / "miss"
+    miss.mkdir(parents=True)
+    statuses = sp.detect(tmp_path, target=tmp_path)
+    results = {r.name: r for r in sp.apply(statuses, target=tmp_path)}
+    assert results["default"].action == "skipped"
+    assert results["ok"].action == "skipped"
+    assert results["miss"].action == "env-written"
+    assert (miss / ".env").read_text() == f"HERMES_TELEMETRY_HOME={tmp_path}\n"
+
+
+def test_apply_isolates_per_profile_errors(tmp_path, monkeypatch):
+    bad = tmp_path / "profiles" / "bad"
+    bad.mkdir(parents=True)
+    good = tmp_path / "profiles" / "good"
+    good.mkdir(parents=True)
+    statuses = sp.detect(tmp_path, target=tmp_path)
+    real_upsert = sp.upsert_env_var
+
+    def flaky(env_path, key, value):
+        if "bad" in str(env_path):
+            raise OSError("permission denied")
+        return real_upsert(env_path, key, value)
+
+    monkeypatch.setattr(sp, "upsert_env_var", flaky)
+    results = {r.name: r for r in sp.apply(statuses, target=tmp_path)}
+    assert results["bad"].action == "error"
+    assert "permission denied" in results["bad"].detail
+    assert results["good"].action == "env-written"
+
+
+# --- Task 7: rendering ---
+
+
+def test_render_dry_run_shows_target_plan_and_warning(tmp_path):
+    named = tmp_path / "profiles" / "coder"
+    named.mkdir(parents=True)
+    statuses = sp.detect(tmp_path, target=tmp_path)
+    text = sp.render(statuses, target=tmp_path)
+    assert str(tmp_path) in text
+    assert "would set" in text
+    assert "hermes plugins enable hermes-telemetry --profile coder" in text
+
+
+def test_render_applied_shows_actions(tmp_path):
+    named = tmp_path / "profiles" / "coder"
+    named.mkdir(parents=True)
+    statuses = sp.detect(tmp_path, target=tmp_path)
+    results = sp.apply(statuses, target=tmp_path)
+    text = sp.render(statuses, target=tmp_path, results=results)
+    assert "env-written" in text
+
+
+def test_to_json_shape(tmp_path):
+    named = tmp_path / "profiles" / "coder"
+    named.mkdir(parents=True)
+    statuses = sp.detect(tmp_path, target=tmp_path)
+    data = json.loads(sp.to_json(statuses, target=tmp_path))
+    assert data["target"] == str(tmp_path)
+    coder = next(p for p in data["profiles"] if p["name"] == "coder")
+    assert coder["env_state"] == "missing"
+    assert coder["plugin_enabled"] == "no-config"

--- a/tests/test_sync_profiles.py
+++ b/tests/test_sync_profiles.py
@@ -237,3 +237,26 @@ def test_to_json_shape(tmp_path):
     coder = next(p for p in data["profiles"] if p["name"] == "coder")
     assert coder["env_state"] == "missing"
     assert coder["plugin_enabled"] == "no-config"
+
+
+# --- export-prefixed .env lines ---
+
+
+def test_read_env_var_reads_export_prefixed(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("export HERMES_TELEMETRY_HOME=/x\n")
+    assert sp.read_env_var(env, sp.ENV_KEY) == "/x"
+
+
+def test_upsert_preserves_export_prefix(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("export HERMES_TELEMETRY_HOME=/old\n")
+    changed = sp.upsert_env_var(env, sp.ENV_KEY, "/shared")
+    assert changed is True
+    assert env.read_text() == "export HERMES_TELEMETRY_HOME=/shared\n"
+
+
+def test_upsert_export_prefix_idempotent(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("export HERMES_TELEMETRY_HOME=/shared\n")
+    assert sp.upsert_env_var(env, sp.ENV_KEY, "/shared") is False

--- a/tests/test_sync_profiles_cli.py
+++ b/tests/test_sync_profiles_cli.py
@@ -1,0 +1,65 @@
+import argparse
+
+import hermes_telemetry.telemetry_cli as tcli
+
+
+def _args(**kw):
+    base = dict(
+        command="sync-profiles",
+        names=[],
+        apply=False,
+        yes=False,
+        telemetry_home=None,
+        json=False,
+    )
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_dry_run_does_not_mutate(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    named = tmp_path / "profiles" / "coder"
+    named.mkdir(parents=True)
+    tcli._handle_sync_profiles(_args())
+    out = capsys.readouterr().out
+    assert "would set" in out
+    assert not (named / ".env").exists()
+
+
+def test_apply_from_default_mutates(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    named = tmp_path / "profiles" / "coder"
+    named.mkdir(parents=True)
+    tcli._handle_sync_profiles(_args(apply=True))
+    out = capsys.readouterr().out
+    assert "env-written" in out
+    assert (named / ".env").read_text() == f"HERMES_TELEMETRY_HOME={tmp_path}\n"
+
+
+def test_apply_from_named_profile_refuses_without_yes(tmp_path, monkeypatch, capsys):
+    base = tmp_path / "profiles" / "coder"
+    (base / "profiles").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(base))
+    tcli._handle_sync_profiles(_args(apply=True))
+    out = capsys.readouterr().out
+    assert "Refusing to apply" in out
+
+
+def test_apply_from_named_profile_proceeds_with_yes(tmp_path, monkeypatch, capsys):
+    base = tmp_path / "profiles" / "coder"
+    (base / "profiles" / "child").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(base))
+    tcli._handle_sync_profiles(_args(apply=True, yes=True))
+    out = capsys.readouterr().out
+    assert "Refusing to apply" not in out
+    assert (base / "profiles" / "child" / ".env").exists()
+
+
+def test_parser_accepts_subcommand():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
+    tcli._build_parser_into(sub)
+    args = parser.parse_args(["sync-profiles", "coder", "--apply", "--yes"])
+    assert args.command == "sync-profiles"
+    assert args.names == ["coder"]
+    assert args.apply is True and args.yes is True

--- a/tests/test_sync_profiles_cli.py
+++ b/tests/test_sync_profiles_cli.py
@@ -63,3 +63,27 @@ def test_parser_accepts_subcommand():
     assert args.command == "sync-profiles"
     assert args.names == ["coder"]
     assert args.apply is True and args.yes is True
+
+
+def test_handler_json_output(tmp_path, monkeypatch, capsys):
+    import json
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "profiles" / "coder").mkdir(parents=True)
+    tcli._handle_sync_profiles(_args(json=True))
+    data = json.loads(capsys.readouterr().out)
+    assert data["target"] == str(tmp_path)
+    assert any(p["name"] == "coder" for p in data["profiles"])
+
+
+def test_handler_explicit_telemetry_home_writes_default_too(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "profiles" / "coder").mkdir(parents=True)
+    shared = tmp_path / "shared"
+    tcli._handle_sync_profiles(_args(apply=True, telemetry_home=str(shared)))
+    # With an external target, the default profile is no longer the target,
+    # so its own .env is written too.
+    assert (tmp_path / ".env").read_text() == f"HERMES_TELEMETRY_HOME={shared}\n"
+    assert (
+        tmp_path / "profiles" / "coder" / ".env"
+    ).read_text() == f"HERMES_TELEMETRY_HOME={shared}\n"


### PR DESCRIPTION
## Summary
- Add `hermes telemetry sync-profiles`: points every Hermes profile at one shared telemetry home so all profiles read the same `pricing.yaml`/`budget.yaml` and write to the same `telemetry.db` (the consolidation `HERMES_TELEMETRY_HOME` enables — slice 3 of the per-profile cost center).
- New self-contained `sync_profiles.py`: read-only `detect()` (per-profile env + `plugins.enabled` status) and an `apply()` that mutates ONLY each profile's `.env` — upserts one `HERMES_TELEMETRY_HOME` line, comment-preserving, atomic (tmp + `os.replace`), idempotent.
- `config.yaml` is **read-only**: warns when a profile has not enabled the plugin, never edits it. No symlinking, no plugin install, no schema change.
- CLI: dry-run by default, `--apply` to mutate, non-default guard (`--yes` required when run from a named profile), `--telemetry-home`, profile-name filter, `--json`. Wired in `telemetry_cli.py` only (`register_cli_command` already forwards the subparser group).
- Docs: ONBOARDING section + the source-verified per-profile on-disk model.

## Test Plan
- [x] `ruff format --check . && ruff check . && pytest tests/ -v` → 486 passed, 6 skipped
- [x] New unit + CLI tests (TDD): enumeration, `.env` upsert (comment/`export` preservation, idempotency, duplicate-drop), read-only plugin check, detect/apply, per-profile error isolation, dry-run vs `--apply`, non-default guard, `--json` / `--telemetry-home`
- [x] End-to-end smoke test against a tmp `HERMES_HOME` with named profiles: dry-run mutates nothing; `--apply` writes `.env` preserving comments and other vars
- [x] Fresh-context adversarial review: APPROVE-WITH-NITS (nits addressed)

## Notes
- Going-forward only: does not backfill telemetry rows already siloed in a profile's pre-consolidation DB.
- No version bump / CHANGELOG (release not yet cut).