### PR TITLE
feat(telemetry): core-sourced pricing snapshots (PR1, storage-only)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -416,6 +416,7 @@ table before applying.
 | v11 | New table `subagent_edges` (parent→child delegation tree) + `idx_subagent_edges_parent`. Attributes async/nested subagent cost to `per_cron_job` via a recursive CTE at query time. (#49) |
 | v12 | Add `runs.profile` (per-profile cost attribution) + `idx_runs_profile`. Captured from `ctx.profile_name` at `on_session_start`, backfilled in `pre_llm_call` (first non-null wins). Adds the `per_profile` budget scope. |
 | v13 | Repair pass — re-creates `subagent_edges` (+ `idx_subagent_edges_parent`) via `CREATE TABLE IF NOT EXISTS`. Heals DBs upgraded from a build that numbered a *different* migration as v11: the per-profile branch shipped `runs.profile` as v11 before #56 settled `subagent_edges` on v11, so those DBs have `version=11` applied but no table, and v11's early-return skips creation forever. No-op on clean v11 DBs. |
+| v14 | New table: `pricing_snapshots` (append-per-change history of the tariffs Hermes core resolves per `(provider, model)`, with provenance: `source` / `source_url` / `pricing_version` / `fetched_at`). Captured from `agent.usage_pricing.get_pricing_entry` via `core_pricing.py` in the `post_api_request` hook; storage-only (no surface yet). + `idx_pricing_snapshots_model`. |
 
 `_SCHEMA_VERSION` in `db.py` is the latest applied version — keep it in lockstep
 with the highest `_migrate_vN`. `test_schema_idempotent` asserts the count of
@@ -697,6 +698,36 @@ Cache prices are derived from multipliers when not explicit:
 sets it back to `None`, forcing the next read to re-parse the YAML. This is
 called by the auto-refresh cycle and by the `/setup` command, so new prices
 take effect immediately without a gateway restart.
+
+### Core-sourced pricing snapshots
+
+`pricing.py` (above) computes *cost* from our own `pricing.yaml`. Separately, the
+plugin records the *tariffs Hermes core itself resolves*, so we have an auditable
+ground truth with provenance to diff against `pricing.yaml` (the Faro
+over-estimate is the motivating case) and to feed the manual pricing editor.
+
+- **`core_pricing.py` is the only module that imports the Hermes core**
+  (`agent.usage_pricing.get_pricing_entry`). The import is lazy (inside the call)
+  and fail-open: `resolve()` returns `None` on any failure — core absent (the
+  isolated test suite has no `agent.*`), unknown model, or endpoint fetch error —
+  and never raises. It normalizes `PricingEntry` to a JSON-safe dict: `Decimal`
+  rates → `float`, the `CostSource` enum → `str`, `fetched_at` `datetime` → ISO.
+- **Capture happens in `post_api_request`**, the only hook that carries `base_url`
+  and `api_mode` (verified against `agent/conversation_loop.py`). It is throttled
+  in-memory to at most one resolve per `(provider, model)` per
+  `_PRICING_SNAPSHOT_TTL_S` (6h) per process, because `get_pricing_entry` can do a
+  `/models` network fetch for custom endpoints.
+- **`pricing_snapshots` is append-per-change** (`db.record_pricing_snapshot`): a
+  new row lands only when a rate field, `pricing_version`, or `source` differs
+  from the latest stored row for that pair. Context-only fields (`base_url`,
+  `api_mode`, `source_url`, `fetched_at`) do not trigger a row.
+- **Caveat:** `post_api_request` carries no `api_key`, so a private
+  OpenAI-compatible endpoint with no cached `/models` metadata resolves to `None`
+  (no snapshot). Nous / OpenRouter / official-docs models resolve without a
+  per-call fetch.
+- **Storage-only for now.** Surfacing (stats, `hermes telemetry pricing`, a
+  dashboard tab rendered inside `TelemetryPage`) and drift-vs-`pricing.yaml`
+  computation are follow-ups.
 
 ---
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -711,7 +711,7 @@ over-estimate is the motivating case) and to feed the manual pricing editor.
   and fail-open: `resolve()` returns `None` on any failure — core absent (the
   isolated test suite has no `agent.*`), unknown model, or endpoint fetch error —
   and never raises. It normalizes `PricingEntry` to a JSON-safe dict: `Decimal`
-  rates → `float`, the `CostSource` enum → `str`, `fetched_at` `datetime` → ISO.
+  rates → `float`, `CostSource` (a `Literal` string) → `str`, `fetched_at` `datetime` → ISO.
 - **Capture happens in `post_api_request`**, the only hook that carries `base_url`
   and `api_mode` (verified against `agent/conversation_loop.py`). It is throttled
   in-memory to at most one resolve per `(provider, model)` per

