### PR TITLE
feat(telemetry): capture pricing snapshots for dated model names

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -417,6 +417,7 @@ table before applying.
 | v12 | Add `runs.profile` (per-profile cost attribution) + `idx_runs_profile`. Captured from `ctx.profile_name` at `on_session_start`, backfilled in `pre_llm_call` (first non-null wins). Adds the `per_profile` budget scope. |
 | v13 | Repair pass — re-creates `subagent_edges` (+ `idx_subagent_edges_parent`) via `CREATE TABLE IF NOT EXISTS`. Heals DBs upgraded from a build that numbered a *different* migration as v11: the per-profile branch shipped `runs.profile` as v11 before #56 settled `subagent_edges` on v11, so those DBs have `version=11` applied but no table, and v11's early-return skips creation forever. No-op on clean v11 DBs. |
 | v14 | New table: `pricing_snapshots` (append-per-change history of the tariffs Hermes core resolves per `(provider, model)`, with provenance: `source` / `source_url` / `pricing_version` / `fetched_at`). Captured from `agent.usage_pricing.get_pricing_entry` via `core_pricing.py` in the `post_api_request` hook; storage-only (no surface yet). + `idx_pricing_snapshots_model`. |
+| v15 | `pricing_snapshots.resolved_model` — Canonical model name captured when a dated id was normalized to resolve against the core `/models` catalog; NULL when the raw name resolved directly. |
 
 `_SCHEMA_VERSION` in `db.py` is the latest applied version — keep it in lockstep
 with the highest `_migrate_vN`. `test_schema_idempotent` asserts the count of
@@ -721,6 +722,15 @@ over-estimate is the motivating case) and to feed the manual pricing editor.
   new row lands only when a rate field, `pricing_version`, or `source` differs
   from the latest stored row for that pair. Context-only fields (`base_url`,
   `api_mode`, `source_url`, `fetched_at`) do not trigger a row.
+- **Dated model names are canonicalized on miss.** The provider `/models` catalog lists
+  canonical (undated) ids, so a dated call like `deepseek/deepseek-v4-pro-20260423` resolves to
+  `None`. When the raw name misses, capture retries under
+  `core_pricing.canonical_model_name()` (strips a trailing `-YYYYMMDD`, incl. before `:free`).
+  The snapshot is stored under the **raw dated name** (`model`) with the canonical name in
+  `resolved_model` (NULL when the raw name resolved directly). Safe because `resolve()` is
+  fail-open: a wrong strip → `None` → no row. Verified on the VPS: the dominant
+  `deepseek/deepseek-v4-pro-20260423` is priced by the plugin via a family prefix (0.27/1.1)
+  while the core's real rate is 0.435/0.87 — the snapshot captures the authoritative rate.
 - **Caveat:** `post_api_request` carries no `api_key`, so a private
   OpenAI-compatible endpoint with no cached `/models` metadata resolves to `None`
   (no snapshot). Nous / OpenRouter / official-docs models resolve without a

--- a/__init__.py
+++ b/__init__.py
@@ -401,9 +401,23 @@ def register(ctx) -> None:  # noqa: ANN001
                 if _do_snapshot:
                     try:
                         _snap = core_pricing.resolve(effective_model, provider, base_url)
+                        _resolved = None
+                        # Dated ids (e.g. ...-20260423) miss the core /models catalog;
+                        # retry under the canonical name. See core_pricing.canonical_model_name.
+                        if not _snap:
+                            _canon = core_pricing.canonical_model_name(effective_model)
+                            if _canon != effective_model:
+                                _snap = core_pricing.resolve(_canon, provider, base_url)
+                                if _snap:
+                                    _resolved = _canon
                         if _snap:
                             db.record_pricing_snapshot(
-                                provider, effective_model, _snap, base_url, api_mode
+                                provider,
+                                effective_model,
+                                _snap,
+                                base_url,
+                                api_mode,
+                                resolved_model=_resolved,
                             )
                     except Exception as _snap_exc:
                         tele_log.debug("pricing snapshot capture failed: %s", _snap_exc)

