### PR TITLE
feat(dashboard): per-profile scoping + Global disclosures (plugin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,32 @@ totals and was invisible to per-cron-job budgets.
 Phase 1 is reporting/aggregation correctness; in-path enforcement of a runaway
 async child mid-flight is deferred to Phase 2.
 
+### Added — Per-profile scoping and Global disclosures in the dashboard plugin (#66)
+
+The plugin dashboard is now legible about scope: every surface either respects
+the selected Hermes profile or is explicitly labeled **Global**. Previously the
+per-profile selector only scoped Summary/Runs/Requests/Providers/Cron, while
+Efficiency, AI smells, the last-run and cron-7d widgets, and the budget section
+silently stayed global.
+
+- **Profile-scoped endpoints** — `/efficiency` and `/smells` now accept an
+  optional `?profile=` (filtering on `runs.profile`; smells qualifies it as
+  `r.profile` across its `tool_calls`→`runs` join), joining the endpoints that
+  already supported it.
+- **Per-profile budget display** — `/budget` emits per-profile scope entries
+  (`profile:<name>/<window>` with a `scope_id`, override-else-default limits)
+  alongside the global ones when `budgets.per_profile` is configured. Display
+  only; the budget engine already modeled per-profile scopes.
+- **Scope disclosures** — a `ScopeBadge` on every surface shows the active scope
+  (the profile name, or "All profiles") or "Global" for surfaces that cannot be
+  scoped (burn-rate forecast, tier-change and model-unavailable widgets).
+- **Own selectors for off-page widgets** — the last-run (`sessions:top`) and
+  cron-7d (`cron:top`) slot widgets render on other shell pages and cannot see
+  the Telemetry tab's selector, so each carries its own profile selector.
+
+Plugin surface only (the standalone dashboard is a later effort); no schema
+change (`runs.profile` already exists).
+
 ## [0.7.0] - 2026-06-20
 
 ### Added — Dashboard widget for model-unavailable alerts

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1154,6 +1154,33 @@ Note: the standalone `/api/budget/forecast` maps the config-key scopes
 projecting — the previous `from . import budget` version raised `ImportError`
 under the standalone loader and never resolved a non-global limit.
 
+#### Per-profile scoping (plugin surface)
+
+The plugin dashboard is legible about scope: every surface either respects a
+selected profile or is explicitly labeled Global.
+
+- **Profile-scoped endpoints** accept an optional `?profile=<name>` query param
+  (empty = all profiles, unchanged): `/summary`, `/runs`, `/requests`,
+  `/providers`, `/cron`, `/token-breakdown`, and — added here — `/efficiency`
+  and `/smells`. All filter on `runs.profile` (`smells` qualifies it as
+  `r.profile` in its `tool_calls JOIN runs` queries).
+- **`/budget`** emits per-profile scope entries alongside the global ones when
+  `budgets.per_profile` is configured — one per profile present in `runs`, per
+  window, with `scope: "profile:<name>/<window>"` and a `scope_id` field.
+  Limits resolve override-else-default; this is **display only** (creating
+  per-profile limits stays a `budget.yaml`/CLI concern). The engine already
+  modeled `per_profile`; this wired it into the read endpoint.
+- **Frontend** (`dist/index.js`): in-page tabs (Efficiency, Smells, …) share the
+  Telemetry tab's single profile `<select>`. The two off-page slot widgets —
+  `sessions:top` (last-run) and `cron:top` (cron-7d) — cannot see that selector
+  (separate shell pages), so each carries its own `MiniProfileSelect` fed by
+  `/profiles`. A `ScopeBadge` labels each surface: the profile name /
+  "All profiles" on scoped surfaces, "Global" on genuinely-global ones.
+- **Stays Global** (labeled, not scoped): the burn-rate forecast (the plugin
+  `/forecast` has no scope param), tier-change and model-unavailable widgets.
+  `model_unavailable_alerts` has no profile/session column, so scoping it would
+  need a schema migration — out of scope.
+
 ---
 
 ## Cron Job Identification

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -399,7 +399,8 @@
         h(Badge, { variant: "outline" }, "Telemetry"),
         run
           ? h("span", null, "Last run: ", h("strong", null, fmtUsd(run.cost_usd)))
-          : h("span", { className: "text-muted-foreground" }, loaded ? "No runs for this profile" : "Loading…"),
+          : h("span", { className: "text-muted-foreground" },
+              loaded ? (profile ? "No runs for this profile" : "No runs recorded") : "Loading…"),
         run
           ? h("span", { className: "text-muted-foreground" },
               `${fmtInt(run.tokens_in)} in / ${fmtInt(run.tokens_out)} out · ${run.model || "—"}`)

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -234,11 +234,11 @@
     return h("div", { className: "grid gap-3" }, [...scopeCards, forecastCard]);
   }
 