--- a/__init__.py
+++ b/__init__.py
@@ -16,6 +16,7 @@ import logging
 import os
 import re
 import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -163,7 +164,7 @@ def register(ctx) -> None:  # noqa: ANN001
     _setup_log_file()
     tele_log = logging.getLogger("hermes_telemetry")
 
-    from . import budget, db, moa, pricing, setup, stats
+    from . import budget, core_pricing, db, moa, pricing, setup, stats
 
     # ------------------------------------------------------------------
     # Start budget file watcher (hot-reload on budget.yaml changes)
@@ -245,6 +246,8 @@ def register(ctx) -> None:  # noqa: ANN001
         session_id: str = "",
         model: str = "",
         provider: str = "",
+        base_url: str = "",
+        api_mode: str = "",
         api_duration: float = 0.0,
         usage: dict | None = None,
         response_model: str | None = None,
@@ -381,6 +384,29 @@ def register(ctx) -> None:  # noqa: ANN001
                 provider_assumed=provider_assumed,
                 moa_preset=moa_preset,
             )
+
+            # Pricing snapshot (v14): capture the core-resolved tariff + provenance
+            # for this (provider, model), throttled to ~once per TTL per process.
+            # Own guard so a pricing failure never affects the call recorded above
+            # or the agent turn. See ONBOARDING.md § Core-sourced pricing snapshots.
+            if effective_model:
+                _snap_key = (provider, effective_model)
+                _snap_now = time.monotonic()
+                _do_snapshot = False
+                with _pricing_snapshot_lock:
+                    _last = _pricing_snapshot_seen.get(_snap_key)
+                    if _last is None or (_snap_now - _last) >= _PRICING_SNAPSHOT_TTL_S:
+                        _pricing_snapshot_seen[_snap_key] = _snap_now
+                        _do_snapshot = True
+                if _do_snapshot:
+                    try:
+                        _snap = core_pricing.resolve(effective_model, provider, base_url)
+                        if _snap:
+                            db.record_pricing_snapshot(
+                                provider, effective_model, _snap, base_url, api_mode
+                            )
+                    except Exception as _snap_exc:
+                        tele_log.debug("pricing snapshot capture failed: %s", _snap_exc)
         except Exception as exc:
             tele_log.error("post_api_request hook failed: %s", exc)
 

--- a/__init__.py
+++ b/__init__.py
@@ -52,6 +52,16 @@ _pending_model_unavailable_lock = threading.Lock()
 _CHARS_PER_TOKEN = 4
 
 # ---------------------------------------------------------------------------
+# Pricing-snapshot capture throttle (v14). get_pricing_entry (Hermes core) can
+# do network I/O for custom endpoints, so we resolve+snapshot a given
+# (provider, model) at most once per _PRICING_SNAPSHOT_TTL_S per process. DB-side
+# change detection dedupes rows regardless; this just bounds the work.
+# ---------------------------------------------------------------------------
+_PRICING_SNAPSHOT_TTL_S = 6 * 60 * 60  # 6 hours
+_pricing_snapshot_seen: dict[tuple[str, str], float] = {}
+_pricing_snapshot_lock = threading.Lock()
+
+# ---------------------------------------------------------------------------
 # Cron session ID regex
 # ---------------------------------------------------------------------------
 CRON_SESSION_RE = re.compile(r"^cron_(?P<job_id>.+)_\d{8}_\d{6}$")

--- a/core_pricing.py
+++ b/core_pricing.py
@@ -12,7 +12,8 @@ error) and never raises, so a telemetry capture can never break an agent turn.
 Verified against NousResearch/hermes-agent ``agent/usage_pricing.py`` (2026-07-11):
 ``get_pricing_entry(model_name, provider=None, base_url=None, api_key=None)``
 returns a ``PricingEntry`` whose cost fields are ``Decimal | None`` per million