--- a/core_pricing.py
+++ b/core_pricing.py
@@ -19,6 +19,7 @@ type alias — verified in agent/usage_pricing.py:19), and ``fetched_at`` a date
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 logger = logging.getLogger("hermes_telemetry")
@@ -40,6 +41,34 @@ def _to_float(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+_DATED_SUFFIX = re.compile(r"-\d{8}(?=:|$)")
+
+
+def canonical_model_name(model: str) -> str:
+    """Strip a trailing dated-version suffix (``-YYYYMMDD``) from a model id.
+
+    Intended ONLY as a FALLBACK, called after ``resolve(raw)`` has already
+    returned ``None``. Hermes core's ``/models`` catalog lists canonical
+    (undated) names, but the gateway calls with dated ids like
+    ``deepseek/deepseek-v4-pro-20260423`` that miss the catalog
+    (``get_pricing_entry`` → ``None``). Removing the date recovers the name the
+    core knows. The lookahead matches the 8-digit token just before end-of-id OR
+    a ``:``-suffix (generic; the gateway uses ``:free`` in practice), so both
+    ``deepseek/deepseek-v4-pro-20260423`` → ``deepseek/deepseek-v4-pro`` and
+    ``tencent/hy3-20260706:free`` → ``tencent/hy3:free`` work. Returns the input
+    unchanged when there is no dated suffix. Pure; never raises for a str model
+    id (a non-str would raise ``TypeError``, but callers only pass the hook's
+    str model, and the capture block is itself fail-open).
+
+    A wrong strip is harmless: this runs only after a direct-resolve miss, so a
+    model id that legitimately ends in 8 digits and is resolvable would have
+    resolved directly and never reach here — no regression is possible. If the
+    stripped name is unknown to the core, ``resolve()`` fail-opens to ``None`` →
+    no capture (same as before). We capture only when the stripped name resolves.
+    """
+    return _DATED_SUFFIX.sub("", model)
 
 
 def resolve(model: str, provider: str = "", base_url: str = "") -> dict | None:

--- a/db.py
+++ b/db.py
@@ -1746,7 +1746,8 @@ def get_latest_pricing_snapshot(provider: str, model: str) -> dict | None:
         "SELECT id, provider, model,"
         " input_cost_per_million, output_cost_per_million,"
         " cache_read_cost_per_million, cache_write_cost_per_million, request_cost,"
-        " source, source_url, pricing_version, fetched_at, captured_at, base_url, api_mode"
+        " source, source_url, pricing_version, fetched_at, captured_at, base_url, api_mode,"
+        " resolved_model"
         " FROM pricing_snapshots"
         " WHERE provider = ? AND model = ?"
         " ORDER BY id DESC LIMIT 1",
@@ -1755,13 +1756,16 @@ def get_latest_pricing_snapshot(provider: str, model: str) -> dict | None:
     return dict(row) if row else None
 
 
-def _pricing_snapshot_changed(latest: dict | None, snap: dict) -> bool:
+def _pricing_snapshot_changed(
+    latest: dict | None, snap: dict, resolved_model: str | None = None
+) -> bool:
     """True if `snap` is a tariff change vs the latest stored row.
 
     Change = any rate field flips None↔value or differs by > 1e-9, OR
-    ``pricing_version`` differs (including a None↔value flip), OR ``source``
-    differs. Context-only fields (``base_url``, ``api_mode``, ``source_url``,
-    ``fetched_at``) never trigger a new row.
+    ``pricing_version`` differs, OR ``source`` differs, OR ``resolved_model``
+    differs (the canonical name the tariff was resolved under; each including a
+    None↔value flip). Context-only fields (``base_url``, ``api_mode``,
+    ``source_url``, ``fetched_at``) never trigger a new row.
     """
     if latest is None:
         return True
@@ -1774,17 +1778,29 @@ def _pricing_snapshot_changed(latest: dict | None, snap: dict) -> bool:
             return True
     if latest.get("pricing_version") != snap.get("pricing_version"):
         return True
-    return latest.get("source") != snap.get("source")
+    if latest.get("source") != snap.get("source"):
+        return True
+    return latest.get("resolved_model") != resolved_model
 
 
 def record_pricing_snapshot(
-    provider: str, model: str, snap: dict, base_url: str = "", api_mode: str = ""
+    provider: str,
+    model: str,
+    snap: dict,
+    base_url: str = "",
+    api_mode: str = "",
+    resolved_model: str | None = None,
 ) -> bool:
     """Append a pricing snapshot row for (provider, model) if it differs from the
     latest stored row (or none exists). Returns True iff a row was written.
 
     `snap` is the dict from ``core_pricing.resolve()``: the five rate floats plus
     ``source`` / ``source_url`` / ``pricing_version`` / ``fetched_at`` (any None).
+
+    ``resolved_model`` is the canonical model name the tariff was resolved under
+    when the raw (dated) name did not resolve directly, or ``None`` when it
+    resolved directly. Unlike ``base_url`` / ``api_mode`` it participates in
+    change detection (a differing ``resolved_model`` writes a new row).
     """
     # Concurrency note (accepted tradeoff): this is a check-then-insert, not
     # atomic. Under WAL with parallel cron processes two callers can both read
@@ -1797,15 +1813,16 @@ def record_pricing_snapshot(
     # tradeoff than a rare duplicate row. The per-process capture throttle in
     # post_api_request already makes same-process duplication a non-issue.
     latest = get_latest_pricing_snapshot(provider, model)
-    if not _pricing_snapshot_changed(latest, snap):
+    if not _pricing_snapshot_changed(latest, snap, resolved_model):
         return False
     conn = _get_conn()
     conn.execute(
         "INSERT INTO pricing_snapshots"
         " (provider, model, input_cost_per_million, output_cost_per_million,"
         "  cache_read_cost_per_million, cache_write_cost_per_million, request_cost,"
-        "  source, source_url, pricing_version, fetched_at, captured_at, base_url, api_mode)"
-        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "  source, source_url, pricing_version, fetched_at, captured_at, base_url, api_mode,"
+        "  resolved_model)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             provider,
             model,
@@ -1821,6 +1838,7 @@ def record_pricing_snapshot(
             _utcnow(),
             base_url,
             api_mode,
+            resolved_model,
         ),
     )
     return True

--- a/db.py
+++ b/db.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover - db.py loaded standalone (no package co
 
 logger = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 14
+_SCHEMA_VERSION = 15
 _local = threading.local()
 
 # Serializes first-time schema setup across threads. Each thread opens its own
@@ -172,6 +172,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     _migrate_v12(conn)
     _migrate_v13(conn)
     _migrate_v14(conn)
+    _migrate_v15(conn)
 
 
 def _migrate_v2(conn: sqlite3.Connection) -> None:
@@ -559,6 +560,26 @@ def _migrate_v14(conn: sqlite3.Connection) -> None:
 
     conn.execute(
         "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (14, ?)",
+        (_utcnow(),),
+    )
+
+
+def _migrate_v15(conn: sqlite3.Connection) -> None:
+    """Add ``pricing_snapshots.resolved_model``: the canonical model name that
+    actually produced the tariff when the raw (dated) name did not resolve against
+    the core ``/models`` catalog. NULL when the raw name resolved directly. Uses
+    ``_add_column_if_missing`` (idempotent; a transient SQLITE_LOCKED re-raises so
+    the version is NOT marked applied). See ONBOARDING.md § Core-sourced pricing
+    snapshots and § Schema evolution.
+    """
+    cur = conn.execute("SELECT version FROM schema_version WHERE version = 15")
+    if cur.fetchone() is not None:
+        return
+
+    _add_column_if_missing(conn, "pricing_snapshots", "resolved_model", "TEXT")
+
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_version(version, applied_at) VALUES (15, ?)",
         (_utcnow(),),
     )
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1675,6 +1675,53 @@ def test_migrate_v14_creates_table_from_wedged_v13():
     assert "idx_pricing_snapshots_model" in indexes
 
 
+def test_schema_v15_columns():
+    conn = db._get_conn()
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(pricing_snapshots)")}
+    assert "resolved_model" in cols
+
+
+def test_schema_v15_recorded():
+    versions = {row[0] for row in db._get_conn().execute("SELECT version FROM schema_version")}
+    assert 15 in versions
+
+
+def test_migrate_v15_adds_column_from_wedged_v14():
+    """Upgrade path: a v14-shaped pricing_snapshots (no resolved_model, v15 marker
+    absent) self-heals on the next connect."""
+    conn = db._get_conn()
+    conn.execute("DROP TABLE IF EXISTS pricing_snapshots")
+    conn.executescript("""
+        CREATE TABLE pricing_snapshots (
+            id                            INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider                      TEXT NOT NULL,
+            model                         TEXT NOT NULL,
+            input_cost_per_million        REAL,
+            output_cost_per_million       REAL,
+            cache_read_cost_per_million   REAL,
+            cache_write_cost_per_million  REAL,
+            request_cost                  REAL,
+            source                        TEXT,
+            source_url                    TEXT,
+            pricing_version               TEXT,
+            fetched_at                    TEXT,
+            captured_at                   TEXT NOT NULL,
+            base_url                      TEXT,
+            api_mode                      TEXT
+        );
+    """)
+    conn.execute("DELETE FROM schema_version WHERE version >= 15")
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(pricing_snapshots)")}
+    assert "resolved_model" not in cols  # wedged state confirmed
+
+    db._ensure_schema(conn)
+
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(pricing_snapshots)")}
+    assert "resolved_model" in cols
+    versions = {r[0] for r in conn.execute("SELECT version FROM schema_version")}
+    assert 15 in versions, "v15 marker must be restored after self-heal"
+
+
 def _snap(**over):
     """Build a core_pricing-shaped snapshot dict; override any field via kwargs."""
     base = {

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1814,3 +1814,40 @@ def test_record_pricing_snapshot_is_provider_model_scoped():
     assert db.get_latest_pricing_snapshot("p2", "m2")["input_cost_per_million"] == 2.0
     assert _snapshot_row_count("p1", "m1") == 1
     assert _snapshot_row_count("p2", "m2") == 1
+
+
+def test_record_pricing_snapshot_persists_resolved_model():
+    assert (
+        db.record_pricing_snapshot(
+            "nous",
+            "deepseek/deepseek-v4-pro-20260423",
+            _snap(),
+            resolved_model="deepseek/deepseek-v4-pro",
+        )
+        is True
+    )
+    row = db.get_latest_pricing_snapshot("nous", "deepseek/deepseek-v4-pro-20260423")
+    assert row["resolved_model"] == "deepseek/deepseek-v4-pro"
+
+
+def test_record_pricing_snapshot_resolved_model_defaults_null():
+    db.record_pricing_snapshot("p", "m", _snap())
+    assert db.get_latest_pricing_snapshot("p", "m")["resolved_model"] is None
+
+
+def test_record_pricing_snapshot_new_row_on_resolved_model_change():
+    db.record_pricing_snapshot("p", "m", _snap(), resolved_model="canon-a")
+    assert db.record_pricing_snapshot("p", "m", _snap(), resolved_model="canon-b") is True
+    assert _snapshot_row_count("p", "m") == 2
+
+
+def test_record_pricing_snapshot_noop_when_resolved_model_unchanged():
+    db.record_pricing_snapshot("p", "m", _snap(), resolved_model="canon-a")
+    assert db.record_pricing_snapshot("p", "m", _snap(), resolved_model="canon-a") is False
+    assert _snapshot_row_count("p", "m") == 1
+
+
+def test_record_pricing_snapshot_new_row_on_resolved_model_null_flip():
+    db.record_pricing_snapshot("p", "m", _snap())  # resolved_model NULL
+    assert db.record_pricing_snapshot("p", "m", _snap(), resolved_model="canon-a") is True
+    assert _snapshot_row_count("p", "m") == 2

--- a/tests/test_pricing_snapshots.py
+++ b/tests/test_pricing_snapshots.py
@@ -118,6 +118,50 @@ def test_core_pricing_resolve_failopen(monkeypatch):
     assert core_pricing.resolve("m", provider="p") is None
 
 
+# --- canonical_model_name --------------------------------------------------
+
+
+def test_canonical_model_name_strips_trailing_date():
+    import hermes_telemetry.core_pricing as core_pricing
+
+    assert (
+        core_pricing.canonical_model_name("deepseek/deepseek-v4-pro-20260423")
+        == "deepseek/deepseek-v4-pro"
+    )
+
+
+def test_canonical_model_name_strips_date_before_free_suffix():
+    import hermes_telemetry.core_pricing as core_pricing
+
+    assert core_pricing.canonical_model_name("tencent/hy3-20260706:free") == "tencent/hy3:free"
+
+
+def test_canonical_model_name_unchanged_without_date():
+    import hermes_telemetry.core_pricing as core_pricing
+
+    assert (
+        core_pricing.canonical_model_name("deepseek/deepseek-v4-pro") == "deepseek/deepseek-v4-pro"
+    )
+    assert core_pricing.canonical_model_name("gpt-4o") == "gpt-4o"
+
+
+def test_canonical_model_name_ignores_non_date_digits():
+    import hermes_telemetry.core_pricing as core_pricing
+
+    # 7 digits (not 8) and a date not anchored to end/:free must NOT be stripped.
+    assert core_pricing.canonical_model_name("model-1234567") == "model-1234567"
+    assert core_pricing.canonical_model_name("foo-20260423-bar") == "foo-20260423-bar"
+
+
+def test_canonical_model_name_strips_any_trailing_8_digits():
+    import hermes_telemetry.core_pricing as core_pricing
+
+    # Accepted heuristic: any trailing 8-digit token is stripped, even if not a
+    # real date. Safe because canonicalization runs ONLY as a fallback after a
+    # direct resolve() miss — a resolvable id never reaches this path.
+    assert core_pricing.canonical_model_name("build-12345678") == "build"
+
+
 # --- post_api_request capture --------------------------------------------
 
 

--- a/tests/test_pricing_snapshots.py
+++ b/tests/test_pricing_snapshots.py
@@ -268,3 +268,101 @@ def test_post_api_request_no_snapshot_when_resolve_none(monkeypatch):
         usage={"input_tokens": 1, "output_tokens": 1},
     )
     assert db.get_latest_pricing_snapshot("p", "m") is None
+
+
+def test_post_api_request_falls_back_to_canonical(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+    import hermes_telemetry.db as db
+
+    calls = []
+
+    def _resolve(model, provider="", base_url=""):
+        calls.append(model)
+        if model == "deepseek/deepseek-v4-pro":  # canonical resolves
+            return {
+                "input_cost_per_million": 0.435,
+                "output_cost_per_million": 0.87,
+                "cache_read_cost_per_million": None,
+                "cache_write_cost_per_million": None,
+                "request_cost": None,
+                "source": "provider_models_api",
+                "source_url": None,
+                "pricing_version": "openai-compatible-models-api",
+                "fetched_at": None,
+            }
+        return None  # dated name misses
+
+    monkeypatch.setattr(core_pricing, "resolve", _resolve)
+    ctx = MockPluginContext()
+    _init_mod.register(ctx)
+    ctx.fire(
+        "post_api_request",
+        session_id="s",
+        model="deepseek/deepseek-v4-pro-20260423",
+        provider="nous",
+        usage={"input_tokens": 1, "output_tokens": 1},
+    )
+
+    row = db.get_latest_pricing_snapshot("nous", "deepseek/deepseek-v4-pro-20260423")
+    assert row is not None  # stored under the RAW dated name
+    assert row["input_cost_per_million"] == 0.435
+    assert row["resolved_model"] == "deepseek/deepseek-v4-pro"
+    assert calls == ["deepseek/deepseek-v4-pro-20260423", "deepseek/deepseek-v4-pro"]
+
+
+def test_post_api_request_direct_resolve_leaves_resolved_model_null(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+    import hermes_telemetry.db as db
+
+    monkeypatch.setattr(core_pricing, "resolve", _fake_resolve_factory())
+    ctx = MockPluginContext()
+    _init_mod.register(ctx)
+    ctx.fire(
+        "post_api_request",
+        session_id="s",
+        model="claude-sonnet-4-6",  # no date; resolves directly
+        provider="anthropic",
+        usage={"input_tokens": 1, "output_tokens": 1},
+    )
+    assert (
+        db.get_latest_pricing_snapshot("anthropic", "claude-sonnet-4-6")["resolved_model"] is None
+    )
+
+
+def test_post_api_request_no_snapshot_when_neither_resolves(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+    import hermes_telemetry.db as db
+
+    monkeypatch.setattr(core_pricing, "resolve", lambda *a, **k: None)
+    ctx = MockPluginContext()
+    _init_mod.register(ctx)
+    ctx.fire(
+        "post_api_request",
+        session_id="s",
+        model="unknown/model-20260101",
+        provider="p",
+        usage={"input_tokens": 1, "output_tokens": 1},
+    )
+    assert db.get_latest_pricing_snapshot("p", "unknown/model-20260101") is None
+
+
+def test_post_api_request_no_second_resolve_when_no_date_suffix(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+
+    calls = []
+
+    def _resolve(model, provider="", base_url=""):
+        calls.append(model)
+        return None  # nothing resolves
+
+    monkeypatch.setattr(core_pricing, "resolve", _resolve)
+    ctx = MockPluginContext()
+    _init_mod.register(ctx)
+    ctx.fire(
+        "post_api_request",
+        session_id="s",
+        model="gpt-4o",  # no date suffix -> canonical == raw -> no second resolve
+        provider="openai",
+        usage={"input_tokens": 1, "output_tokens": 1},
+    )
+    assert calls == ["gpt-4o"]  # second resolve skipped when canonical == raw


### PR DESCRIPTION
## Summary

Follow-up to #71. That PR captures core-sourced pricing snapshots per `(provider, model)` in the `post_api_request` hook, but a live VPS test found it captures **nothing for the dominant model**: dated ids like `deepseek/deepseek-v4-pro-20260423` (5559 calls, $114.82 tracked) miss the provider `/models` catalog — which lists only canonical (undated) names — so `get_pricing_entry` returns `None`.

This PR adds a canonicalization **fallback**: when the raw (dated) name misses, capture retries under the canonical name and stores the snapshot under the **raw** name with the canonical name in a new `resolved_model` column.

**Why it matters (measured on the VPS):** the plugin prices the dominant dated model via a generic family prefix (`0.27 / 1.1` in/out per M), while the core's real rate is `0.435 / 0.87`. Capturing the core snapshot surfaces that drift — the whole point of the feature.

**What changed:**
- **`core_pricing.py`** — new pure `canonical_model_name(model)`: strips a trailing `-YYYYMMDD` (incl. before `:free`) via `re.sub(r"-\d{8}(?=:|$)")`. No core import (seam stays pure). Safe as a heuristic because it only feeds the fail-open `resolve()`: a wrong strip → `None` → no row.
- **`db.py`** — migration `_migrate_v15` adds `pricing_snapshots.resolved_model TEXT` (via `_add_column_if_missing`); `record_pricing_snapshot` gains a `resolved_model` kwarg; `get_latest_pricing_snapshot` returns it; `_pricing_snapshot_changed` treats a differing `resolved_model` as a new row.
- **`__init__.py`** — capture fallback in `post_api_request`: on a raw-name miss, retry under the canonical name; record under the RAW name with `resolved_model` = canonical (`NULL` on direct resolve). Throttle + fail-open unchanged.
- **`ONBOARDING.md`** — § Core-sourced pricing snapshots bullet + § Schema evolution v15 row.

Storage-only and going-forward, matching #71's shape. **Backfill of historical dated rows is a separate PR (non-goal here).**

## Test Plan

- [x] `ruff format --check .` + `ruff check .` — clean
- [x] `pytest tests/` — 529 passed, 6 skipped (only the pre-existing TZ flake `test_budget_update_returns_viewer_timezone_metadata` fails, unrelated — reproduces on main)
- [x] Unit: `canonical_model_name` (paid dated / `:free` dated / no-date unchanged / non-8-digit / accepted-heuristic trailing-8-digit)
- [x] Migration: `test_schema_v15_columns`, `test_schema_v15_recorded`, upgrade-path `test_migrate_v15_adds_column_from_wedged_v14`
- [x] DB: `resolved_model` persist / default-NULL / new-row on change / None↔value flip / no-op unchanged
- [x] Capture: fallback records under raw name with `resolved_model` set + resolve called raw→canonical; direct resolve leaves `resolved_model` NULL; neither resolves → no row; no second resolve when canonical == raw
- [x] Migration v14→v15 validated on a WAL-safe copy of the real VPS DB (zero data loss)