### PR TITLE
fix(dashboard): honor explicit UTC viewer timezone without zoneinfo

### DIFF
--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -2264,6 +2264,10 @@ def _dashboard_viewer_tz(tz_name: str | None):
             return ZoneInfo(tz_name), tz_name
         except Exception:
             pass
+    # UTC needs no timezone database, so honor it even when zoneinfo is
+    # unavailable (Python 3.8) rather than falling back to the server's local tz.
+    if tz_name and tz_name.upper() == "UTC":
+        return timezone.utc, "UTC"
     local_tz = datetime.now().astimezone().tzinfo or timezone.utc
     label = getattr(local_tz, "key", None) or str(local_tz)
     return local_tz, label

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -404,6 +404,16 @@ def test_budget_window_bounds_follow_viewer_timezone_monthly(serve_module):
     assert bounds["window_end_utc"] == "2027-01-31T18:00:00+00:00"
 
 
+def test_dashboard_viewer_tz_honors_utc_without_zoneinfo(serve_module, monkeypatch):
+    # UTC needs no timezone database, so an explicit "UTC" request must be honored
+    # even when zoneinfo is unavailable (e.g. Python 3.8, where ZoneInfo is None) —
+    # not silently replaced by the server's local timezone.
+    monkeypatch.setattr(serve_module, "ZoneInfo", None)
+    tzinfo, label = serve_module._dashboard_viewer_tz("UTC")
+    assert label == "UTC"
+    assert tzinfo == timezone.utc
+
+
 def test_budget_update_returns_viewer_timezone_metadata(serve_module, tmp_path):
     import sqlite3
 


### PR DESCRIPTION
## Problem

`_dashboard_viewer_tz` fell back to the server's **local** timezone whenever `ZoneInfo` was unavailable — which is the case on **Python 3.8**, where `zoneinfo` is not in the stdlib (`ZoneInfo = None`). As a result, an explicit `"UTC"` viewer-timezone request was silently ignored and replaced by the machine's local tz.

This surfaced as a flaky-looking test: `test_budget_update_returns_viewer_timezone_metadata` asserts `viewer_timezone == "UTC"` but has no zoneinfo/version guard (unlike its sibling tz tests). It only passed on CI because GitHub Actions runners default to UTC, so the local-tz fallback happened to return UTC. On any non-UTC machine running Python 3.8 (e.g. CEST), the test failed and — more importantly — real dashboard users on 3.8 saw their local tz instead of the UTC they selected.

## Fix

Honor UTC via `timezone.utc` regardless of `zoneinfo` availability. UTC needs no timezone database, so it can always be resolved. Non-UTC IANA zones still require zoneinfo and keep the existing local-tz degradation.

## Tests

- Adds `test_dashboard_viewer_tz_honors_utc_without_zoneinfo`, which forces `ZoneInfo = None` (so it exercises the fallback path on **all** Python versions, not just 3.8) and asserts UTC is honored.
- `test_budget_update_returns_viewer_timezone_metadata` now passes for the right reason, independent of the runner's local timezone.
- Full suite: 544 passed, 6 skipped.