### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-09
+
 ### Fixed — `/stats models` mislabeled known-free $0 rows as "no price entry"
 
 - A `$0.00` row resolved by the `:free` suffix rule (including the dated ids a
@@ -51,6 +53,30 @@ dashboards.
   `dashboard/vendor/chart.umd.min.js` and uses jsDelivr only as a fallback.
   This removes the main cause of `Chart is not defined` when the CDN is
   unreachable or filtered.
+
+### Added — Mixture-of-Agents (MoA) attribution (#55)
+
+Hermes added a `moa` virtual provider: selecting a MoA preset runs N reference
+models plus an aggregator. The aggregator is the acting model, but
+`post_api_request` reports `provider="moa"` and `model="<preset>"` — neither
+priceable — while the usage belongs to the aggregator.
+
+- **`moa.py`** (new): resolves a preset name to its aggregator's real
+  `provider`/`model` via `hermes_cli.moa_config.resolve_moa_preset`. Fully
+  defensive — never raises, falls back to raw hook values.
+- **`post_api_request`** re-attributes MoA calls to the aggregator's real
+  provider/model, fixing the spurious `provider_assumed` pricing fallback, and
+  tags the row with the preset name.
+- **Schema v10** (`_migrate_v10`): `llm_calls.moa_preset` + `runs.moa_calls`.
+- **`/stats summary`** and both dashboards surface `moa_calls` / `moa_preset`,
+  each noting that reference-model tokens are untracked (cost is a lower bound).
+- Reference-model cost is deliberately **not** estimated (no token counts
+  available), and the one-shot `/moa <prompt>` path runs through the auxiliary
+  (no-hook) client, so it is invisible to telemetry by Hermes' design — both
+  documented as Known Limitations.
+
+Verified against `NousResearch/hermes-agent@main`: `agent/moa_loop.py`,
+`agent/auxiliary_client.py`, `hermes_cli/moa_config.py`.
 
 ### Added — Attribute async/nested subagent cost to `per_cron_job` budgets (#49)
 
@@ -511,6 +537,7 @@ brings both surfaces up to date in lockstep. Verified against
 - MIT License
 - README with architecture, usage, screenshots
 
+[0.8.0]: https://github.com/nujovich/hermes-telemetry/compare/v0.7.0...v0.8.0
 [0.5.1]: https://github.com/nujovich/hermes-telemetry/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/nujovich/hermes-telemetry/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/nujovich/hermes-telemetry/compare/v0.4.0...v0.4.1

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1373,7 +1373,7 @@ the real `~/.hermes/telemetry`. Enforced by
   injection, and backfill tests; `test_db.py` and `test_pricing.py` gained
   corresponding unit tests.
 
-### Unreleased — Free→paid id-change handling (issue #32)
+### v0.5.1 — Free→paid id-change handling (issue #32)
 
 - **`is_free_tier_transition(model, provider)`** in `db.py`: reverse-looks-up a
   stored `<id>:free` row when a provider moves a model to paid under a *different*
@@ -1395,7 +1395,7 @@ the real `~/.hermes/telemetry`. Enforced by
   `test_pricing.py` gained the ultra paid-seed + `:free`-suffix → $0 (bare and
   OpenRouter-long-form), `super:free` regression, and explicit-override cases.
 
-### Unreleased — Mixture-of-Agents (MoA) attribution
+### v0.8.0 — Mixture-of-Agents (MoA) attribution
 
 - **`moa.py`** (new module): resolves the `provider="moa"` virtual-provider
   preset to its aggregator's real `provider`/`model` via
@@ -1413,7 +1413,7 @@ the real `~/.hermes/telemetry`. Enforced by
 
 ---
 
-### Unreleased — Agent intelligence (efficiency · smells · forecast, issue #8)
+### v0.8.0 — Agent intelligence (efficiency · smells · forecast, issue #8)
 
 - **`smell_detector.py`** (new module): five read-only anti-pattern heuristics
   over existing telemetry. See `§ Agent Intelligence`.

--- a/__init__.py
+++ b/__init__.py
@@ -9,7 +9,7 @@ Errors are caught silently — telemetry never takes down a session.
 
 from __future__ import annotations
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 import json
 import logging

--- a/dashboard/manifest.json
+++ b/dashboard/manifest.json
@@ -3,7 +3,7 @@
   "label": "Telemetry",
   "description": "Tokens, cost, latency and budgets — hermes-telemetry plugin",
   "icon": "Activity",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "tab": { "path": "/telemetry", "position": "after:analytics" },
   "slots": ["sessions:top", "cron:top", "header-right", "analytics:bottom"],
   "entry": "dist/index.js",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: hermes-telemetry
-version: "0.7.0"
+version: "0.8.0"
 description: >-
   Observability + budget guardrails for Hermes Agent — tokens, cost, latency,
   tool calls per session and cron job. Persists to local SQLite. Exposes /stats

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-telemetry"
-version = "0.7.0"
+version = "0.8.0"
 description = "Observability + budget guardrails for Hermes Agent — tokens, cost, latency, tool calls per session and cron job."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Release 0.8.0

Finalizes the `[Unreleased]` changelog into `[0.8.0] - 2026-07-09` and bumps the version across `pyproject.toml`, `__init__.py`, `plugin.yaml`, and `dashboard/manifest.json`.

### Highlights

- **Agent intelligence (#8)** — efficiency scoring, AI smell detection, and burn-rate forecasting, surfaced through the slash command, the CLI, and both dashboards.
- **Per-cron-job subagent cost attribution (#49)** — async/nested `delegate_task` spend now rolls up to the parent cron job's `per_cron_job` budget via the new `subagent_edges` table (schema **v11**).
- **Per-profile dashboard scoping (#66)** — the plugin dashboard scopes efficiency/smells/budget per profile, with `ScopeBadge` disclosures and per-widget selectors.
- **Fixes** — `/stats models` now labels known-free `$0` rows as "free tier" instead of "no price entry" (#67); the standalone dashboard vendors Chart.js locally to avoid `Chart is not defined` when the CDN is unreachable.

### Verification

`ruff format --check . && ruff check . && pytest tests/ -q` — format and lint clean; **492 passed / 6 skipped** under `TZ=UTC`. One dashboard test (`test_budget_update_returns_viewer_timezone_metadata`) is timezone-sensitive and fails only on a non-UTC local machine; it passes on CI (UTC).

Tag `v0.8.0` to be applied to the merge commit once this PR lands.