### PR TITLE
docs(readme): document telemetry sync-profiles and multi-profile consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ LLM provider
   - [/budget](#budget)
 - [Configuration](#configuration)
   - [Shared telemetry home (HERMES_TELEMETRY_HOME)](#shared-telemetry-home-hermes_telemetry_home)
+  - [Consolidating multiple profiles (telemetry sync-profiles)](#consolidating-multiple-profiles-telemetry-sync-profiles)
   - [pricing.yaml](#pricingyaml)
   - [budget.yaml](#budgetyaml)
 - [Pricing Auto-Refresh](#pricing-auto-refresh)
@@ -848,6 +849,37 @@ export HERMES_TELEMETRY_HOME=~/.hermes-shared
 Telemetry paths resolve with precedence **`HERMES_TELEMETRY_HOME` › `HERMES_HOME` › `~/.hermes`**. When unset, nothing changes — each profile keeps its own (profile-tagged) telemetry dir.
 
 > This relocates **telemetry files only** (`telemetry.db`, `budget.yaml`, `pricing.yaml`). It never moves Hermes's own `state.db` or `cron/`, which stay on `HERMES_HOME`.
+
+### Consolidating multiple profiles (`telemetry sync-profiles`)
+
+Setting `HERMES_TELEMETRY_HOME` by hand in every profile's `.env` gets tedious and error-prone once you run more than a couple of profiles. The `telemetry sync-profiles` command automates it — it points every Hermes profile at one shared telemetry home so they all read the same `pricing.yaml` / `budget.yaml` and write to the same `telemetry.db`.
+
+Run it **from the default profile** (its home, `~/.hermes`, is the shared target):
+
+```bash
+# Dry-run (default) — prints the plan, changes nothing
+hermes telemetry sync-profiles
+
+# Apply — writes HERMES_TELEMETRY_HOME into each profile's .env
+hermes telemetry sync-profiles --apply
+
+# Limit to specific profiles, or point at a custom shared home:
+hermes telemetry sync-profiles coder writer --apply
+hermes telemetry sync-profiles --telemetry-home ~/.hermes-shared --apply
+
+# Machine-readable report (for scripting):
+hermes telemetry sync-profiles --json
+```
+
+What it does — and what it deliberately doesn't:
+
+- **Writes only** a single `HERMES_TELEMETRY_HOME` line into each profile's `.env` (atomic and idempotent; existing lines, comments, and an `export ` prefix are preserved). Hermes loads `<home>/.env` *before* it loads plugins, so the setting reaches each profile's process on its own — no manual `source` step.
+- Treats `config.yaml` as **read-only**: it *warns* when a profile hasn't enabled the plugin (`hermes plugins enable hermes-telemetry --profile <name>`) but never edits it.
+- Is **going-forward only** — it does not backfill rows already written to a profile's own pre-consolidation `telemetry.db`.
+
+> **Scope safety:** with no profile names, `--apply` targets **every** profile under `~/.hermes/profiles/*`. Pass explicit names to narrow it, and always read the dry-run first. Run from a named profile and `--apply` refuses unless you add `--yes`.
+
+**Multiplexed profiles.** Consolidation (one DB / pricing / budget) works no matter how your profiles run. Per-profile *attribution* — the `profile` tag that powers the dashboard's profile filter and `per_profile` budgets — is a separate concern: it is accurate only when each profile runs in its **own process** (a dedicated per-profile gateway or cron). A single multiplexed gateway serving several profiles from one process may tag some runs with the wrong profile (typically `default`), because the profile is derived from that process's `HERMES_HOME`.
 
 ### `pricing.yaml`
 


### PR DESCRIPTION
## What

Adds a README section documenting how to work with **multiple / multiplexed Hermes profiles**, covering the two things that were only in `ONBOARDING.md` (or not surfaced at all) for end users:

1. **Setting the shared telemetry home** — already documented under *Shared telemetry home (`HERMES_TELEMETRY_HOME`)*; left as-is.
2. **The `telemetry sync-profiles` command** — new subsection *Consolidating multiple profiles* that shows how to point every profile at one shared telemetry home so they all read the same `pricing.yaml` / `budget.yaml` and write to the same `telemetry.db`.

## Details

- Documents dry-run (default) vs `--apply`, scoping by profile name, `--telemetry-home`, and `--json`.
- Calls out what the command does and doesn't touch: `.env`-only (atomic, idempotent, comment/`export`-preserving), `config.yaml` read-only (warns, never edits), going-forward only (no backfill).
- Scope-safety note: unscoped `--apply` targets every profile; the non-default guard refuses without `--yes`.
- A **multiplexed profiles** note distinguishing consolidation (works regardless) from per-profile *attribution* (accurate only with dedicated per-profile processes) — aligned with the known-limitations note in `ONBOARDING.md`.
- Adds the matching Table of Contents entry.

## Scope

Docs only — no code, no schema change, no version bump.