-  function EfficiencyPanel() {
+  function EfficiencyPanel({ profile }) {
     const [data, setData] = useState(null);
     useEffect(() => {
-      api("/efficiency?window_hours=24").then(setData).catch(() => setData({ sessions: [] }));
-    }, []);
+      api(`/efficiency?window_hours=24${profileQS(profile)}`).then(setData).catch(() => setData({ sessions: [] }));
+    }, [profile]);
     if (!data) return h("p", { className: "text-sm" }, "Loading…");
     const rows = data.sessions || [];
     return h("div", { className: "flex flex-col gap-3" },
@@ -298,7 +298,7 @@
     }, []);
     const Panel = (TABS.find((t) => t.id === active) || TABS[0]).render;
     return h("div", { className: "flex flex-col gap-4" },
-      h(SmellsWidget, null),
+      h(SmellsWidget, { profile }),
       h(ModelUnavailableWidget, null),
       h(TierTransitionsWidget, null),
       h(Card, null,
@@ -517,14 +517,14 @@
     );
   }
 
-  function SmellsWidget() {
+  function SmellsWidget({ profile }) {
     // Surfaces AI anti-patterns detected in the last 24h. Same happy-path
     // contract as the sibling widgets: render nothing when no smells fire so
     // it stays invisible in normal operation.
     const [data, setData] = useState(null);
     useEffect(() => {
-      api("/smells?window_hours=24").then(setData).catch(() => setData({ smells: [] }));
-    }, []);
+      api(`/smells?window_hours=24${profileQS(profile)}`).then(setData).catch(() => setData({ smells: [] }));
+    }, [profile]);
     const smells = (data && data.smells) || [];
     if (!smells.length) return null;
     const hasHigh = smells.some((s) => s.severity === "high");

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -238,12 +238,14 @@
       return h(Card, null, h(CardContent, { className: "py-4 text-sm text-muted-foreground" },
         "Budget enabled but no global daily/monthly limit set."));
     }
+    const scopeTitle = (s) => (s.scope_id ? `Profile '${s.scope_id}' · ${s.window}` : s.scope);
     const scopeCards = data.scopes.map((s) =>
       h(Card, { key: s.scope },
         h(CardHeader, null,
           h("div", { className: "flex items-center gap-2" },
-            h(CardTitle, { className: "text-sm" }, s.scope),
+            h(CardTitle, { className: "text-sm" }, scopeTitle(s)),
             h(Badge, { variant: s.level === "ok" ? "outline" : "destructive" }, s.level),
+            (s.scope_id ? null : h(ScopeBadge, { global: true })),
           ),
         ),
         h(CardContent, { className: "text-sm font-courier" },
@@ -256,6 +258,7 @@
             h("div", { className: "flex items-center gap-2" },
               h(CardTitle, { className: "text-sm" }, `Burn-rate forecast (${forecast.window})`),
               h(Badge, { variant: forecast.status === "ok" ? "outline" : "destructive" }, forecast.status),
+              h(ScopeBadge, { global: true }),
             ),
           ),
           h(CardContent, { className: "text-sm font-courier" },

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -71,6 +71,30 @@
     }, label);
   }
 
