### PR TITLE
feat(telemetry): add 'hermes telemetry pricing backfill' command

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -735,9 +735,29 @@ over-estimate is the motivating case) and to feed the manual pricing editor.
   OpenAI-compatible endpoint with no cached `/models` metadata resolves to `None`
   (no snapshot). Nous / OpenRouter / official-docs models resolve without a
   per-call fetch.
-- **Storage-only for now.** Surfacing (stats, `hermes telemetry pricing`, a
-  dashboard tab rendered inside `TelemetryPage`) and drift-vs-`pricing.yaml`
-  computation are follow-ups.
+- **Storage-only for now.** Surfacing (stats, a dashboard tab rendered inside
+  `TelemetryPage`) and drift-vs-`pricing.yaml` computation are follow-ups.
+
+#### Backfill (`hermes telemetry pricing backfill`)
+
+Live capture only records a snapshot when a model is actually called, and it keys
+off `effective_model = response_model or model` — on nous the provider returns the
+**canonical** id, so historical **dated** ids (e.g. `deepseek/deepseek-v4-pro-20260423`)
+that dominate `llm_calls` get no live snapshot. `hermes telemetry pricing backfill`
+seeds coverage for them:
+
+- Enumerates distinct `(provider, model)` in `llm_calls` with no `pricing_snapshots`
+  row (`db.models_needing_pricing_snapshot`).
+- Resolves each via `core_pricing.resolve_with_fallback` (the shared helper the live
+  `post_api_request` capture also uses — dated ids retry under the canonical name).
+- **Dry-run by default**; `--apply` writes, `--json` for machine output.
+
+It is a **coverage seed, not historical reconstruction**: rows carry the tariff the
+core resolves *today* (`captured_at` = now, real provenance), stored under the raw
+model name plus `resolved_model` when the canonical fallback was used. Fail-open and
+idempotent — re-running skips already-covered keys; unresolvable models (no core
+price) are retried each run and captured automatically once the core can price them.
+No schema change; backfilled rows are indistinguishable from same-day live captures.
 
 ---
 

--- a/__init__.py
+++ b/__init__.py
@@ -400,16 +400,9 @@ def register(ctx) -> None:  # noqa: ANN001
                         _do_snapshot = True
                 if _do_snapshot:
                     try:
-                        _snap = core_pricing.resolve(effective_model, provider, base_url)
-                        _resolved = None
-                        # Dated ids (e.g. ...-20260423) miss the core /models catalog;
-                        # retry under the canonical name. See core_pricing.canonical_model_name.
-                        if not _snap:
-                            _canon = core_pricing.canonical_model_name(effective_model)
-                            if _canon != effective_model:
-                                _snap = core_pricing.resolve(_canon, provider, base_url)
-                                if _snap:
-                                    _resolved = _canon
+                        _snap, _resolved = core_pricing.resolve_with_fallback(
+                            effective_model, provider, base_url
+                        )
                         if _snap:
                             db.record_pricing_snapshot(
                                 provider,

--- a/core_pricing.py
+++ b/core_pricing.py
@@ -111,3 +111,28 @@ def resolve(model: str, provider: str = "", base_url: str = "") -> dict | None:
             "core_pricing.resolve failed for model=%r provider=%r: %s", model, provider, exc
         )
         return None
+
+
+def resolve_with_fallback(
+    model: str, provider: str = "", base_url: str = ""
+) -> tuple[dict | None, str | None]:
+    """Resolve pricing for ``model``, retrying under the canonical name when the
+    raw (dated) id misses the core /models catalog.
+
+    Returns ``(snapshot, resolved_model)``: ``snapshot`` is ``resolve()``'s dict or
+    ``None``; ``resolved_model`` is the canonical name the tariff was recovered
+    under when the dated-suffix fallback succeeded, else ``None`` (direct resolve
+    or total miss). Fail-open — delegates to ``resolve()``, which never raises.
+
+    Single source of truth for the capture path (``post_api_request``) and the
+    ``pricing_backfill`` command, so both treat dated ids identically.
+    """
+    snap = resolve(model, provider, base_url)
+    if snap:
+        return snap, None
+    canon = canonical_model_name(model)
+    if canon != model:
+        snap = resolve(canon, provider, base_url)
+        if snap:
+            return snap, canon
+    return None, None

