### PR TITLE
fix(stats): label known-free $0 rows as "free tier", not "no price entry"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `/stats models` mislabeled known-free $0 rows as "no price entry"
+
+- A `$0.00` row resolved by the `:free` suffix rule (including the dated ids a
+  gateway sends, e.g. `tencent/hy3-20260706:free`) or a built-in $0 seed was
+  bucketed as `no price entry`, wrongly implying a lookup miss and prompting the
+  user to run `/setup pricing auto`. The Notes column consulted only
+  `subscription_models` and ignored `is_explicitly_priced`, so it could not tell a
+  known-free model from a genuine unknown. `stats._models_block` now splits $0
+  rows three ways — `subscription/free-tier` > `free tier` (`:free` suffix or
+  built-in $0 seed) > `no price entry` — with a matching footer line. Documented
+  the `:free`-vs-`_subscription` distinction (and the exact-id requirement for a
+  `_subscription` declaration) in the README free-tier notice and ONBOARDING.
+
 ### Added — Agent intelligence: efficiency scoring, smell detection, burn-rate forecasting (#8)
 
 Three read-only analytical capabilities over existing telemetry (no new capture,

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -633,6 +633,28 @@ only to make the assumption visible so the user can pin the rate.
 The bare id is never returned by OpenRouter, so it never collides with an
 auto-fetched entry and survives every refresh untouched.
 
+**`/stats models` $0 classification (three-way).** The Notes column disambiguates
+every `$0.00` row so the footer never nags about a deliberate zero.
+`stats._models_block` splits them, in order:
+
+1. `subscription/free-tier` — exact-id membership in `subscription_models` (a
+   declared `_subscription` entry).
+2. `free tier` — `pricing.is_explicitly_priced(model, provider)` is True but it is
+   not a declared subscription: a `:free` suffix id (resolved to $0 by the rule
+   above) or a built-in $0 seed. Known-free, not a lookup miss.
+3. `no price entry` — genuine unknown (`is_explicitly_priced` is False).
+
+**Gotcha — `_subscription` is the wrong tool for a `:free`-served model.** When the
+gateway serves the model with a `:free` suffix — and gateways send **dated** ids,
+e.g. `tencent/hy3-20260706:free` — the `:free` rule already resolves it to $0,
+records it known-free, and arms the free→paid alert, so **no `pricing.yaml` entry is
+needed** and the row shows as `free tier`. `_subscription` is only for a model served
+free under a **bare native id** (no `:free`), and the entry must match the **exact id
+the gateway records**: a non-dated key (`tencent/hy3:free`) never matches the dated
+id, so it neither prices nor labels the row. Both the cost lookup
+(`subscription_models` / custom exact match) and the stats label key on the exact
+recorded id — there is no prefix or date-stripping normalization for either.
+
 ### Google-symmetric normalization (added v0.4.0)
 
 **Problem:** The gateway reports model IDs differently depending on routing path:

--- a/README.md
+++ b/README.md
@@ -52,35 +52,40 @@ LLM provider
 
 -----
 
-> ### ℹ️ Two models are free right now — declare them while the promo lasts
+> ### ℹ️ Two models are on a free tier right now
 >
-> Two gateway models currently bill at **$0** on a time-limited free tier:
+> Two models currently bill at **$0** on a time-limited free tier:
 >
-> | Model id | Free until |
-> |----------|------------|
-> | `tencent/hy3` | 2026-07-15 |
-> | `stepfun/step-3.7-flash` | 2026-07-23 |
+> | Model | Free until |
+> |-------|------------|
+> | Tencent Hy3 | 2026-07-15 |
+> | StepFun Step 3.7 Flash | 2026-07-23 |
 >
-> Both are served under **bare ids** (no `:free` suffix), so the automatic
-> free-tier suffix rule does not fire — left undeclared they'd be treated as
-> unknown and raise an estimated-price warning. Declare each with
-> `_subscription: true` in [`pricing.yaml`](#pricingyaml) so the `$0` is recorded
-> as intentional (not a lookup miss) and survives every OpenRouter refresh:
+> **What you need to do depends on the id your gateway sends** (check `/stats
+> models` to see the exact id recorded):
+>
+> - **Served with a `:free` suffix** (e.g. `tencent/hy3-20260706:free`) —
+>   **nothing to do.** Any id ending in `:free` resolves to `$0` automatically,
+>   is recorded as known-free (no estimated-price warning), shows as `free tier`
+>   in `/stats models`, and arms the free→paid alert for when the promo ends and
+>   the suffix is dropped.
+> - **Served under a bare native id** (no `:free` suffix) — the auto-$0 rule does
+>   not fire, so declare it with `_subscription: true` in
+>   [`pricing.yaml`](#pricingyaml) so the `$0` is recorded as intentional (not a
+>   lookup miss) and survives every OpenRouter refresh. Use the **exact id the
+>   gateway records** — a non-dated key will not match a dated id:
 >
 > ```yaml
 > models:
->   tencent/hy3:
+>   tencent/hy3:            # ← the exact bare id from `/stats models`
 >     input: 0.0
 >     output: 0.0
 >     _subscription: true   # free tier ends 2026-07-15
->   stepfun/step-3.7-flash:
->     input: 0.0
->     output: 0.0
->     _subscription: true   # free tier ends 2026-07-23
 > ```
 >
-> When a promo ends the model starts incurring cost. Remove its entry (or set the
-> real price) so hermes-telemetry bills it correctly again.
+> When a promo ends the model starts incurring cost. For a `:free` id the alert
+> fires on its own; for a declared entry, remove it (or set the real price) so
+> hermes-telemetry bills it correctly again.
 
 -----
 
@@ -625,11 +630,13 @@ hermes-telemetry — models (last 24 h)
   Provider             Model                                           Calls   Real   Est         Cost  Notes
   ----------------------------------------------------------------------------------------------------------
   nous                 deepseek/deepseek-v4-pro-20260423                 449    448     1    $2.318788
-  nous                 tencent/hy3                                       153    153     0    $0.000000  subscription/free-tier
+  nous                 tencent/hy3-20260706:free                         153    153     0    $0.000000  free tier
+  nous                 qwen3.7-plus                                       80     80     0    $0.000000  subscription/free-tier
   openrouter           some/unpriced-model                                12     12     0    $0.000000  no price entry
 
   Rows are grouped by provider, then by calls (desc).
   1 model(s) at $0.00 are subscription/free tier (declared in pricing.yaml via `_subscription: true`).
+  1 model(s) at $0.00 are free tier (`:free` suffix or built-in $0 price).
   1 model(s) at $0.00 have no price entry in pricing.yaml — run /setup pricing auto
   to refresh, or add them manually.
 ```
@@ -639,9 +646,10 @@ Breaks each provider's spend down to individual models. Rows are grouped by prov
 The `Notes` column disambiguates `$0.000000` rows so the user can tell intentional zeros from missing pricing:
 
 - **`subscription/free-tier`** — the model is declared with `_subscription: true` in `pricing.yaml`. The $0 is intentional (subscription plan or free tier), not a bug. Pricing refresh preserves these entries verbatim.
-- **`no price entry`** — there is no row for this model in `pricing.yaml`. The $0 means Hermes had nothing to multiply by; run `/setup pricing auto` to refresh, or add a manual entry.
+- **`free tier`** — the model resolves to an explicit $0 on its own, with no `pricing.yaml` entry needed: a `:free` suffix variant (any id ending in `:free`, including the dated ids a gateway sends, e.g. `tencent/hy3-20260706:free`) or a built-in $0 seed. Recorded as known-free, so it never triggers the estimated-price warning and arms the free→paid alert for when the suffix is later dropped.
+- **`no price entry`** — there is no row for this model in `pricing.yaml` and nothing resolves it to $0. The $0 means Hermes had nothing to multiply by; run `/setup pricing auto` to refresh, or add a manual entry.
 
-The footer reflects the same split: subscription rows are claimed as declared, no-entry rows keep the original `/setup pricing auto` hint, and a mixed window emits both lines.
+The footer reflects the same split: subscription rows are claimed as declared, free-tier rows are flagged as known-free, no-entry rows keep the original `/setup pricing auto` hint, and a mixed window emits every applicable line.
 
 **Example output (`/stats efficiency`):**
 

--- a/stats.py
+++ b/stats.py
@@ -298,6 +298,7 @@ def _models_block(
         "  " + "-" * 106,
     ]
     sub_zero_count = 0
+    free_zero_count = 0
     noentry_zero_count = 0
     for r in rows:
         prov = (r.get("provider") or "(unknown)")[:20]
@@ -311,9 +312,21 @@ def _models_block(
         cost = _fmt_cost(cost_v)
         note = ""
         if cost_v == 0.0:
-            if (r.get("model") or "").lower() in subscription_models:
+            # Three-way split of $0.00 rows so the footer never nags about a
+            # deliberate zero. `is_explicitly_priced` is the authority for
+            # "intentional $0" vs "unknown model": it is True for a `:free`
+            # suffix variant (resolved to $0 by rule, incl. the dated ids a
+            # gateway actually sends) and for built-in $0 seeds, but False for a
+            # genuine lookup miss. Subscription is checked first — a declared
+            # `_subscription` model is also explicitly priced, but earns the more
+            # specific label.
+            model_raw = r.get("model") or ""
+            if model_raw.lower() in subscription_models:
                 note = "subscription/free-tier"
                 sub_zero_count += 1
+            elif _pricing.is_explicitly_priced(model_raw, r.get("provider") or ""):
+                note = "free tier"
+                free_zero_count += 1
             else:
                 note = "no price entry"
                 noentry_zero_count += 1
@@ -325,6 +338,11 @@ def _models_block(
         lines.append(
             f"  {sub_zero_count} model(s) at $0.00 are subscription/free tier "
             "(declared in pricing.yaml via `_subscription: true`)."
+        )
+    if free_zero_count:
+        lines.append(
+            f"  {free_zero_count} model(s) at $0.00 are free tier "
+            "(`:free` suffix or built-in $0 price)."
         )
     if noentry_zero_count:
         lines.append(

--- a/tests/test_stats_models.py
+++ b/tests/test_stats_models.py
@@ -228,6 +228,48 @@ def test_stats_models_zero_cost_mixed_emits_both_footers(tmp_path, monkeypatch):
     assert "/setup pricing auto" in out
 
 
+def test_stats_models_zero_cost_free_suffix_row_labeled_free_tier(tmp_path, monkeypatch):
+    """A $0.00 row served with a `:free` suffix is an intentional free tier: the
+    `:free` rule resolves it to $0 and records it as known-free. It must NOT be
+    tagged 'no price entry' even with NO pricing.yaml entry, and even for the dated
+    variant the gateway actually sends (e.g. tencent/hy3-20260706:free)."""
+    import hermes_telemetry.pricing as pricing
+
+    pricing.reload_custom_pricing()  # no pricing.yaml at all
+
+    now = db._utcnow()
+    db.start_run("s1", model="m", platform="cli")
+    db.record_llm_call("s1", now, "tencent/hy3-20260706:free", "nous", 100, 50, 0.0, 100)
+
+    out = stats_mod.handle("models")
+    assert "tencent/hy3-20260706:free" in out
+    assert "free tier" in out
+    assert "no price entry" not in out
+
+
+def test_stats_models_free_suffix_unaffected_by_nonmatching_subscription(tmp_path, monkeypatch):
+    """Regression for the dated-id gap: declaring a NON-dated `:free` id as
+    `_subscription` does not match the dated id the gateway sends, so the row is not
+    tagged subscription/free-tier — but it is still correctly shown as a free tier
+    (via the `:free` rule), never 'no price entry'."""
+    _seed_pricing_yaml(
+        tmp_path,
+        "models:\n  tencent/hy3:free:\n    input: 0.0\n    output: 0.0\n    _subscription: true\n",
+    )
+    import hermes_telemetry.pricing as pricing
+
+    pricing.reload_custom_pricing()
+
+    now = db._utcnow()
+    db.start_run("s1", model="m", platform="cli")
+    db.record_llm_call("s1", now, "tencent/hy3-20260706:free", "nous", 100, 50, 0.0, 100)
+
+    out = stats_mod.handle("models")
+    assert "tencent/hy3-20260706:free" in out
+    assert "free tier" in out
+    assert "no price entry" not in out
+
+
 # ---------------------------------------------------------------------------
 # date_from / date_to filtering (PR #35)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`/stats models` rendered free `:free` models at `$0.00` labeled **`no price entry`**, with the footer nagging to run `/setup pricing auto` — even when the model is genuinely known-free. Seen in a real session: `tencent/hy3-20260706:free` (a dated free-tier id the gateway sends) showed as `no price entry` despite a `_subscription: true` declaration in `pricing.yaml`.

## Root cause

Two independent facts combine:

1. The gateway records **dated** `:free` ids (`tencent/hy3-20260706:free`), not the non-dated key a user declares (`tencent/hy3:free`). Both the cost lookup and the stats label key on the **exact recorded id** — there is no prefix or date-stripping normalization — so the declaration never matches.
2. The `$0` comes (correctly) from the `:free` suffix rule in `pricing._lookup_form` (any `:free` id → `$0`, before the prefix scan). But `stats._models_block` classified the Notes column **only** by exact membership in `subscription_models`, ignoring `is_explicitly_priced`. So a known-free `:free` model was indistinguishable from a genuine unknown and fell into `no price entry`.

`_subscription: true` is the wrong tool for a `:free`-served model: the `:free` rule already resolves cost to `$0`, records it known-free, and arms the free→paid alert. No `pricing.yaml` entry is needed.

## Fix

`stats._models_block` now splits `$0.00` rows three ways (subscription checked first — it is also explicitly priced but earns the more specific label):

1. `subscription/free-tier` — declared `_subscription` (exact-id membership).
2. `free tier` — `pricing.is_explicitly_priced(model, provider)` is True but not a declared subscription (`:free` suffix or built-in `$0` seed). Known-free, not a miss.
3. `no price entry` — genuine unknown.

Each bucket emits its own footer line.

## Tests

- New: a dated `:free` row shows `free tier`, not `no price entry`.
- New (regression): a non-matching non-dated `_subscription` declaration still shows `free tier` via the `:free` rule.
- Existing subscription / no-entry / mixed-footer tests unchanged and passing.
- Full suite: **488 passed, 6 skipped** (UTC); `ruff format --check` + `ruff check` clean.

## Docs

- **README**: corrected the free-tier notice (`:free`-served needs no entry; a `_subscription` entry must use the exact recorded id), documented the new `free tier` Notes value, and refreshed the `/stats models` sample.
- **ONBOARDING**: three-way `$0` classification + the `:free`-vs-`_subscription` gotcha.
- **CHANGELOG**: entry under `[Unreleased]` (no version bump).

The README free-tier notice was first introduced in `8e071f6` (already on main); this PR corrects it.