+  // Shared profile enumeration for the off-page slot widgets, which cannot see
+  // the Telemetry tab's selector (they render in separate shell pages).
+  function useProfiles() {
+    const [profiles, setProfiles] = useState([]);
+    useEffect(() => {
+      api("/profiles").then((d) => setProfiles((d && d.profiles) || [])).catch(() => setProfiles([]));
+    }, []);
+    return profiles;
+  }
+
+  function MiniProfileSelect({ profile, profiles, onChange }) {
+    if (!profiles.length) return null;
+    return h("select", {
+      className: "text-xs border border-border bg-transparent px-1 py-0.5 ml-auto",
+      value: profile,
+      onChange: (e) => onChange(e.target.value),
+      title: "Filter by Hermes profile",
+      "aria-label": "Filter by Hermes profile",
+    },
+      h("option", { value: "" }, "All profiles"),
+      profiles.map((p) => h("option", { key: p, value: p }, p)),
+    );
+  }
+
   function SummaryPanel({ profile }) {
     const [data, setData] = useState(null);
     const [err, setErr] = useState(null);
@@ -341,15 +365,16 @@
   function SessionsTopWidget() {
     // The shell renders sessions:top on /sessions; the active session id is
     // not yet exposed by the SDK, so we surface the most-recent run as a
-    // pinned "last session" card. When the SDK adds useActiveSession we
-    // swap this for a per-row card.
+    // pinned "last session" card. This widget renders on a different page than
+    // the Telemetry tab, so it carries its OWN profile selector.
     const [run, setRun] = useState(null);
+    const [loaded, setLoaded] = useState(false);
+    const [profile, setProfile] = useState("");
+    const profiles = useProfiles();
     useEffect(() => {
+      setLoaded(false);
       // Pull a handful of recent runs and pick the first one with real data.
-      // The literal last run in the table can be a session that died at
-      // init (no API key, agent never made a call), which shows as a noisy
-      // "Last run: $0.0000 · 0 in / 0 out" badge.
-      api("/runs?limit=10&window_hours=0")
+      api(`/runs?limit=10&window_hours=0${profileQS(profile)}`)
         .then((d) => {
           const rows = (d && d.rows) || [];
           const real = rows.find((r) =>
@@ -359,33 +384,47 @@
             || r.model,
           );
           setRun(real || null);
+          setLoaded(true);
         })
-        .catch(() => setRun(null));
-    }, []);
-    if (!run) return null;
+        .catch(() => { setRun(null); setLoaded(true); });
+    }, [profile]);
+    // Stay invisible on the happy path only when there is nothing to show AND
+    // no profile selector to offer.
+    if (!run && !profiles.length) return null;
     return h(Card, { className: "border-dashed" },
       h(CardContent, { className: "py-2 flex items-center gap-3 text-xs font-courier" },
         h(Badge, { variant: "outline" }, "Telemetry"),
-        h("span", null, "Last run: ", h("strong", null, fmtUsd(run.cost_usd))),
-        h("span", { className: "text-muted-foreground" },
-          `${fmtInt(run.tokens_in)} in / ${fmtInt(run.tokens_out)} out · ${run.model || "—"}`),
+        run
+          ? h("span", null, "Last run: ", h("strong", null, fmtUsd(run.cost_usd)))
+          : h("span", { className: "text-muted-foreground" }, loaded ? "No runs for this profile" : "Loading…"),
+        run
+          ? h("span", { className: "text-muted-foreground" },
+              `${fmtInt(run.tokens_in)} in / ${fmtInt(run.tokens_out)} out · ${run.model || "—"}`)
+          : null,
+        h(MiniProfileSelect, { profile, profiles, onChange: setProfile }),
       ),
     );
   }
 
   function CronTopWidget() {
+    // Renders on the shell's /cron page, so it carries its OWN profile selector
+    // (it cannot see the Telemetry tab's selector).
     const [data, setData] = useState(null);
+    const [profile, setProfile] = useState("");
+    const profiles = useProfiles();
     useEffect(() => {
-      api("/cron?window_hours=168").then(setData).catch(() => setData({ rows: [] }));
-    }, []);
-    if (!data) return null;
-    const total = (data.rows || []).reduce((acc, r) => acc + (r.cost_usd || 0), 0);
-    const failed = (data.rows || []).reduce((acc, r) => acc + (r.failed_runs || 0), 0);
+      api(`/cron?window_hours=168${profileQS(profile)}`).then(setData).catch(() => setData({ rows: [] }));
+    }, [profile]);
+    if (!data && !profiles.length) return null;
+    const rows = (data && data.rows) || [];
+    const total = rows.reduce((acc, r) => acc + (r.cost_usd || 0), 0);
+    const failed = rows.reduce((acc, r) => acc + (r.failed_runs || 0), 0);
     return h(Card, { className: "border-dashed" },
       h(CardContent, { className: "py-2 flex items-center gap-3 text-xs font-courier" },
         h(Badge, { variant: "outline" }, "Telemetry"),
         h("span", null, "Cron 7d: ", h("strong", null, fmtUsd(total))),
         failed ? h(Badge, { variant: "destructive" }, `${failed} failed`) : null,
+        h(MiniProfileSelect, { profile, profiles, onChange: setProfile }),
       ),
     );
   }

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -60,6 +60,17 @@
 
   const profileQS = (p) => (p ? `&profile=${encodeURIComponent(p)}` : "");
 