--- a/db.py
+++ b/db.py
@@ -1842,3 +1842,38 @@ def record_pricing_snapshot(
         ),
     )
     return True
+
+
+def count_distinct_llm_models() -> int:
+    """Number of distinct (provider, model) pairs in llm_calls with a non-empty model."""
+    conn = _get_conn()
+    row = conn.execute(
+        "SELECT COUNT(*) FROM ("
+        " SELECT DISTINCT provider, model FROM llm_calls"
+        " WHERE model IS NOT NULL AND model != ''"
+        ")"
+    ).fetchone()
+    return int(row[0])
+
+
+def models_needing_pricing_snapshot() -> list[tuple[str, str]]:
+    """Distinct (provider, model) pairs seen in llm_calls (non-empty model) that
+    have NO pricing_snapshots row yet, ordered by (provider, model).
+
+    Uses ``IS`` for the provider match so a NULL/'' provider compares NULL-safely.
+    Backfill idempotency (skipping already-captured pairs) is enforced HERE, at the
+    query layer — that is why the plain ``provider = ?`` reads in
+    ``get_latest_pricing_snapshot`` / ``record_pricing_snapshot`` are safe for the
+    backfill path.
+    """
+    conn = _get_conn()
+    rows = conn.execute(
+        "SELECT DISTINCT lc.provider, lc.model FROM llm_calls lc"
+        " WHERE lc.model IS NOT NULL AND lc.model != ''"
+        " AND NOT EXISTS ("
+        "   SELECT 1 FROM pricing_snapshots ps"
+        "   WHERE ps.provider IS lc.provider AND ps.model = lc.model"
+        " )"
+        " ORDER BY lc.provider, lc.model"
+    ).fetchall()
+    return [(r[0], r[1]) for r in rows]

--- a/pricing_backfill.py
+++ b/pricing_backfill.py
@@ -1,0 +1,84 @@
+"""hermes telemetry pricing backfill — seed a current pricing snapshot for every
+historical (provider, model) in llm_calls that has none yet.
+
+Coverage seed, NOT historical reconstruction: each written row carries the tariff
+the core resolves TODAY (captured_at = now), using the same dated->canonical
+fallback as the live capture. Dry-run by default; fail-open; idempotent (skips
+already-covered keys, re-tries unresolvable ones on every run).
+"""
+
+from __future__ import annotations
+
+import json
+
+from . import core_pricing, db
+
+
+def run(apply: bool) -> dict:
+    """Enumerate uncovered models, resolve each, and (if apply) write snapshots.
+
+    Returns a result dict: applied, distinct_total, already_covered, to_process,
+    resolvable (list of {provider, model, resolved_model}), unresolvable (list of
+    {provider, model}), written, via_fallback.
+    """
+    distinct_total = db.count_distinct_llm_models()
+    models = db.models_needing_pricing_snapshot()
+    resolvable: list[dict] = []
+    unresolvable: list[dict] = []
+    written = 0
+    for provider, model in models:
+        # base_url intentionally omitted: llm_calls does not store the per-call
+        # endpoint. A model that only resolves via a base_url /models fetch already
+        # has a live snapshot (captured with its base_url) and is excluded by
+        # models_needing_pricing_snapshot(), so nothing extra is recoverable here.
+        snap, resolved_model = core_pricing.resolve_with_fallback(model, provider)
+        if snap:
+            resolvable.append(
+                {"provider": provider, "model": model, "resolved_model": resolved_model}
+            )
+            if apply and db.record_pricing_snapshot(
+                provider, model, snap, resolved_model=resolved_model
+            ):
+                written += 1
+        else:
+            unresolvable.append({"provider": provider, "model": model})
+    via_fallback = sum(1 for r in resolvable if r["resolved_model"])
+    return {
+        "applied": apply,
+        "distinct_total": distinct_total,
+        "already_covered": distinct_total - len(models),
+        "to_process": len(models),
+        "resolvable": resolvable,
+        "unresolvable": unresolvable,
+        "written": written,
+        "via_fallback": via_fallback,
+    }
+
+
+def render(result: dict) -> str:
+    """Human-readable report for a run() result."""
+    if result["applied"]:
+        return (
+            "Pricing snapshot backfill\n"
+            f"  Wrote {result['written']} snapshot rows "
+            f"({result['via_fallback']} via dated fallback), "
+            f"{len(result['unresolvable'])} unresolvable, "
+            f"{result['already_covered']} already covered."
+        )
+    lines = [
+        "Pricing snapshot backfill (dry-run)",
+        f"  Distinct (provider, model) in llm_calls: {result['distinct_total']}",
+        f"  Already have a snapshot:                 {result['already_covered']}   (skipped)",
+        f"  To process:                              {result['to_process']}",
+        f"    Resolvable (would write):              {len(result['resolvable'])}"
+        f"   (via dated fallback: {result['via_fallback']})",
+        f"    Unresolvable (no core price):          {len(result['unresolvable'])}",
+    ]
+    for u in result["unresolvable"]:
+        lines.append(f"      - {u['model']}  ({u['provider']})")
+    lines.append(f"  Run with --apply to write {len(result['resolvable'])} snapshot rows.")
+    return "\n".join(lines)
+
+
+def to_json(result: dict) -> str:
+    return json.dumps(result, default=str)