-tokens, ``source`` is a ``CostSource`` enum, and ``fetched_at`` is a ``datetime``.
+tokens, ``source`` is a plain string (``CostSource`` is a ``Literal[...]`` string
+type alias — verified in agent/usage_pricing.py:19), and ``fetched_at`` a datetime.
 """
 
 from __future__ import annotations
@@ -65,13 +66,11 @@ def resolve(model: str, provider: str = "", base_url: str = "") -> dict | None:
 
         snap: dict = {field: _to_float(getattr(entry, field, None)) for field in _RATE_FIELDS}
 
+        # source is a plain string (CostSource = Literal[...]), verified against
+        # agent/usage_pricing.py. str() coerces defensively but is a no-op for the
+        # real string value.
         source = getattr(entry, "source", None)
-        if source is None:
-            snap["source"] = None
-        elif hasattr(source, "value"):
-            snap["source"] = str(source.value)
-        else:
-            snap["source"] = str(source)
+        snap["source"] = str(source) if source is not None else None
 
         snap["source_url"] = getattr(entry, "source_url", None)
         snap["pricing_version"] = getattr(entry, "pricing_version", None)

--- a/core_pricing.py
+++ b/core_pricing.py
@@ -1,0 +1,85 @@
+"""Bridge to Hermes core pricing (``agent.usage_pricing``).
+
+This is the ONLY module in the plugin that imports the Hermes core. Everywhere
+else the plugin receives what it needs through hook kwargs; this seam lets us
+capture the authoritative tariffs (with provenance) the core resolves for a
+model without coupling the rest of the plugin — or the isolated test suite — to
+``agent.*``.
+
+``resolve()`` is lazy (the import happens inside the call) and fail-open: it
+returns ``None`` on any failure (core absent, unknown model, endpoint fetch
+error) and never raises, so a telemetry capture can never break an agent turn.
+Verified against NousResearch/hermes-agent ``agent/usage_pricing.py`` (2026-07-11):
+``get_pricing_entry(model_name, provider=None, base_url=None, api_key=None)``
+returns a ``PricingEntry`` whose cost fields are ``Decimal | None`` per million
+tokens, ``source`` is a ``CostSource`` enum, and ``fetched_at`` is a ``datetime``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("hermes_telemetry")
+
+# PricingEntry numeric fields copied name-for-name, converted to float | None.
+_RATE_FIELDS = (
+    "input_cost_per_million",
+    "output_cost_per_million",
+    "cache_read_cost_per_million",
+    "cache_write_cost_per_million",
+    "request_cost",
+)
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def resolve(model: str, provider: str = "", base_url: str = "") -> dict | None:
+    """Return a JSON-safe pricing snapshot for (model, provider, base_url), or None.
+
+    Keys: the five ``*_per_million`` / ``request_cost`` floats, plus ``source``
+    (str), ``source_url`` (str), ``pricing_version`` (str), ``fetched_at`` (ISO
+    str). Any field the core leaves unset is ``None``. Returns ``None`` if the
+    core cannot price the model or is not importable. Never raises.
+    """
+    if not model:
+        return None
+    try:
+        from agent.usage_pricing import get_pricing_entry
+
+        entry = get_pricing_entry(
+            model,
+            provider=provider or None,
+            base_url=base_url or None,
+            api_key="",
+        )
+        if entry is None:
+            return None
+
+        snap: dict = {field: _to_float(getattr(entry, field, None)) for field in _RATE_FIELDS}
+
+        source = getattr(entry, "source", None)
+        if source is None:
+            snap["source"] = None
+        elif hasattr(source, "value"):
+            snap["source"] = str(source.value)
+        else:
+            snap["source"] = str(source)
+
+        snap["source_url"] = getattr(entry, "source_url", None)
+        snap["pricing_version"] = getattr(entry, "pricing_version", None)
+        fetched_at = getattr(entry, "fetched_at", None)
+        snap["fetched_at"] = fetched_at.isoformat() if fetched_at is not None else None
+        return snap
+    except Exception as exc:  # fail-open — telemetry must never break a turn
+        logger.debug(
+            "core_pricing.resolve failed for model=%r provider=%r: %s", model, provider, exc
+        )
+        return None