+  // Scope disclosure: on profile-scoped surfaces shows the active scope
+  // (profile name, or "All profiles"); on global-only surfaces shows "Global".
+  function ScopeBadge({ profile, global: isGlobal }) {
+    const label = isGlobal ? "Global" : (profile ? profile : "All profiles");
+    return h(Badge, {
+      variant: "outline",
+      className: "font-courier ml-auto",
+      title: isGlobal ? "Global — not filtered by profile" : `Scope: ${label}`,
+    }, label);
+  }
+
   function SummaryPanel({ profile }) {
     const [data, setData] = useState(null);
     const [err, setErr] = useState(null);
@@ -462,6 +473,7 @@
         h(CardTitle, { className: "text-sm flex items-center gap-2" },
           h(Badge, { variant: within24h ? "destructive" : "outline" }, "Tier change"),
           h("span", null, `${rows.length} model${rows.length === 1 ? "" : "s"} flipped free→paid (72h)`),
+          h(ScopeBadge, { global: true }),
         ),
       ),
       h(CardContent, { className: "py-2 space-y-1 text-xs font-courier" },
@@ -501,6 +513,7 @@
         h(CardTitle, { className: "text-sm flex items-center gap-2" },
           h(Badge, { variant: within24h ? "destructive" : "outline" }, "Model unavailable"),
           h("span", null, `${rows.length} model${rows.length === 1 ? "" : "s"} 404'd (72h)`),
+          h(ScopeBadge, { global: true }),
         ),
       ),
       h(CardContent, { className: "py-2 space-y-1 text-xs font-courier" },
@@ -533,6 +546,7 @@
         h(CardTitle, { className: "text-sm flex items-center gap-2" },
           h(Badge, { variant: hasHigh ? "destructive" : "outline" }, "AI smells"),
           h("span", null, `${smells.length} anti-pattern${smells.length === 1 ? "" : "s"} detected (24h)`),
+          h(ScopeBadge, { profile }),
         ),
       ),
       h(CardContent, { className: "py-2 space-y-1 text-xs font-courier" },

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -415,6 +415,46 @@ def budget() -> dict:
             }
         )
 