--- a/telemetry_cli.py
+++ b/telemetry_cli.py
@@ -175,6 +175,15 @@ def _build_parser_into(sub) -> None:
     )
     spp.add_argument("--json", action="store_true", help="Output as JSON")
 
+    pp = sub.add_parser("pricing", help="Pricing snapshot operations")
+    psub = pp.add_subparsers(dest="pricing_command", metavar="PRICING_COMMAND")
+    pb = psub.add_parser(
+        "backfill",
+        help="Seed pricing snapshots for historical models that have none",
+    )
+    pb.add_argument("--apply", action="store_true", help="Write changes (default: dry-run)")
+    pb.add_argument("--json", action="store_true", help="Output as JSON")
+
 
 def main(argv: list[str] | None = None) -> None:
     parser = _build_parser()
@@ -189,6 +198,8 @@ def _dispatch(args: argparse.Namespace, parser: argparse.ArgumentParser | None =
         _handle_budget(args)
     elif args.command == "sync-profiles":
         _handle_sync_profiles(args)
+    elif args.command == "pricing":
+        _handle_pricing(args, parser)
     else:
         if parser:
             parser.print_help()
@@ -352,6 +363,20 @@ def _handle_sync_profiles(args: argparse.Namespace) -> None:
     print(
         sp.to_json(statuses, target, results) if args.json else sp.render(statuses, target, results)
     )
+
+
+def _handle_pricing(
+    args: argparse.Namespace, parser: argparse.ArgumentParser | None = None
+) -> None:
+    from . import pricing_backfill
+
+    if args.pricing_command == "backfill":
+        result = pricing_backfill.run(apply=args.apply)
+        print(pricing_backfill.to_json(result) if args.json else pricing_backfill.render(result))
+        return
+    if parser:
+        parser.print_help()
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1851,3 +1851,38 @@ def test_record_pricing_snapshot_new_row_on_resolved_model_null_flip():
     db.record_pricing_snapshot("p", "m", _snap())  # resolved_model NULL
     assert db.record_pricing_snapshot("p", "m", _snap(), resolved_model="canon-a") is True
     assert _snapshot_row_count("p", "m") == 2
+
+
+# ---------------------------------------------------------------------------
+# models_needing_pricing_snapshot / count_distinct_llm_models
+# ---------------------------------------------------------------------------
+
+_BF_NOW = "2026-07-14T00:00:00+00:00"
+
+
+def test_models_needing_pricing_snapshot_excludes_covered_and_empty():
+    db.record_llm_call("s1", _BF_NOW, "deepseek/deepseek-v4-pro-20260423", "nous", 10, 2, 0.01, 100)
+    db.record_llm_call("s2", _BF_NOW, "deepseek/deepseek-v4-pro-20260423", "nous", 10, 2, 0.01, 100)
+    db.record_llm_call("s3", _BF_NOW, "tencent/hy3:free", "nous", 5, 1, 0.0, 50)
+    db.record_llm_call("s4", _BF_NOW, "", "nous", 1, 1, 0.0, 10)  # empty model — ignored
+    db.record_pricing_snapshot(
+        "nous",
+        "tencent/hy3:free",
+        {
+            "input_cost_per_million": 0.0,
+            "output_cost_per_million": 0.0,
+            "source": "provider_models_api",
+        },
+    )
+
+    needing = db.models_needing_pricing_snapshot()
+    assert needing == [("nous", "deepseek/deepseek-v4-pro-20260423")]
+
+
+def test_count_distinct_llm_models_ignores_empty():
+    db.record_llm_call("s1", _BF_NOW, "a/m", "nous", 1, 1, 0.0, 1)
+    db.record_llm_call("s2", _BF_NOW, "a/m", "nous", 1, 1, 0.0, 1)  # duplicate
+    db.record_llm_call("s3", _BF_NOW, "b/m", "openai", 1, 1, 0.0, 1)
+    db.record_llm_call("s4", _BF_NOW, "", "nous", 1, 1, 0.0, 1)  # empty — ignored
+
+    assert db.count_distinct_llm_models() == 2

--- a/tests/test_pricing_backfill.py
+++ b/tests/test_pricing_backfill.py
@@ -1,0 +1,150 @@
+"""hermes telemetry pricing backfill — module logic + CLI wiring."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_db():
+    import hermes_telemetry.db as db_mod
+
+    db_mod._local.conn = None
+    yield
+    if getattr(db_mod._local, "conn", None):
+        db_mod._local.conn.close()
+        db_mod._local.conn = None
+
+
+import hermes_telemetry.core_pricing as core_pricing
+import hermes_telemetry.db as db
+import hermes_telemetry.pricing_backfill as pricing_backfill
+
+_NOW = "2026-07-14T00:00:00+00:00"
+
+
+def _seed():
+    db.record_llm_call("s1", _NOW, "deepseek/deepseek-v4-pro-20260423", "nous", 10, 2, 0.01, 100)
+    db.record_llm_call("s2", _NOW, "tencent/hy3:free", "nous", 5, 1, 0.0, 50)
+    db.record_llm_call("s3", _NOW, "nvidia/nemotron-3-ultra:free", "nous", 5, 1, 0.0, 50)
+
+
+def _fake_resolve(model, provider="", base_url=""):
+    if model == "deepseek/deepseek-v4-pro":
+        return {
+            "input_cost_per_million": 0.435,
+            "output_cost_per_million": 0.87,
+            "source": "provider_models_api",
+        }
+    if model == "tencent/hy3:free":
+        return {
+            "input_cost_per_million": 0.0,
+            "output_cost_per_million": 0.0,
+            "source": "provider_models_api",
+        }
+    return None  # nemotron never resolves (dated or canonical)
+
+
+def test_run_dry_run_writes_nothing(monkeypatch):
+    _seed()
+    monkeypatch.setattr(core_pricing, "resolve", _fake_resolve)
+    result = pricing_backfill.run(apply=False)
+    assert result["applied"] is False
+    assert result["to_process"] == 3
+    assert len(result["resolvable"]) == 2
+    assert result["via_fallback"] == 1  # deepseek recovered via canonical
+    assert len(result["unresolvable"]) == 1
+    assert result["written"] == 0
+    assert db.get_latest_pricing_snapshot("nous", "deepseek/deepseek-v4-pro-20260423") is None
+
+
+def test_run_apply_writes_rows_and_is_idempotent(monkeypatch):
+    _seed()
+    monkeypatch.setattr(core_pricing, "resolve", _fake_resolve)
+    r1 = pricing_backfill.run(apply=True)
+    assert r1["written"] == 2
+    row = db.get_latest_pricing_snapshot("nous", "deepseek/deepseek-v4-pro-20260423")
+    assert row["resolved_model"] == "deepseek/deepseek-v4-pro"
+    assert row["input_cost_per_million"] == 0.435
+    assert db.get_latest_pricing_snapshot("nous", "tencent/hy3:free")["resolved_model"] is None
+
+    r2 = pricing_backfill.run(apply=True)
+    assert r2["written"] == 0
+    assert r2["to_process"] == 1  # only the still-unresolvable nemotron remains
+    assert len(r2["unresolvable"]) == 1
+
+
+def test_run_apply_unresolvable_writes_no_row(monkeypatch):
+    _seed()
+    monkeypatch.setattr(core_pricing, "resolve", _fake_resolve)
+    pricing_backfill.run(apply=True)
+    assert db.get_latest_pricing_snapshot("nous", "nvidia/nemotron-3-ultra:free") is None
+
+
+def test_render_dry_run_text(monkeypatch):
+    _seed()
+    monkeypatch.setattr(core_pricing, "resolve", _fake_resolve)
+    text = pricing_backfill.render(pricing_backfill.run(apply=False))
+    assert "dry-run" in text
+    assert "To process:" in text
+    assert "nvidia/nemotron-3-ultra:free" in text
+
+
+def test_to_json_roundtrips(monkeypatch):
+    _seed()
+    monkeypatch.setattr(core_pricing, "resolve", _fake_resolve)
+    payload = json.loads(pricing_backfill.to_json(pricing_backfill.run(apply=True)))
+    assert payload["written"] == 2
+    assert payload["via_fallback"] == 1
+
+
+def test_cli_pricing_backfill_dry_run_default(monkeypatch, capsys):
+    import hermes_telemetry.pricing_backfill as pb
+    import hermes_telemetry.telemetry_cli as cli
+
+    captured = {}
+
+    def _fake_run(apply):
+        captured["apply"] = apply
+        return {
+            "applied": apply,
+            "distinct_total": 0,
+            "already_covered": 0,
+            "to_process": 0,
+            "resolvable": [],
+            "unresolvable": [],
+            "written": 0,
+            "via_fallback": 0,
+        }
+
+    monkeypatch.setattr(pb, "run", _fake_run)
+    cli.main(["pricing", "backfill"])
+    assert captured["apply"] is False
+    assert "dry-run" in capsys.readouterr().out
+
+
+def test_cli_pricing_backfill_apply_json(monkeypatch, capsys):
+    import hermes_telemetry.pricing_backfill as pb
+    import hermes_telemetry.telemetry_cli as cli
+
+    captured = {}
+
+    def _fake_run(apply):
+        captured["apply"] = apply
+        return {
+            "applied": apply,
+            "distinct_total": 3,
+            "already_covered": 1,
+            "to_process": 2,
+            "resolvable": [{"provider": "nous", "model": "m", "resolved_model": None}],
+            "unresolvable": [],
+            "written": 1,
+            "via_fallback": 0,
+        }
+
+    monkeypatch.setattr(pb, "run", _fake_run)
+    cli.main(["pricing", "backfill", "--apply", "--json"])
+    assert captured["apply"] is True
+    assert json.loads(capsys.readouterr().out)["written"] == 1

--- a/tests/test_pricing_snapshots.py
+++ b/tests/test_pricing_snapshots.py
@@ -366,3 +366,62 @@ def test_post_api_request_no_second_resolve_when_no_date_suffix(monkeypatch):
         usage={"input_tokens": 1, "output_tokens": 1},
     )
     assert calls == ["gpt-4o"]  # second resolve skipped when canonical == raw
+
+
+# --- core_pricing.resolve_with_fallback -----------------------------------
+
+
+def test_resolve_with_fallback_direct(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+
+    def _resolve(model, provider="", base_url=""):
+        if model == "claude-sonnet-4-6":
+            return {"input_cost_per_million": 3.0, "source": "official_docs_snapshot"}
+        return None
+
+    monkeypatch.setattr(core_pricing, "resolve", _resolve)
+    snap, resolved = core_pricing.resolve_with_fallback("claude-sonnet-4-6", "anthropic")
+    assert snap == {"input_cost_per_million": 3.0, "source": "official_docs_snapshot"}
+    assert resolved is None
+
+
+def test_resolve_with_fallback_dated(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+
+    calls = []
+
+    def _resolve(model, provider="", base_url=""):
+        calls.append(model)
+        if model == "deepseek/deepseek-v4-pro":
+            return {"input_cost_per_million": 0.435, "source": "provider_models_api"}
+        return None
+
+    monkeypatch.setattr(core_pricing, "resolve", _resolve)
+    snap, resolved = core_pricing.resolve_with_fallback("deepseek/deepseek-v4-pro-20260423", "nous")
+    assert snap["input_cost_per_million"] == 0.435
+    assert resolved == "deepseek/deepseek-v4-pro"
+    assert calls == ["deepseek/deepseek-v4-pro-20260423", "deepseek/deepseek-v4-pro"]
+
+
+def test_resolve_with_fallback_miss(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+
+    monkeypatch.setattr(core_pricing, "resolve", lambda *a, **k: None)
+    snap, resolved = core_pricing.resolve_with_fallback("unknown/model-20260101", "p")
+    assert snap is None
+    assert resolved is None
+
+
+def test_resolve_with_fallback_no_date_single_call(monkeypatch):
+    import hermes_telemetry.core_pricing as core_pricing
+
+    calls = []
+
+    def _resolve(model, provider="", base_url=""):
+        calls.append(model)
+        return None
+
+    monkeypatch.setattr(core_pricing, "resolve", _resolve)
+    snap, resolved = core_pricing.resolve_with_fallback("plain/model", "p")
+    assert (snap, resolved) == (None, None)
+    assert calls == ["plain/model"]  # no canonical retry when there is no date suffix


### PR DESCRIPTION
## What

Adds `hermes telemetry pricing backfill` — a dry-run-by-default CLI that seeds one current pricing snapshot for every `(provider, model)` in `llm_calls` that has none yet.

## Why

Live capture keys its snapshot off `effective_model = response_model or model`, and on the nous endpoint the provider returns the **canonical** id. So the historical **dated** ids that dominate `llm_calls` (e.g. `deepseek/deepseek-v4-pro-20260423`, the model concentrating spend) never get a live snapshot. This backfill seeds coverage for them.

It is a **coverage seed, not historical reconstruction**: rows carry the tariff the core resolves *today* (`captured_at` = now, real provenance), stored under the raw model name plus `resolved_model` when the dated→canonical fallback was used. **No schema change.** Fail-open and idempotent (re-running skips already-covered keys; unresolvable models are retried each run).

## How

- `core_pricing.resolve_with_fallback()` — the resolve→canonical-fallback logic, factored out of `post_api_request` into a shared helper (both call sites now use it).
- `db.models_needing_pricing_snapshot()` + `db.count_distinct_llm_models()`.
- `pricing_backfill.py` — `run(apply)` / `render` / `to_json`.
- `telemetry_cli.py` — `pricing backfill` subcommand (`--apply`, `--json`).
- ONBOARDING documented.

## Testing

- 6 tasks implemented TDD; full suite `543 passed, 6 skipped` (TZ=UTC), ruff clean.
- Validated on the VPS against **real** historical data (isolated `/tmp` copy, prod untouched): dry-run = 11 distinct, 1 already covered, 8 resolvable (5 via dated fallback), 2 unresolvable (discontinued models); `--apply` wrote 8 rows incl. `deepseek/deepseek-v4-pro-20260423` → `deepseek/deepseek-v4-pro` @ real 0.435/0.87; re-apply wrote 0 (idempotent).