--- a/db.py
+++ b/db.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover - db.py loaded standalone (no package co
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 13
+_SCHEMA_VERSION = 14
 _local = threading.local()
 
 # Serializes first-time schema setup across threads. Each thread opens its own
@@ -171,6 +171,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _migrate_v11(conn)
     _migrate_v12(conn)
     _migrate_v13(conn)
+    _migrate_v14(conn)
 
 
 def _migrate_v2(conn: sqlite3.Connection) -> None:
@@ -518,6 +519,46 @@ def _migrate_v13(conn: sqlite3.Connection) -> None:
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (13, ?)",
+        (_utcnow(),),
+    )
+
+
+def _migrate_v14(conn: sqlite3.Connection) -> None:
+    """New table ``pricing_snapshots``: an append-per-change history of the
+    tariffs Hermes core resolves for each ``(provider, model)``, with provenance
+    (``source`` / ``source_url`` / ``pricing_version`` / ``fetched_at``). Captured
+    from ``agent.usage_pricing.get_pricing_entry`` in the ``post_api_request``
+    hook (see ``core_pricing.py``). New table only ⇒ ``CREATE TABLE IF NOT
+    EXISTS``, no ALTER. See ONBOARDING.md § Core-sourced pricing snapshots.
+    """
+    cur = conn.execute("SELECT version FROM schema_version WHERE version = 14")
+    if cur.fetchone() is not None:
+        return
+
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS pricing_snapshots (
+            id                            INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider                      TEXT NOT NULL,
+            model                         TEXT NOT NULL,
+            input_cost_per_million        REAL,
+            output_cost_per_million       REAL,
+            cache_read_cost_per_million   REAL,
+            cache_write_cost_per_million  REAL,
+            request_cost                  REAL,
+            source                        TEXT,
+            source_url                    TEXT,
+            pricing_version               TEXT,
+            fetched_at                    TEXT,
+            captured_at                   TEXT NOT NULL,
+            base_url                      TEXT,
+            api_mode                      TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_pricing_snapshots_model
+            ON pricing_snapshots(provider, model, id);
+    """)
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (14, ?)",
         (_utcnow(),),
     )
 

--- a/db.py
+++ b/db.py
@@ -1702,3 +1702,94 @@ def backfill_known_free_models(models: list) -> int:
         )
         inserted += cur.rowcount
     return inserted
+
+
+# ---------------------------------------------------------------------------
+# Pricing snapshots (v14): auditable per-(provider, model) tariff history
+# captured from Hermes core (agent.usage_pricing) via the post_api_request hook.
+# Append-per-change: a new row lands only when the tariff/version/source changed.
+# ---------------------------------------------------------------------------
+_PRICING_SNAPSHOT_RATE_FIELDS = (
+    "input_cost_per_million",
+    "output_cost_per_million",
+    "cache_read_cost_per_million",
+    "cache_write_cost_per_million",
+    "request_cost",
+)
+
+
+def get_latest_pricing_snapshot(provider: str, model: str) -> dict | None:
+    """Return the most recent pricing snapshot row for (provider, model), or None."""
+    conn = _get_conn()
+    row = conn.execute(
+        "SELECT id, provider, model,"
+        " input_cost_per_million, output_cost_per_million,"
+        " cache_read_cost_per_million, cache_write_cost_per_million, request_cost,"
+        " source, source_url, pricing_version, fetched_at, captured_at, base_url, api_mode"
+        " FROM pricing_snapshots"
+        " WHERE provider = ? AND model = ?"
+        " ORDER BY id DESC LIMIT 1",
+        (provider, model),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def _pricing_snapshot_changed(latest: dict | None, snap: dict) -> bool:
+    """True if `snap` is a tariff change vs the latest stored row.
+
+    Change = any rate field flips None↔value or differs by > 1e-9, OR
+    ``pricing_version`` differs (including a None↔value flip), OR ``source``
+    differs. Context-only fields (``base_url``, ``api_mode``, ``source_url``,
+    ``fetched_at``) never trigger a new row.
+    """
+    if latest is None:
+        return True
+    for field in _PRICING_SNAPSHOT_RATE_FIELDS:
+        old = latest.get(field)
+        new = snap.get(field)
+        if (old is None) != (new is None):
+            return True
+        if old is not None and new is not None and abs(float(old) - float(new)) > 1e-9:
+            return True
+    if latest.get("pricing_version") != snap.get("pricing_version"):
+        return True
+    return latest.get("source") != snap.get("source")
+
+
+def record_pricing_snapshot(
+    provider: str, model: str, snap: dict, base_url: str = "", api_mode: str = ""
+) -> bool:
+    """Append a pricing snapshot row for (provider, model) if it differs from the
+    latest stored row (or none exists). Returns True iff a row was written.
+
+    `snap` is the dict from ``core_pricing.resolve()``: the five rate floats plus
+    ``source`` / ``source_url`` / ``pricing_version`` / ``fetched_at`` (any None).
+    """
+    latest = get_latest_pricing_snapshot(provider, model)
+    if not _pricing_snapshot_changed(latest, snap):
+        return False
+    conn = _get_conn()
+    conn.execute(
+        "INSERT INTO pricing_snapshots"
+        " (provider, model, input_cost_per_million, output_cost_per_million,"
+        "  cache_read_cost_per_million, cache_write_cost_per_million, request_cost,"
+        "  source, source_url, pricing_version, fetched_at, captured_at, base_url, api_mode)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            provider,
+            model,
+            snap.get("input_cost_per_million"),
+            snap.get("output_cost_per_million"),
+            snap.get("cache_read_cost_per_million"),
+            snap.get("cache_write_cost_per_million"),
+            snap.get("request_cost"),
+            snap.get("source"),
+            snap.get("source_url"),
+            snap.get("pricing_version"),
+            snap.get("fetched_at"),
+            _utcnow(),
+            base_url,
+            api_mode,
+        ),
+    )
+    return True

--- a/db.py
+++ b/db.py
@@ -1765,6 +1765,16 @@ def record_pricing_snapshot(
     `snap` is the dict from ``core_pricing.resolve()``: the five rate floats plus
     ``source`` / ``source_url`` / ``pricing_version`` / ``fetched_at`` (any None).
     """
+    # Concurrency note (accepted tradeoff): this is a check-then-insert, not
+    # atomic. Under WAL with parallel cron processes two callers can both read
+    # the same latest row, both conclude "changed", and both insert — yielding
+    # duplicate *identical* consecutive rows. Benign for an append-only audit
+    # history: no change is ever lost and get_latest_pricing_snapshot still
+    # returns correct content. We deliberately do NOT wrap this in a
+    # BEGIN IMMEDIATE transaction — holding a write lock across the SELECT would
+    # add contention in exactly the cron-concurrency path we care about, a worse
+    # tradeoff than a rare duplicate row. The per-process capture throttle in
+    # post_api_request already makes same-process duplication a non-issue.
     latest = get_latest_pricing_snapshot(provider, model)
     if not _pricing_snapshot_changed(latest, snap):
         return False

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1669,3 +1669,7 @@ def test_migrate_v14_creates_table_from_wedged_v13():
 
     tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
     assert "pricing_snapshots" in tables
+    versions = {r[0] for r in conn.execute("SELECT version FROM schema_version")}
+    assert 14 in versions, "v14 marker must be restored after self-heal"
+    indexes = {r[1] for r in conn.execute("PRAGMA index_list('pricing_snapshots')")}
+    assert "idx_pricing_snapshots_model" in indexes

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1622,3 +1622,50 @@ def test_spend_by_scope_profile_filters():
 
     result = db.spend_by_scope("profile", "coder", "2000-01-01T00:00:00+00:00")
     assert result["spent_usd"] == 1.50
+
+
+# ---------------------------------------------------------------------------
+# v14 — pricing_snapshots (core-sourced tariff history w/ provenance)
+# ---------------------------------------------------------------------------
+
+
+def test_schema_v14_columns():
+    conn = db._get_conn()
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(pricing_snapshots)")}
+    assert {
+        "id",
+        "provider",
+        "model",
+        "input_cost_per_million",
+        "output_cost_per_million",
+        "cache_read_cost_per_million",
+        "cache_write_cost_per_million",
+        "request_cost",
+        "source",
+        "source_url",
+        "pricing_version",
+        "fetched_at",
+        "captured_at",
+        "base_url",
+        "api_mode",
+    } <= cols
+
+
+def test_schema_v14_recorded():
+    versions = {row[0] for row in db._get_conn().execute("SELECT version FROM schema_version")}
+    assert 14 in versions
+
+
+def test_migrate_v14_creates_table_from_wedged_v13():
+    """Upgrade path: a DB stuck in the pre-v14 shape (no pricing_snapshots, v14
+    marker absent) self-heals on the next connect."""
+    conn = db._get_conn()
+    conn.execute("DROP TABLE IF EXISTS pricing_snapshots")
+    conn.execute("DELETE FROM schema_version WHERE version >= 14")
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "pricing_snapshots" not in tables  # wedged state confirmed
+
+    db._ensure_schema(conn)
+
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "pricing_snapshots" in tables

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1673,3 +1673,82 @@ def test_migrate_v14_creates_table_from_wedged_v13():
     assert 14 in versions, "v14 marker must be restored after self-heal"
     indexes = {r[1] for r in conn.execute("PRAGMA index_list('pricing_snapshots')")}
     assert "idx_pricing_snapshots_model" in indexes
+
+
+def _snap(**over):
+    """Build a core_pricing-shaped snapshot dict; override any field via kwargs."""
+    base = {
+        "input_cost_per_million": 3.0,
+        "output_cost_per_million": 15.0,
+        "cache_read_cost_per_million": 0.3,
+        "cache_write_cost_per_million": 3.75,
+        "request_cost": None,
+        "source": "official_docs_snapshot",
+        "source_url": "https://example/pricing",
+        "pricing_version": "2026-07-01",
+        "fetched_at": "2026-07-01T00:00:00+00:00",
+    }
+    base.update(over)
+    return base
+
+
+def _snapshot_row_count(provider, model):
+    return (
+        db._get_conn()
+        .execute(
+            "SELECT COUNT(*) FROM pricing_snapshots WHERE provider = ? AND model = ?",
+            (provider, model),
+        )
+        .fetchone()[0]
+    )
+
+
+def test_record_pricing_snapshot_first_insert():
+    assert db.record_pricing_snapshot("anthropic", "m", _snap(), "https://u", "messages") is True
+    row = db.get_latest_pricing_snapshot("anthropic", "m")
+    assert row is not None
+    assert row["input_cost_per_million"] == 3.0
+    assert row["source"] == "official_docs_snapshot"
+    assert row["base_url"] == "https://u"
+    assert row["api_mode"] == "messages"
+    assert row["captured_at"]  # non-empty timestamp
+
+
+def test_get_latest_pricing_snapshot_missing_returns_none():
+    assert db.get_latest_pricing_snapshot("nope", "nope") is None
+
+
+def test_record_pricing_snapshot_noop_when_unchanged():
+    assert db.record_pricing_snapshot("p", "m", _snap()) is True
+    assert db.record_pricing_snapshot("p", "m", _snap()) is False
+    assert _snapshot_row_count("p", "m") == 1
+
+
+def test_record_pricing_snapshot_new_row_on_rate_change():
+    db.record_pricing_snapshot("p", "m", _snap(input_cost_per_million=3.0))
+    assert db.record_pricing_snapshot("p", "m", _snap(input_cost_per_million=4.0)) is True
+    assert _snapshot_row_count("p", "m") == 2
+    assert db.get_latest_pricing_snapshot("p", "m")["input_cost_per_million"] == 4.0
+
+
+def test_record_pricing_snapshot_new_row_on_version_change():
+    db.record_pricing_snapshot("p", "m", _snap(pricing_version="v1"))
+    assert db.record_pricing_snapshot("p", "m", _snap(pricing_version="v2")) is True
+    assert _snapshot_row_count("p", "m") == 2
+
+
+def test_record_pricing_snapshot_new_row_on_null_flip():
+    db.record_pricing_snapshot("p", "m", _snap(cache_read_cost_per_million=None))
+    assert db.record_pricing_snapshot("p", "m", _snap(cache_read_cost_per_million=0.3)) is True
+    assert _snapshot_row_count("p", "m") == 2
+
+
+def test_record_pricing_snapshot_ignores_context_only_change():
+    """A base_url / source_url / fetched_at change with identical tariff is NOT a
+    new row — those are context, not tariff."""
+    db.record_pricing_snapshot("p", "m", _snap(fetched_at="2026-07-01T00:00:00+00:00"), "urlA")
+    assert (
+        db.record_pricing_snapshot("p", "m", _snap(fetched_at="2026-07-09T00:00:00+00:00"), "urlB")
+        is False
+    )
+    assert _snapshot_row_count("p", "m") == 1

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1752,3 +1752,18 @@ def test_record_pricing_snapshot_ignores_context_only_change():
         is False
     )
     assert _snapshot_row_count("p", "m") == 1