+    # Per-profile scopes. The budget engine already models per_profile (default
+    # + overrides); this is display only — mirror the global loop for each
+    # profile present in runs, resolving override-else-default limits.
+    pp_cfg = (cfg.get("budgets", {}) or {}).get("per_profile", {}) or {}
+    if pp_cfg:
+        pp_default = pp_cfg.get("default", {}) or {}
+        pp_overrides = pp_cfg.get("overrides", {}) or {}
+        profile_rows = _rows(
+            "SELECT DISTINCT profile FROM runs "
+            "WHERE profile IS NOT NULL AND profile != '' ORDER BY profile"
+        )
+        for prow in profile_rows:
+            name = prow["profile"]
+            limits = pp_overrides.get(name, pp_default) or {}
+            for window in ("daily", "monthly"):
+                limit = limits.get(f"{window}_usd")
+                if limit is None:
+                    continue
+                start_utc = _window_start_utc(window)
+                spend = _one(
+                    "SELECT COALESCE(SUM(cost_usd), 0.0) AS spent FROM runs "
+                    "WHERE started_at >= ? AND profile = ?",
+                    (start_utc, name),
+                )
+                spent = float(spend.get("spent") or 0.0)
+                pct = spent / limit if limit > 0 else 0.0
+                level = "hard" if pct >= hard_pct else ("soft" if pct >= soft_pct else "ok")
+                scopes.append(
+                    {
+                        "scope": f"profile:{name}/{window}",
+                        "scope_id": name,
+                        "window": window,
+                        "limit_usd": float(limit),
+                        "spent_usd": round(spent, 6),
+                        "pct": round(pct * 100, 1),
+                        "level": level,
+                        "window_start_utc": start_utc,
+                    }
+                )
+
     return {
         "enabled": True,
         "scopes": scopes,

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -555,23 +555,30 @@ def efficiency(window_hours: int = 24, profile: str = "") -> dict:
 # AI smell detection
 # ---------------------------------------------------------------------------
 @router.get("/smells")
-def smells(window_hours: int = 24) -> dict:
+def smells(window_hours: int = 24, profile: str = "") -> dict:
     """AI smell detection over existing telemetry. Inlined per the standalone
     loader constraint; mirrors smell_detector.detect_all."""
     from collections import Counter
 
     sc = _since_clause(window_hours, "started_at")
     tsc = _since_clause(window_hours, "tc.ts")
+    # Profile scoping: `pc` for queries on `runs` directly, `pcr` for queries
+    # that JOIN runs as `r` (column name must be qualified there). `pp` is the
+    # shared parameter tuple for whichever clause is used.
+    pc = " AND profile = ?" if profile else ""
+    pcr = " AND r.profile = ?" if profile else ""
+    pp: tuple = (profile,) if profile else ()
     found: list[dict] = []
 
     for r in _rows(
         f"""SELECT session_id, COALESCE(cron_job_id,'') AS cron_job_id,
                    COALESCE(tokens_in,0) AS tokens_in, COALESCE(tokens_out,0) AS tokens_out,
                    COALESCE(status,'running') AS status, started_at
-            FROM runs WHERE {sc} AND status != 'running'
+            FROM runs WHERE {sc} AND status != 'running'{pc}
               AND tokens_in > 1000
               AND CAST(tokens_out AS REAL) / CAST(tokens_in AS REAL) < 0.10
-            ORDER BY tokens_in DESC LIMIT 50"""
+            ORDER BY tokens_in DESC LIMIT 50""",
+        pp,
     ):
         ratio = r["tokens_out"] / max(r["tokens_in"], 1) * 100
         found.append(
@@ -591,11 +598,12 @@ def smells(window_hours: int = 24) -> dict:
                    COUNT(*) AS total_tools,
                    SUM(CASE WHEN tc.ok = 0 THEN 1 ELSE 0 END) AS failed_tools
             FROM tool_calls tc JOIN runs r ON tc.session_id = r.session_id
-            WHERE {tsc} AND r.status != 'running'
+            WHERE {tsc} AND r.status != 'running'{pcr}
             GROUP BY tc.session_id
             HAVING total_tools > 20
                AND CAST(failed_tools AS REAL) / CAST(total_tools AS REAL) > 0.30
-            ORDER BY total_tools DESC LIMIT 50"""
+            ORDER BY total_tools DESC LIMIT 50""",
+        pp,
     ):
         rate = r["failed_tools"] / max(r["total_tools"], 1) * 100
         found.append(
@@ -613,7 +621,8 @@ def smells(window_hours: int = 24) -> dict:
     tool_rows = _rows(
         f"""SELECT tc.session_id, tc.tool_name, r.cron_job_id, r.status, r.started_at
             FROM tool_calls tc JOIN runs r ON tc.session_id = r.session_id
-            WHERE {tsc} AND r.status != 'running'"""
+            WHERE {tsc} AND r.status != 'running'{pcr}""",
+        pp,
     )
     by_session: dict = {}
     meta: dict = {}
@@ -654,7 +663,8 @@ def smells(window_hours: int = 24) -> dict:
     agg = _one(
         f"""SELECT COUNT(*) AS total,
                    SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS errors
-            FROM runs WHERE {sc} AND status != 'running'"""
+            FROM runs WHERE {sc} AND status != 'running'{pc}""",
+        pp,
     )
     total_runs = agg.get("total") or 0
     error_runs = agg.get("errors") or 0
@@ -663,8 +673,9 @@ def smells(window_hours: int = 24) -> dict:
         for r in _rows(
             f"""SELECT session_id, COALESCE(cron_job_id,'') AS cron_job_id, status,
                        COALESCE(api_calls,0) AS api_calls, ROUND(COALESCE(cost_usd,0.0),6) AS cost_usd, started_at
-                FROM runs WHERE {sc} AND status = 'error'
-                ORDER BY started_at DESC LIMIT 50"""
+                FROM runs WHERE {sc} AND status = 'error'{pc}
+                ORDER BY started_at DESC LIMIT 50""",
+            pp,
         ):
             found.append(
                 {
@@ -682,9 +693,10 @@ def smells(window_hours: int = 24) -> dict:
         f"""SELECT session_id, COALESCE(cron_job_id,'') AS cron_job_id, COALESCE(status,'running') AS status,
                    COALESCE(tokens_in,0) AS tokens_in, COALESCE(tokens_out,0) AS tokens_out,
                    COALESCE(api_calls,0) AS api_calls, ROUND(COALESCE(cost_usd,0.0),6) AS cost_usd, started_at
-            FROM runs WHERE {sc} AND status != 'running'
+            FROM runs WHERE {sc} AND status != 'running'{pc}
               AND ((tokens_in + tokens_out) > 100000 OR api_calls > 50)
-            ORDER BY (tokens_in + tokens_out) DESC LIMIT 50"""
+            ORDER BY (tokens_in + tokens_out) DESC LIMIT 50""",
+        pp,
     ):
         found.append(
             {

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -428,7 +428,9 @@ def budget() -> dict:
         )
         for prow in profile_rows:
             name = prow["profile"]
-            limits = pp_overrides.get(name, pp_default) or {}
+            # Empty/absent override falls back to default, matching the runtime
+            # engine's budget._resolve_limits (overrides.get(id) or default).
+            limits = (pp_overrides.get(name) or pp_default) or {}
             for window in ("daily", "monthly"):
                 limit = limits.get(f"{window}_usd")
                 if limit is None:

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -499,9 +499,10 @@ def _compute_efficiency(tokens_in: int, tokens_out: int, api_calls: int, status:
 
 
 @router.get("/efficiency")
-def efficiency(window_hours: int = 24) -> dict:
+def efficiency(window_hours: int = 24, profile: str = "") -> dict:
     """Return per-session efficiency scores and aggregate stats."""
     sc = _since_clause(window_hours, "started_at")
+    pc, pc_params = _runs_profile_clause(profile)
     rows = _rows(
         f"""
         SELECT session_id,
@@ -514,10 +515,11 @@ def efficiency(window_hours: int = 24) -> dict:
                started_at
         FROM runs
         WHERE {sc}
-          AND status != 'running'
+          AND status != 'running'{pc}
         ORDER BY started_at DESC
         LIMIT 100
-    """
+    """,
+        pc_params,
     )
     scored = []
     for r in rows:

--- a/tests/test_dashboard_plugin_api.py
+++ b/tests/test_dashboard_plugin_api.py
@@ -736,3 +736,47 @@ def test_budget_no_per_profile_block_stays_global(plugin_api):
     )
     out = plugin_api.budget()
     assert all(s["scope"].startswith("global/") for s in out["scopes"])
+
+
+def test_budget_empty_profile_override_falls_back_to_default(plugin_api):
+    """An empty per-profile override ({}) falls back to the default limit,
+    matching the runtime budget engine (budget._resolve_limits)."""
+    import os
+    from datetime import datetime, timezone
+
+    import db as runtime_db
+
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    (hermes_home / "telemetry").mkdir(parents=True, exist_ok=True)
+    (hermes_home / "telemetry" / "budget.yaml").write_text(
+        "budgets:\n"
+        "  global:\n"
+        "    daily_usd: 100.0\n"
+        "  per_profile:\n"
+        "    default:\n"
+        "      daily_usd: 5.0\n"
+        "    overrides:\n"
+        "      coder: {}\n",
+        encoding="utf-8",
+    )
+    now = datetime.now(timezone.utc).isoformat()
+    _seed(
+        rows_runs=[{"session_id": "c1", "model": "m", "platform": "cli", "profile": "coder"}],
+        rows_llm=[
+            {
+                "session_id": "c1",
+                "ts": now,
+                "model": "m",
+                "provider": "p",
+                "tokens_in": 10,
+                "tokens_out": 10,
+                "cost_usd": 1.0,
+                "latency_ms": 5,
+            },
+        ],
+    )
+    runtime_db.end_run("c1", "ok")
+
+    out = plugin_api.budget()
+    scopes = {s["scope"]: s for s in out["scopes"]}
+    assert scopes["profile:coder/daily"]["limit_usd"] == 5.0

--- a/tests/test_dashboard_plugin_api.py
+++ b/tests/test_dashboard_plugin_api.py
@@ -611,3 +611,48 @@ def test_efficiency_filters_by_profile(plugin_api):
 
     # No profile = both sessions (unchanged behavior).
     assert plugin_api.efficiency(window_hours=24)["sessions_scored"] == 2
+
+
+def test_smells_filters_by_profile(plugin_api):
+    """/smells scopes detected anti-patterns to a single profile when asked."""
+    from datetime import datetime, timezone
+
+    import db as runtime_db
+
+    now = datetime.now(timezone.utc).isoformat()
+    _seed(
+        rows_runs=[
+            {"session_id": "c1", "model": "m", "platform": "cli", "profile": "coder"},
+            {"session_id": "o1", "model": "m", "platform": "cli", "profile": "ops"},
+        ],
+        rows_llm=[
+            {
+                "session_id": "c1",
+                "ts": now,
+                "model": "m",
+                "provider": "p",
+                "tokens_in": 10000,
+                "tokens_out": 500,
+                "cost_usd": 0.05,
+                "latency_ms": 100,
+            },
+            {
+                "session_id": "o1",
+                "ts": now,
+                "model": "m",
+                "provider": "p",
+                "tokens_in": 10000,
+                "tokens_out": 500,
+                "cost_usd": 0.05,
+                "latency_ms": 100,
+            },
+        ],
+    )
+    runtime_db.end_run("c1", "ok")
+    runtime_db.end_run("o1", "ok")
+
+    out = plugin_api.smells(window_hours=24, profile="coder")
+    assert {s["session_id"] for s in out["smells"]} == {"c1"}
+
+    # No profile = smells from both profiles.
+    assert {s["session_id"] for s in plugin_api.smells(window_hours=24)["smells"]} == {"c1", "o1"}

--- a/tests/test_dashboard_plugin_api.py
+++ b/tests/test_dashboard_plugin_api.py
@@ -656,3 +656,83 @@ def test_smells_filters_by_profile(plugin_api):
 
     # No profile = smells from both profiles.
     assert {s["session_id"] for s in plugin_api.smells(window_hours=24)["smells"]} == {"c1", "o1"}
+
+
+def test_budget_includes_per_profile_scopes(plugin_api):
+    """/budget emits a scope per profile present in runs, using override-else-default limits."""
+    import os
+    from datetime import datetime, timezone
+
+    import db as runtime_db
+
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    (hermes_home / "telemetry").mkdir(parents=True, exist_ok=True)
+    (hermes_home / "telemetry" / "budget.yaml").write_text(
+        "budgets:\n"
+        "  global:\n"
+        "    daily_usd: 100.0\n"
+        "  per_profile:\n"
+        "    default:\n"
+        "      daily_usd: 2.0\n"
+        "    overrides:\n"
+        "      coder:\n"
+        "        daily_usd: 10.0\n"
+        "thresholds:\n"
+        "  soft_pct: 0.8\n"
+        "  hard_pct: 1.0\n",
+        encoding="utf-8",
+    )
+    now = datetime.now(timezone.utc).isoformat()
+    _seed(
+        rows_runs=[
+            {"session_id": "c1", "model": "m", "platform": "cli", "profile": "coder"},
+            {"session_id": "o1", "model": "m", "platform": "cli", "profile": "ops"},
+        ],
+        rows_llm=[
+            {
+                "session_id": "c1",
+                "ts": now,
+                "model": "m",
+                "provider": "p",
+                "tokens_in": 10,
+                "tokens_out": 10,
+                "cost_usd": 3.0,
+                "latency_ms": 5,
+            },
+            {
+                "session_id": "o1",
+                "ts": now,
+                "model": "m",
+                "provider": "p",
+                "tokens_in": 10,
+                "tokens_out": 10,
+                "cost_usd": 1.0,
+                "latency_ms": 5,
+            },
+        ],
+    )
+    runtime_db.end_run("c1", "ok")
+    runtime_db.end_run("o1", "ok")
+
+    out = plugin_api.budget()
+    scopes = {s["scope"]: s for s in out["scopes"]}
+    assert "global/daily" in scopes
+    assert scopes["profile:coder/daily"]["scope_id"] == "coder"
+    assert scopes["profile:coder/daily"]["limit_usd"] == 10.0
+    assert scopes["profile:coder/daily"]["spent_usd"] == 3.0
+    assert scopes["profile:ops/daily"]["limit_usd"] == 2.0
+    assert scopes["profile:ops/daily"]["spent_usd"] == 1.0
+
+
+def test_budget_no_per_profile_block_stays_global(plugin_api):
+    """With no per_profile config, /budget emits only global scopes (unchanged)."""
+    import os
+
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    (hermes_home / "telemetry").mkdir(parents=True, exist_ok=True)
+    (hermes_home / "telemetry" / "budget.yaml").write_text(
+        "budgets:\n  global:\n    daily_usd: 1.0\n",
+        encoding="utf-8",
+    )
+    out = plugin_api.budget()
+    assert all(s["scope"].startswith("global/") for s in out["scopes"])

--- a/tests/test_dashboard_plugin_api.py
+++ b/tests/test_dashboard_plugin_api.py
@@ -565,3 +565,49 @@ def test_forecast_endpoint_reads_global_limit(plugin_api):
     assert out["limit_usd"] == 10.0
     assert out["spent_so_far_usd"] >= 2.0
     assert out["status"] in ("ok", "soft", "hard")
+
+
+def test_efficiency_filters_by_profile(plugin_api):
+    """/efficiency scopes scored sessions to a single profile when asked."""
+    from datetime import datetime, timezone
+
+    import db as runtime_db
+
+    now = datetime.now(timezone.utc).isoformat()
+    _seed(
+        rows_runs=[
+            {"session_id": "c1", "model": "m", "platform": "cli", "profile": "coder"},
+            {"session_id": "o1", "model": "m", "platform": "cli", "profile": "ops"},
+        ],
+        rows_llm=[
+            {
+                "session_id": "c1",
+                "ts": now,
+                "model": "m",
+                "provider": "p",
+                "tokens_in": 100,
+                "tokens_out": 100,
+                "cost_usd": 0.001,
+                "latency_ms": 50,
+            },
+            {
+                "session_id": "o1",
+                "ts": now,
+                "model": "m",
+                "provider": "p",
+                "tokens_in": 100,
+                "tokens_out": 100,
+                "cost_usd": 0.001,
+                "latency_ms": 50,
+            },
+        ],
+    )
+    runtime_db.end_run("c1", "ok")
+    runtime_db.end_run("o1", "ok")
+
+    out = plugin_api.efficiency(window_hours=24, profile="coder")
+    assert [s["session_id"] for s in out["sessions"]] == ["c1"]
+    assert out["sessions_scored"] == 1
+
+    # No profile = both sessions (unchanged behavior).
+    assert plugin_api.efficiency(window_hours=24)["sessions_scored"] == 2


### PR DESCRIPTION
## Summary

Makes the **plugin** dashboard legible about scope: every surface either respects the selected Hermes profile or is explicitly labeled **Global**. Previously the per-profile filter only scoped Summary/Runs/Requests/Providers/Cron, while Efficiency, AI smells, the last-run and cron-7d slot widgets, and the budget section silently stayed global.

**Backend (`dashboard/plugin_api.py`, self-contained — no engine import):**
- `/efficiency` and `/smells` accept an optional `?profile=<name>` (empty = all profiles). Filters on `runs.profile`; smells qualifies it as `r.profile` in its `tool_calls JOIN runs` queries.
- `/budget` emits per-profile scope entries alongside the global ones when `budgets.per_profile` is configured — one per profile present in `runs`, `scope: "profile:<name>/<window>"` with a `scope_id` field, override-else-default limits. **Display only** (the engine already modeled `per_profile`; this wires it into the read endpoint).

**Frontend (`dashboard/dist/index.js`):**
- Efficiency and AI-smells honor the Telemetry tab's single profile selector.
- New `ScopeBadge` disclosure on every surface: profile name / "All profiles" on scoped surfaces, "Global" on the rest.
- The two off-page slot widgets — `sessions:top` (last-run) and `cron:top` (cron-7d) — render on separate shell pages and can't see the tab selector, so each carries its own `MiniProfileSelect` fed by `/profiles`.
- `BudgetsPanel` renders per-profile scope cards; forecast card labeled Global.

**Docs:** ONBOARDING § Dashboard surfaces documents the scoping and why some surfaces stay Global.

## Out of scope (intentional)
- Standalone dashboard (`serve.py` / `index.html`) — separate later slices.
- Editing per-profile budget limits via the UI (stays `budget.yaml` / CLI).
- Per-profile burn-rate forecast in the plugin (forecast stays Global).
- Per-profile attribution for `model_unavailable_alerts` — the table has no profile/session column; would need a schema migration.

No schema migration (`runs.profile` already exists at v12). No version bump / CHANGELOG entry (deferred until the release is cut).

## Test plan
- [x] `ruff format --check . && ruff check .` clean.
- [x] `pytest tests/` — green except the pre-existing env-dependent `test_dashboard.py::test_budget_update_returns_viewer_timezone_metadata` (asserts UTC on a CEST machine; already failing on `main`).
- [x] New tests: `test_efficiency_filters_by_profile`, `test_smells_filters_by_profile`, `test_budget_includes_per_profile_scopes`, `test_budget_no_per_profile_block_stays_global`, `test_budget_empty_profile_override_falls_back_to_default`.
- [ ] Manual on the server: update the plugin, pick a profile — Efficiency / AI-smells / last-run / cron-7d / per-profile budget scope to it; tier-change, model-unavailable and forecast show "Global".