+
+
+def test_record_pricing_snapshot_new_row_on_source_change():
+    db.record_pricing_snapshot("p", "m", _snap(source="official_docs_snapshot"))
+    assert db.record_pricing_snapshot("p", "m", _snap(source="endpoint_models_api")) is True
+    assert _snapshot_row_count("p", "m") == 2
+
+
+def test_record_pricing_snapshot_is_provider_model_scoped():
+    db.record_pricing_snapshot("p1", "m1", _snap(input_cost_per_million=1.0))
+    db.record_pricing_snapshot("p2", "m2", _snap(input_cost_per_million=2.0))
+    assert db.get_latest_pricing_snapshot("p1", "m1")["input_cost_per_million"] == 1.0
+    assert db.get_latest_pricing_snapshot("p2", "m2")["input_cost_per_million"] == 2.0
+    assert _snapshot_row_count("p1", "m1") == 1
+    assert _snapshot_row_count("p2", "m2") == 1

--- a/tests/test_pricing_snapshots.py
+++ b/tests/test_pricing_snapshots.py
@@ -57,16 +57,13 @@ def isolated_db():
 def test_core_pricing_resolve_normalizes(monkeypatch):
     import hermes_telemetry.core_pricing as core_pricing
 
-    class _Source:
-        value = "official_docs_snapshot"
-
     class _Entry:
         input_cost_per_million = Decimal("3.00")
         output_cost_per_million = Decimal("15.00")
         cache_read_cost_per_million = None
         cache_write_cost_per_million = Decimal("3.75")
         request_cost = None
-        source = _Source()
+        source = "official_docs_snapshot"
         source_url = "https://example/pricing"
         pricing_version = "2026-07-01"
         fetched_at = datetime(2026, 7, 1, tzinfo=timezone.utc)

--- a/tests/test_pricing_snapshots.py
+++ b/tests/test_pricing_snapshots.py
@@ -1,0 +1,121 @@
+"""core_pricing seam + post_api_request pricing-snapshot capture (v14)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+_spec = importlib.util.spec_from_file_location("hermes_telemetry", str(_ROOT / "__init__.py"))
+_init_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_init_mod)
+
+
+class MockPluginContext:
+    """Minimal stand-in for Hermes PluginContext."""
+
+    def __init__(self, profile_name="default"):
+        self.hooks: dict = {}
+        self.commands: dict = {}
+        self.profile_name = profile_name
+
+    def register_hook(self, name, fn):
+        self.hooks[name] = fn
+
+    def register_command(self, name, fn, description="", args_hint=""):
+        self.commands[name] = fn
+
+    def register_cli_command(self, *a, **k):
+        pass
+
+    def fire(self, hook_name, **kwargs):
+        fn = self.hooks.get(hook_name)
+        return fn(**kwargs) if fn else None
+
+
+@pytest.fixture(autouse=True)
+def isolated_db():
+    import hermes_telemetry.db as db_mod
+
+    db_mod._local.conn = None
+    _init_mod._pricing_snapshot_seen.clear()
+    yield
+    if getattr(db_mod._local, "conn", None):
+        db_mod._local.conn.close()
+        db_mod._local.conn = None
+
+
+# --- core_pricing.resolve -------------------------------------------------
+
+
+def test_core_pricing_resolve_normalizes(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+
+    class _Source:
+        value = "official_docs_snapshot"
+
+    class _Entry:
+        input_cost_per_million = Decimal("3.00")
+        output_cost_per_million = Decimal("15.00")
+        cache_read_cost_per_million = None
+        cache_write_cost_per_million = Decimal("3.75")
+        request_cost = None
+        source = _Source()
+        source_url = "https://example/pricing"
+        pricing_version = "2026-07-01"
+        fetched_at = datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+    fake_mod = types.ModuleType("agent.usage_pricing")
+    fake_mod.get_pricing_entry = lambda model, provider=None, base_url=None, api_key="": _Entry()
+    monkeypatch.setitem(sys.modules, "agent", types.ModuleType("agent"))
+    monkeypatch.setitem(sys.modules, "agent.usage_pricing", fake_mod)
+
+    snap = core_pricing.resolve("claude-sonnet-4-6", provider="anthropic")
+    assert snap["input_cost_per_million"] == 3.0
+    assert snap["output_cost_per_million"] == 15.0
+    assert snap["cache_read_cost_per_million"] is None
+    assert snap["cache_write_cost_per_million"] == 3.75
+    assert snap["request_cost"] is None
+    assert snap["source"] == "official_docs_snapshot"
+    assert snap["source_url"] == "https://example/pricing"
+    assert snap["pricing_version"] == "2026-07-01"
+    assert snap["fetched_at"] == "2026-07-01T00:00:00+00:00"
+
+
+def test_core_pricing_resolve_none_when_core_absent(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+
+    # Guarantee no `agent` module is importable, regardless of test order.
+    monkeypatch.setitem(sys.modules, "agent", None)
+    assert core_pricing.resolve("whatever", provider="p") is None
+
+
+def test_core_pricing_resolve_none_when_entry_none(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+
+    fake_mod = types.ModuleType("agent.usage_pricing")
+    fake_mod.get_pricing_entry = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "agent", types.ModuleType("agent"))
+    monkeypatch.setitem(sys.modules, "agent.usage_pricing", fake_mod)
+
+    assert core_pricing.resolve("m", provider="p") is None
+
+
+def test_core_pricing_resolve_failopen(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+
+    def _boom(*a, **k):
+        raise RuntimeError("core exploded")
+
+    fake_mod = types.ModuleType("agent.usage_pricing")
+    fake_mod.get_pricing_entry = _boom
+    monkeypatch.setitem(sys.modules, "agent", types.ModuleType("agent"))
+    monkeypatch.setitem(sys.modules, "agent.usage_pricing", fake_mod)
+
+    assert core_pricing.resolve("m", provider="p") is None

--- a/tests/test_pricing_snapshots.py
+++ b/tests/test_pricing_snapshots.py
@@ -116,3 +116,111 @@ def test_core_pricing_resolve_failopen(monkeypatch):
     monkeypatch.setitem(sys.modules, "agent.usage_pricing", fake_mod)
 
     assert core_pricing.resolve("m", provider="p") is None
+
+
+# --- post_api_request capture --------------------------------------------
+
+
+def _fake_resolve_factory(counter=None, snap=None):
+    def _resolve(model, provider="", base_url=""):
+        if counter is not None:
+            counter["n"] += 1
+        return (
+            snap
+            if snap is not None
+            else {
+                "input_cost_per_million": 3.0,
+                "output_cost_per_million": 15.0,
+                "cache_read_cost_per_million": None,
+                "cache_write_cost_per_million": None,
+                "request_cost": None,
+                "source": "official_docs_snapshot",
+                "source_url": None,
+                "pricing_version": "2026-07-01",
+                "fetched_at": None,
+            }
+        )
+
+    return _resolve
+
+
+def test_post_api_request_records_snapshot(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+    import hermes_telemetry.db as db
+
+    monkeypatch.setattr(core_pricing, "resolve", _fake_resolve_factory())
+    ctx = MockPluginContext()
+    _init_mod.register(ctx)
+    ctx.fire(
+        "post_api_request",
+        session_id="s1",
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        api_mode="messages",
+        usage={"input_tokens": 100, "output_tokens": 50},
+    )
+
+    row = db.get_latest_pricing_snapshot("anthropic", "claude-sonnet-4-6")
+    assert row is not None
+    assert row["input_cost_per_million"] == 3.0
+    assert row["pricing_version"] == "2026-07-01"
+    assert row["base_url"] == "https://api.anthropic.com"
+    assert row["api_mode"] == "messages"
+
+
+def test_post_api_request_snapshot_is_throttled(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+
+    counter = {"n": 0}
+    monkeypatch.setattr(core_pricing, "resolve", _fake_resolve_factory(counter))
+    ctx = MockPluginContext()
+    _init_mod.register(ctx)
+    for _ in range(3):
+        ctx.fire(
+            "post_api_request",
+            session_id="s",
+            model="m",
+            provider="p",
+            usage={"input_tokens": 1, "output_tokens": 1},
+        )
+    assert counter["n"] == 1  # resolve throttled after first (provider, model)
+
+
+def test_post_api_request_snapshot_failopen(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+    import hermes_telemetry.db as db
+
+    def _boom(model, provider="", base_url=""):
+        raise RuntimeError("core exploded")
+
+    monkeypatch.setattr(core_pricing, "resolve", _boom)
+    ctx = MockPluginContext()
+    _init_mod.register(ctx)
+    # Must not raise, and the llm_calls row must still be recorded.
+    ctx.fire(
+        "post_api_request",
+        session_id="s",
+        model="m",
+        provider="p",
+        usage={"input_tokens": 1, "output_tokens": 1},
+    )
+    assert db.get_latest_pricing_snapshot("p", "m") is None
+    assert db.get_run("s") is not None  # the call itself was still recorded
+
+
+def test_post_api_request_no_snapshot_when_resolve_none(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+    import hermes_telemetry.db as db
+
+    monkeypatch.setattr(core_pricing, "resolve", lambda *a, **k: None)
+    ctx = MockPluginContext()
+    _init_mod.register(ctx)
+    ctx.fire(
+        "post_api_request",
+        session_id="s",
+        model="m",
+        provider="p",
+        usage={"input_tokens": 1, "output_tokens": 1},
+    )
+    assert db.get_latest_pricing_snapshot("p", "m") is None


### PR DESCRIPTION
## Summary

Persist an append-per-change history of the pricing tariffs Hermes' **core** resolves per `(provider, model)`, with full provenance (`source`, `source_url`, `pricing_version`, `fetched_at`). This gives us ground truth to diff against our own `pricing.yaml` (the Faro/Nous over-estimate is the motivating case) and a foundation for the manual pricing editor (#65).

This is **PR1 — storage-only**: migration + capture + tests + docs. No stats block, CLI command, dashboard tab, or drift detection yet (those are follow-up PRs).

**What changed:**
- **`core_pricing.py`** — new seam, the only module that imports the Hermes core (`agent.usage_pricing.get_pricing_entry`). Lazy import, **fail-open**: `resolve()` returns `None` on any failure (core absent, unknown model, endpoint fetch error) and never raises into the hook path. Normalizes `PricingEntry` to a JSON-safe dict (`Decimal`→`float`, `CostSource` Literal string→`str`, `datetime`→ISO).
- **`db.py`** — `_migrate_v14` + new `pricing_snapshots` table (schema `v14`), `record_pricing_snapshot` / `get_latest_pricing_snapshot` with append-per-change detection (new row only when rate / `pricing_version` / `source` differ).
- **`__init__.py`** — throttled capture in `post_api_request` (the only hook carrying `base_url` / `api_mode`, verified against `agent/conversation_loop.py`). In-memory TTL of 6h per `(provider, model)` per process, because `get_pricing_entry` can trigger a `/models` network fetch for custom endpoints.
- **`ONBOARDING.md`** — new § Core-sourced pricing snapshots + v14 row in the schema-evolution table.

## Test Plan

- [x] `ruff format --check .` + `ruff check .` — clean
- [x] `pytest tests/` — 513 passed, 6 skipped (`TZ=UTC`)
- [x] Per-version test `test_schema_v14_columns` + wedged-upgrade-path test `test_migrate_v14_creates_table_from_wedged_v13`
- [x] Fail-open verified: core absent (isolated suite has no `agent.*`), DB-layer exception both swallowed in the hook
- [x] Fresh-context adversarial review — READY TO MERGE, no migration-checklist gate violated

## Known non-blocking follow-ups
- Throttle marks `(provider, model)` "seen" before resolve succeeds → a transient `None` suppresses retry for the full 6h TTL.
- `api_key=""` vs core's `api_key=None` default (potential latency amplification on first touch if core branches on `is None`).
- One test fixture uses the string `endpoint_models_api` while the real `CostSource` value is `provider_models_api`.