### PR TITLE
feat(telemetry): add 'hermes telemetry pricing drift' command

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -735,8 +735,8 @@ over-estimate is the motivating case) and to feed the manual pricing editor.
   OpenAI-compatible endpoint with no cached `/models` metadata resolves to `None`
   (no snapshot). Nous / OpenRouter / official-docs models resolve without a
   per-call fetch.
-- **Storage-only for now.** Surfacing (stats, a dashboard tab rendered inside
-  `TelemetryPage`) and drift-vs-`pricing.yaml` computation are follow-ups.
+- **Drift computation shipped** (see below). Surfacing snapshots in the dashboard
+  (a tab rendered inside `TelemetryPage`) remains a follow-up.
 
 #### Backfill (`hermes telemetry pricing backfill`)
 
@@ -758,6 +758,37 @@ model name plus `resolved_model` when the canonical fallback was used. Fail-open
 idempotent — re-running skips already-covered keys; unresolvable models (no core
 price) are retried each run and captured automatically once the core can price them.
 No schema change; backfilled rows are indistinguishable from same-day live captures.
+
+#### Drift detection (`hermes telemetry pricing drift`)
+
+`pricing.yaml` is the plugin's cost source; `pricing_snapshots` is the core's
+ground truth. Drift detection diffs them so an over-priced local entry (the Faro
+case) surfaces instead of silently inflating cost:
+
+- Reads the latest snapshot per `(provider, model)` via
+  `db.list_latest_pricing_snapshots`, collapsed to the canonical write-key
+  (`resolved_model or model`, latest-id wins on collision).
+- Resolves each model's local rate via `pricing._resolve_pricing` (provider-aware)
+  and flags **input/output** drift beyond `--threshold` (default 1%). Cache/
+  reasoning are derived and `request_cost` has no `pricing.yaml` analog, so they
+  are intentionally excluded. A zero snapshot rate vs. a non-zero local price is
+  always drift (the per-side percentage is reported as undefined).
+- `_subscription: true` entries are skipped (a declared $0 is intentional).
+  `_provider_assumed` best-effort guesses are treated as "no local price", not
+  drift, since they were never pinned for that provider.
+- **Coverage-gap aware:** reuses `db.models_needing_pricing_snapshot` — if models
+  in `llm_calls` have no snapshot, the report says so and points at
+  `pricing backfill`, so drift never gives a false all-clear. The gap count is
+  DB-wide; the human-facing nudge is suppressed when `--model` scopes the run.
+- **Dry-run by default**; `--apply` merges the snapshot input/output rates back
+  into `pricing.yaml` (never clobber), tags each repaired entry `_source:
+  core-snapshot`, and hot-reloads. Because `pricing.yaml` is keyed by model only,
+  a model that drifted under two providers is written once (first wins; a
+  conflicting second rate is logged and skipped). Routes through
+  `paths.get_pricing_path()` (not `HERMES_HOME`-direct like
+  `pricing_refresh.PRICING_FILE`, whose latent bug is a separate follow-up).
+  `--model` limits to one canonical model; `--json` for machine output. No schema
+  change.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -471,6 +471,42 @@ The `Notes` column (subscription/free-tier vs no price entry) and footer
 behaviour described in [`/stats models`](#stats) work the same way under a
 date filter — they're computed against whatever rows the filter selected.
 
+### Pricing snapshots (`pricing backfill` / `pricing drift`)
+
+Every real LLM call captures a pricing snapshot from the core (ground truth). Two
+subcommands work with that snapshot history:
+
+```bash
+# Seed snapshots for historical models that never got one (dry-run first)
+hermes-telemetry pricing backfill
+hermes-telemetry pricing backfill --apply    # write the resolvable ones
+hermes-telemetry pricing backfill --json     # machine-readable output
+
+# Compare pricing.yaml against the core snapshots (dry-run first)
+hermes-telemetry pricing drift
+hermes-telemetry pricing drift --apply               # rewrite drifted entries
+hermes-telemetry pricing drift --threshold 5          # flag drift > 5% (default: 1%)
+hermes-telemetry pricing drift --model deepseek/deepseek-v4-pro
+hermes-telemetry pricing drift --json
+```
+
+`pricing backfill` seeds a current snapshot for every historical `(provider, model)`
+in `llm_calls` that has none yet — mainly dated model ids that never matched a live
+capture. It's a coverage seed, not historical reconstruction: the tariff written is
+whatever the core resolves *today*. Dry-run by default; `--apply` writes; idempotent
+and safe to re-run.
+
+`pricing drift` diffs `pricing.yaml`'s input/output rates against the latest core
+snapshot per model (input/output only — cache/reasoning rates have no `pricing.yaml`
+analog). It skips `_subscription: true` entries (a declared $0 is intentional) and
+flags anything beyond `--threshold` percent (default `1.0`). If models in `llm_calls`
+still lack a snapshot, the report reminds you to run `pricing backfill` first so a
+clean drift run isn't a false all-clear. Dry-run by default; `--apply` merges the
+core rates back into `pricing.yaml` (never clobbers) and tags each repaired entry
+`_source: core-snapshot`.
+
+See `ONBOARDING.md § Core-sourced pricing snapshots` for the full design rationale.
+
 -----
 
 ## Setup Wizard

--- a/db.py
+++ b/db.py
@@ -1756,6 +1756,30 @@ def get_latest_pricing_snapshot(provider: str, model: str) -> dict | None:
     return dict(row) if row else None
 
 
+def list_latest_pricing_snapshots() -> list[dict]:
+    """Return the most recent pricing_snapshots row for every (provider, model)
+    pair, ordered by (provider, model). Latest = highest id per pair.
+
+    Unlike get_latest_pricing_snapshot (single pair), this powers pricing-drift
+    which must diff every captured tariff against pricing.yaml at once.
+    """
+    conn = _get_conn()
+    rows = conn.execute(
+        "SELECT ps.id, ps.provider, ps.model,"
+        " ps.input_cost_per_million, ps.output_cost_per_million,"
+        " ps.cache_read_cost_per_million, ps.cache_write_cost_per_million, ps.request_cost,"
+        " ps.source, ps.source_url, ps.pricing_version, ps.fetched_at, ps.captured_at,"
+        " ps.base_url, ps.api_mode, ps.resolved_model"
+        " FROM pricing_snapshots ps"
+        " JOIN ("
+        "   SELECT provider, model, MAX(id) AS max_id FROM pricing_snapshots"
+        "   GROUP BY provider, model"
+        " ) latest ON ps.id = latest.max_id"
+        " ORDER BY ps.provider, ps.model"
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
 def _pricing_snapshot_changed(
     latest: dict | None, snap: dict, resolved_model: str | None = None
 ) -> bool:

--- a/pricing_drift.py
+++ b/pricing_drift.py
@@ -166,7 +166,7 @@ def render(result: dict) -> str:
     if result["coverage_gap"] and result["model_filter"] is None:
         lines.append(
             f"  ! {result['coverage_gap']} model(s) in llm_calls have NO snapshot — "
-            "run `hermes telemetry pricing backfill --apply` for full coverage."
+            "run `hermes-telemetry pricing backfill --apply` for full coverage."
         )
     if result["drifted"]:
         lines.append(

--- a/pricing_drift.py
+++ b/pricing_drift.py
@@ -1,0 +1,5 @@
+"""hermes telemetry pricing drift — compare pricing.yaml against core pricing
+snapshots. Implemented incrementally; see docs/superpowers/plans/2026-07-16-pricing-drift.md.
+"""
+
+from __future__ import annotations

--- a/pricing_drift.py
+++ b/pricing_drift.py
@@ -51,6 +51,8 @@ def run(*, apply: bool = False, threshold_pct: float = 1.0, model: str | None = 
     Returns a result dict: applied, threshold_pct, model_filter, compared,
     drifted (list), in_sync, skipped_subscription (list), no_local_price (list),
     coverage_gap (int), written (int).
+
+    A threshold_pct of 0 flags any difference; a negative value flags everything.
     """
     snapshots = db.list_latest_pricing_snapshots()
 
@@ -197,10 +199,20 @@ def _apply_drift(drifted: list[dict]) -> int:
     import yaml
 
     path = paths.get_pricing_path()
-    data: dict = {}
     if path.exists():
-        with open(path) as f:
-            data = yaml.safe_load(f) or {}
+        try:
+            with open(path) as f:
+                data = yaml.safe_load(f) or {}
+        except yaml.YAMLError as exc:
+            logger.error(
+                "hermes-telemetry: could not parse %s (%s) — skipping drift apply "
+                "to avoid clobbering a malformed file. Fix the YAML and re-run.",
+                path,
+                exc,
+            )
+            return 0
+    else:
+        data = {"models": {}}
 
     models = data.setdefault("models", {}) if "models" in data or "defaults" in data else data
 

--- a/pricing_drift.py
+++ b/pricing_drift.py
@@ -12,8 +12,11 @@ lack any snapshot, so drift never gives a false all-clear.
 from __future__ import annotations
 
 import json
+import logging
 
-from . import db, pricing
+from . import db, paths, pricing
+
+logger = logging.getLogger(__name__)
 
 
 def _drift_pct(local: float, snap: float) -> float | None:
@@ -182,13 +185,16 @@ def _apply_drift(drifted: list[dict]) -> int:
     dump back with sort_keys=False (preserve insertion order). Routes through
     paths.get_pricing_path() at call time (honors HERMES_TELEMETRY_HOME), then
     hot-reloads pricing.py's cache. Returns the number of entries written.
+
+    pricing.yaml is keyed by model only, so if the same model drifted under two
+    providers (run() keys canonical by (provider, model)), only the first is
+    written; a conflicting second rate is logged and skipped rather than silently
+    overwriting.
     """
     if not drifted:
         return 0
 
     import yaml
-
-    from . import paths
 
     path = paths.get_pricing_path()
     data: dict = {}
@@ -196,12 +202,25 @@ def _apply_drift(drifted: list[dict]) -> int:
         with open(path) as f:
             data = yaml.safe_load(f) or {}
 
-    # New format nests models under "models:"; legacy is a flat model->entry map.
     models = data.setdefault("models", {}) if "models" in data or "defaults" in data else data
 
     written = 0
+    applied: dict[str, tuple] = {}
     for d in drifted:
         target = d["model"].lower()
+        rates = (d["snap_input"], d["snap_output"])
+        if target in applied:
+            if applied[target] != rates:
+                logger.warning(
+                    "hermes-telemetry: conflicting core rates for model %r across "
+                    "providers (%s vs %s) — keeping the first, skipping the rest. "
+                    "pricing.yaml is keyed by model only, so per-provider rates "
+                    "cannot both be pinned.",
+                    d["model"],
+                    applied[target],
+                    rates,
+                )
+            continue
         existing_key = next((k for k in models if str(k).lower() == target), None)
         if existing_key is not None:
             entry = models[existing_key]
@@ -214,6 +233,7 @@ def _apply_drift(drifted: list[dict]) -> int:
         entry["input"] = d["snap_input"]
         entry["output"] = d["snap_output"]
         entry["_source"] = "core-snapshot"
+        applied[target] = rates
         written += 1
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/pricing_drift.py
+++ b/pricing_drift.py
@@ -16,15 +16,30 @@ import json  # noqa: F401 -- used by later tasks in this plan (CLI --json output
 from . import db, pricing
 
 
-def _drift_pct(local: float, snap: float) -> float:
+def _drift_pct(local: float, snap: float) -> float | None:
     """Signed drift of local vs snapshot as a percentage: (local/snap - 1) * 100.
 
-    When snap is 0: 0.0 if local is also 0, else infinite (a real, unbounded
-    over-charge — treated as drift by any finite threshold).
+    Returns None when snap is 0 — the ratio is undefined (division by zero),
+    not an infinite drift. Callers that need a drift *decision* (not a display
+    percentage) for the zero-snapshot case should use `_is_drift` instead.
     """
     if snap == 0:
-        return 0.0 if local == 0 else float("inf")
+        return None
     return (local / snap - 1.0) * 100.0
+
+
+def _is_drift(local: float, snap: float, threshold_pct: float) -> bool:
+    """True if local drifts from snap beyond threshold. A zero snapshot with a
+    nonzero local price is always drift (was free / unpriced, now priced).
+
+    A tiny epsilon is added to the threshold to absorb binary floating-point
+    noise at the exact boundary (e.g. 1.01 / 1.0 evaluates to
+    1.0000000000000009, not 1.0, purely from float representation) so a value
+    at *exactly* the threshold percentage doesn't spuriously read as drift.
+    """
+    if snap == 0:
+        return local != 0
+    return abs((local / snap - 1.0) * 100.0) > threshold_pct + 1e-9
 
 
 def run(*, apply: bool = False, threshold_pct: float = 1.0, model: str | None = None) -> dict:
@@ -66,14 +81,14 @@ def run(*, apply: bool = False, threshold_pct: float = 1.0, model: str | None = 
             skipped_subscription.append({"provider": provider, "model": write_key})
             continue
         prices = pricing._resolve_pricing(write_key, provider)
-        if prices is None:
+        if prices is None or prices.get("_provider_assumed"):
             no_local_price.append({"provider": provider, "model": write_key})
             continue
         local_in = float(prices["input"])
         local_out = float(prices["output"])
-        in_pct = _drift_pct(local_in, float(snap_in))
-        out_pct = _drift_pct(local_out, float(snap_out))
-        if abs(in_pct) > threshold_pct or abs(out_pct) > threshold_pct:
+        in_drift = _is_drift(local_in, float(snap_in), threshold_pct)
+        out_drift = _is_drift(local_out, float(snap_out), threshold_pct)
+        if in_drift or out_drift:
             drifted.append(
                 {
                     "provider": provider,
@@ -82,8 +97,8 @@ def run(*, apply: bool = False, threshold_pct: float = 1.0, model: str | None = 
                     "local_output": local_out,
                     "snap_input": float(snap_in),
                     "snap_output": float(snap_out),
-                    "input_drift_pct": in_pct,
-                    "output_drift_pct": out_pct,
+                    "input_drift_pct": _drift_pct(local_in, float(snap_in)),
+                    "output_drift_pct": _drift_pct(local_out, float(snap_out)),
                 }
             )
         else:
@@ -100,6 +115,9 @@ def run(*, apply: bool = False, threshold_pct: float = 1.0, model: str | None = 
         "in_sync": in_sync,
         "skipped_subscription": skipped_subscription,
         "no_local_price": no_local_price,
+        # Global by design: a data-health signal about the whole snapshot store,
+        # independent of `model` — NOT scoped by the model filter above. A
+        # narrower drift run should still surface store-wide coverage gaps.
         "coverage_gap": len(db.models_needing_pricing_snapshot()),
         "written": written,
     }

--- a/pricing_drift.py
+++ b/pricing_drift.py
@@ -1,5 +1,110 @@
-"""hermes telemetry pricing drift — compare pricing.yaml against core pricing
-snapshots. Implemented incrementally; see docs/superpowers/plans/2026-07-16-pricing-drift.md.
+"""hermes telemetry pricing drift — compare pricing.yaml against the core-resolved
+pricing_snapshots (ground truth) and report / repair drift.
+
+Offline: reads DB snapshots + pricing.yaml only, no live core call. Input/output
+rates only (cache/reasoning are derived, request_cost has no pricing.yaml analog).
+Dry-run by default; --apply rewrites pricing.yaml (merge, never clobber), skipping
+_subscription entries and tagging repaired models with _source: core-snapshot.
+Coverage-gap aware: reminds you to run `pricing backfill` when models in llm_calls
+lack any snapshot, so drift never gives a false all-clear.
 """
 
 from __future__ import annotations
+
+import json  # noqa: F401 -- used by later tasks in this plan (CLI --json output)
+
+from . import db, pricing
+
+
+def _drift_pct(local: float, snap: float) -> float:
+    """Signed drift of local vs snapshot as a percentage: (local/snap - 1) * 100.
+
+    When snap is 0: 0.0 if local is also 0, else infinite (a real, unbounded
+    over-charge — treated as drift by any finite threshold).
+    """
+    if snap == 0:
+        return 0.0 if local == 0 else float("inf")
+    return (local / snap - 1.0) * 100.0
+
+
+def run(*, apply: bool = False, threshold_pct: float = 1.0, model: str | None = None) -> dict:
+    """Diff pricing.yaml against the latest core pricing snapshots.
+
+    Returns a result dict: applied, threshold_pct, model_filter, compared,
+    drifted (list), in_sync, skipped_subscription (list), no_local_price (list),
+    coverage_gap (int), written (int).
+    """
+    snapshots = db.list_latest_pricing_snapshots()
+
+    # Collapse each (provider, dated-model) snapshot to its canonical write-key
+    # (resolved_model or model). When several dated names collapse to the same
+    # canonical pair, keep the one captured latest (highest id).
+    canonical: dict[tuple[str, str], dict] = {}
+    for row in snapshots:
+        write_key = row.get("resolved_model") or row["model"]
+        key = (row["provider"], write_key)
+        cur = canonical.get(key)
+        if cur is None or row["id"] > cur["id"]:
+            canonical[key] = row
+
+    custom = pricing._load_custom_pricing()
+    subscription = custom.get("subscription_models", set())
+
+    drifted: list[dict] = []
+    skipped_subscription: list[dict] = []
+    no_local_price: list[dict] = []
+    in_sync = 0
+
+    for (provider, write_key), row in sorted(canonical.items()):
+        if model is not None and write_key != model:
+            continue
+        snap_in = row.get("input_cost_per_million")
+        snap_out = row.get("output_cost_per_million")
+        if snap_in is None or snap_out is None:
+            continue  # incomplete snapshot — nothing comparable
+        if write_key.lower() in subscription:
+            skipped_subscription.append({"provider": provider, "model": write_key})
+            continue
+        prices = pricing._resolve_pricing(write_key, provider)
+        if prices is None:
+            no_local_price.append({"provider": provider, "model": write_key})
+            continue
+        local_in = float(prices["input"])
+        local_out = float(prices["output"])
+        in_pct = _drift_pct(local_in, float(snap_in))
+        out_pct = _drift_pct(local_out, float(snap_out))
+        if abs(in_pct) > threshold_pct or abs(out_pct) > threshold_pct:
+            drifted.append(
+                {
+                    "provider": provider,
+                    "model": write_key,
+                    "local_input": local_in,
+                    "local_output": local_out,
+                    "snap_input": float(snap_in),
+                    "snap_output": float(snap_out),
+                    "input_drift_pct": in_pct,
+                    "output_drift_pct": out_pct,
+                }
+            )
+        else:
+            in_sync += 1
+
+    written = _apply_drift(drifted) if apply else 0
+
+    return {
+        "applied": apply,
+        "threshold_pct": threshold_pct,
+        "model_filter": model,
+        "compared": len(drifted) + in_sync,
+        "drifted": drifted,
+        "in_sync": in_sync,
+        "skipped_subscription": skipped_subscription,
+        "no_local_price": no_local_price,
+        "coverage_gap": len(db.models_needing_pricing_snapshot()),
+        "written": written,
+    }
+
+
+def _apply_drift(drifted: list[dict]) -> int:
+    """Placeholder — implemented in Task 4."""
+    return 0

--- a/pricing_drift.py
+++ b/pricing_drift.py
@@ -11,7 +11,7 @@ lack any snapshot, so drift never gives a false all-clear.
 
 from __future__ import annotations
 
-import json  # noqa: F401 -- used by later tasks in this plan (CLI --json output)
+import json
 
 from . import db, pricing
 
@@ -121,6 +121,57 @@ def run(*, apply: bool = False, threshold_pct: float = 1.0, model: str | None = 
         "coverage_gap": len(db.models_needing_pricing_snapshot()),
         "written": written,
     }
+
+
+def _fmt_pct(pct: float | None) -> str:
+    """Format a drift percentage. None means the snapshot rate was 0 (the model
+    was free / unpriced), so a ratio is undefined — show that instead of a number."""
+    return "was $0" if pct is None else f"{pct:+.1f}%"
+
+
+def render(result: dict) -> str:
+    """Human-readable report for a run() result."""
+    if result["applied"]:
+        return (
+            "Pricing drift (--apply)\n"
+            f"  Rewrote {result['written']} model(s) in pricing.yaml from core snapshots."
+        )
+    lines = [
+        f"Pricing drift (dry-run, threshold {result['threshold_pct']:.2f}%)",
+        f"  Compared (snapshot + local price): {result['compared']}",
+        f"  In sync:                           {result['in_sync']}",
+        f"  Drifted:                           {len(result['drifted'])}",
+    ]
+    for d in result["drifted"]:
+        lines.append(
+            f"    - {d['model']} ({d['provider']}): "
+            f"input {d['local_input']:.4f} vs {d['snap_input']:.4f} "
+            f"({_fmt_pct(d['input_drift_pct'])}), "
+            f"output {d['local_output']:.4f} vs {d['snap_output']:.4f} "
+            f"({_fmt_pct(d['output_drift_pct'])})"
+        )
+    if result["skipped_subscription"]:
+        lines.append(f"  Skipped (subscription): {len(result['skipped_subscription'])}")
+    if result["no_local_price"]:
+        lines.append(f"  Snapshot but no pricing.yaml entry: {len(result['no_local_price'])}")
+        for n in result["no_local_price"]:
+            lines.append(f"      - {n['model']} ({n['provider']})")
+    # Coverage-gap nudge is DB-wide; only surface it on an unfiltered run so a
+    # scoped --model check doesn't nag about unrelated uncovered models.
+    if result["coverage_gap"] and result["model_filter"] is None:
+        lines.append(
+            f"  ! {result['coverage_gap']} model(s) in llm_calls have NO snapshot — "
+            "run `hermes telemetry pricing backfill --apply` for full coverage."
+        )
+    if result["drifted"]:
+        lines.append(
+            f"  Run with --apply to rewrite {len(result['drifted'])} model(s) in pricing.yaml."
+        )
+    return "\n".join(lines)
+
+
+def to_json(result: dict) -> str:
+    return json.dumps(result, default=str)
 
 
 def _apply_drift(drifted: list[dict]) -> int:

--- a/pricing_drift.py
+++ b/pricing_drift.py
@@ -175,5 +175,50 @@ def to_json(result: dict) -> str:
 
 
 def _apply_drift(drifted: list[dict]) -> int:
-    """Placeholder — implemented in Task 4."""
-    return 0
+    """Write each drifted model's snapshot input/output rates into pricing.yaml.
+
+    Merge (never clobber): load the existing file, update only input/output on the
+    matching (case-insensitive) model entry, tag it _source: core-snapshot, and
+    dump back with sort_keys=False (preserve insertion order). Routes through
+    paths.get_pricing_path() at call time (honors HERMES_TELEMETRY_HOME), then
+    hot-reloads pricing.py's cache. Returns the number of entries written.
+    """
+    if not drifted:
+        return 0
+
+    import yaml
+
+    from . import paths
+
+    path = paths.get_pricing_path()
+    data: dict = {}
+    if path.exists():
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+
+    # New format nests models under "models:"; legacy is a flat model->entry map.
+    models = data.setdefault("models", {}) if "models" in data or "defaults" in data else data
+
+    written = 0
+    for d in drifted:
+        target = d["model"].lower()
+        existing_key = next((k for k in models if str(k).lower() == target), None)
+        if existing_key is not None:
+            entry = models[existing_key]
+            if not isinstance(entry, dict):
+                entry = {}
+                models[existing_key] = entry
+        else:
+            entry = {}
+            models[target] = entry
+        entry["input"] = d["snap_input"]
+        entry["output"] = d["snap_output"]
+        entry["_source"] = "core-snapshot"
+        written += 1
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+    pricing.reload_custom_pricing()
+    return written

--- a/telemetry_cli.py
+++ b/telemetry_cli.py
@@ -184,6 +184,17 @@ def _build_parser_into(sub) -> None:
     pb.add_argument("--apply", action="store_true", help="Write changes (default: dry-run)")
     pb.add_argument("--json", action="store_true", help="Output as JSON")
 
+    pd = psub.add_parser(
+        "drift",
+        help="Compare pricing.yaml against core pricing snapshots",
+    )
+    pd.add_argument("--apply", action="store_true", help="Rewrite pricing.yaml (default: dry-run)")
+    pd.add_argument(
+        "--threshold", type=float, default=1.0, help="Drift threshold in %% (default: 1.0)"
+    )
+    pd.add_argument("--model", default=None, help="Limit to a single canonical model name")
+    pd.add_argument("--json", action="store_true", help="Output as JSON")
+
 
 def main(argv: list[str] | None = None) -> None:
     parser = _build_parser()
@@ -373,6 +384,12 @@ def _handle_pricing(
     if args.pricing_command == "backfill":
         result = pricing_backfill.run(apply=args.apply)
         print(pricing_backfill.to_json(result) if args.json else pricing_backfill.render(result))
+        return
+    if args.pricing_command == "drift":
+        from . import pricing_drift
+
+        result = pricing_drift.run(apply=args.apply, threshold_pct=args.threshold, model=args.model)
+        print(pricing_drift.to_json(result) if args.json else pricing_drift.render(result))
         return
     if parser:
         parser.print_help()

--- a/tests/test_pricing_drift.py
+++ b/tests/test_pricing_drift.py
@@ -1,0 +1,50 @@
+"""hermes telemetry pricing drift — module logic + CLI wiring."""
+
+from __future__ import annotations
+
+import json  # noqa: F401 -- used by later tasks in this plan (CLI --json output)
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_db():
+    import hermes_telemetry.db as db_mod
+
+    db_mod._local.conn = None
+    yield
+    if getattr(db_mod._local, "conn", None):
+        db_mod._local.conn.close()
+        db_mod._local.conn = None
+
+
+import hermes_telemetry.db as db
+import hermes_telemetry.pricing as pricing
+import hermes_telemetry.pricing_drift as pricing_drift  # noqa: F401 -- exercised by later tasks
+
+_NOW = "2026-07-16T00:00:00+00:00"
+
+
+def _snap(inp, out):
+    return {"input_cost_per_million": inp, "output_cost_per_million": out}
+
+
+def _write_pricing_yaml(models: dict):
+    import yaml
+    from hermes_telemetry import paths
+
+    path = paths.get_pricing_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump({"models": models}, f, sort_keys=False)
+    pricing.reload_custom_pricing()
+
+
+def test_list_latest_pricing_snapshots_returns_latest_per_pair():
+    db.record_pricing_snapshot("nous", "m", _snap(1.0, 2.0))
+    db.record_pricing_snapshot("nous", "m", _snap(1.5, 2.5))  # newer → new row
+    rows = db.list_latest_pricing_snapshots()
+    ms = [r for r in rows if r["model"] == "m"]
+    assert len(ms) == 1
+    assert ms[0]["input_cost_per_million"] == 1.5
+    assert ms[0]["output_cost_per_million"] == 2.5

--- a/tests/test_pricing_drift.py
+++ b/tests/test_pricing_drift.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json  # noqa: F401 -- used by later tasks in this plan (CLI --json output)
+import json
 
 import pytest
 
@@ -118,6 +118,7 @@ def test_run_reports_snapshot_without_local_price():
 
 
 def test_run_flags_coverage_gap():
+    _write_pricing_yaml({})
     db.record_llm_call("s1", _NOW, "uncovered/model", "nous", 10, 2, 0.01, 100)
     result = pricing_drift.run(apply=False)
     assert result["coverage_gap"] >= 1
@@ -130,3 +131,56 @@ def test_run_model_filter():
     result = pricing_drift.run(apply=False, model="a")
     assert len(result["drifted"]) == 1
     assert result["drifted"][0]["model"] == "a"
+
+
+def test_drift_pct_none_for_zero_snapshot_and_numeric_otherwise():
+    from hermes_telemetry import pricing_drift as pd
+
+    assert pd._drift_pct(1.0, 0.0) is None
+    assert pd._drift_pct(0.0, 0.0) is None
+    assert pd._drift_pct(1.5, 1.0) == 50.0
+    assert pd._drift_pct(0.5, 1.0) == -50.0
+
+
+def test_is_drift_zero_snapshot_and_threshold_boundary():
+    from hermes_telemetry import pricing_drift as pd
+
+    assert pd._is_drift(1.0, 0.0, 1.0) is True
+    assert pd._is_drift(0.0, 0.0, 1.0) is False
+    assert pd._is_drift(1.01, 1.0, 1.0) is False  # exactly 1.0% is NOT > 1.0%
+    assert pd._is_drift(1.02, 1.0, 1.0) is True
+
+
+def test_run_zero_snapshot_drifts_with_none_pct_and_json_safe():
+    db.record_pricing_snapshot("nous", "m", _snap(0.0, 0.0))
+    _write_pricing_yaml({"m": {"input": 1.0, "output": 2.0}})
+    result = pricing_drift.run(apply=False)
+    assert len(result["drifted"]) == 1
+    d = result["drifted"][0]
+    assert d["input_drift_pct"] is None
+    assert d["output_drift_pct"] is None
+    # JSON-safe: no Infinity token
+    payload = json.loads(json.dumps(result, default=str))
+    assert payload["drifted"][0]["input_drift_pct"] is None
+
+
+def test_run_output_only_drift():
+    db.record_pricing_snapshot("nous", "m", _snap(1.0, 2.0))
+    _write_pricing_yaml({"m": {"input": 1.0, "output": 3.0}})  # input sync, output +50%
+    result = pricing_drift.run(apply=False)
+    assert len(result["drifted"]) == 1
+    assert result["drifted"][0]["output_drift_pct"] == 50.0
+    assert result["in_sync"] == 0
+
+
+def test_run_provider_assumed_routed_to_no_local_price(monkeypatch):
+    db.record_pricing_snapshot("nous", "x", _snap(0.5, 1.0))
+    _write_pricing_yaml({"x": {"input": 1.6, "output": 3.2}})
+    monkeypatch.setattr(
+        pricing,
+        "_resolve_pricing",
+        lambda m, p="": {"input": 1.6, "output": 3.2, "_provider_assumed": True},
+    )
+    result = pricing_drift.run(apply=False)
+    assert {"provider": "nous", "model": "x"} in result["no_local_price"]
+    assert result["drifted"] == []

--- a/tests/test_pricing_drift.py
+++ b/tests/test_pricing_drift.py
@@ -334,3 +334,61 @@ def test_apply_same_model_conflicting_rates_keeps_first(caplog):
         data = yaml.safe_load(f)
     assert data["models"]["m"]["input"] == 0.4  # first kept
     assert "conflicting core rates" in caplog.text
+
+
+def test_cli_pricing_drift_dry_run_default(monkeypatch, capsys):
+    import hermes_telemetry.pricing_drift as pd
+    import hermes_telemetry.telemetry_cli as cli
+
+    captured = {}
+
+    def _fake_run(*, apply, threshold_pct, model):
+        captured.update(apply=apply, threshold_pct=threshold_pct, model=model)
+        return {
+            "applied": apply,
+            "threshold_pct": threshold_pct,
+            "model_filter": model,
+            "compared": 0,
+            "drifted": [],
+            "in_sync": 0,
+            "skipped_subscription": [],
+            "no_local_price": [],
+            "coverage_gap": 0,
+            "written": 0,
+        }
+
+    monkeypatch.setattr(pd, "run", _fake_run)
+    cli.main(["pricing", "drift"])
+    assert captured["apply"] is False
+    assert captured["threshold_pct"] == 1.0
+    assert captured["model"] is None
+    assert "dry-run" in capsys.readouterr().out
+
+
+def test_cli_pricing_drift_apply_json_with_flags(monkeypatch, capsys):
+    import hermes_telemetry.pricing_drift as pd
+    import hermes_telemetry.telemetry_cli as cli
+
+    captured = {}
+
+    def _fake_run(*, apply, threshold_pct, model):
+        captured.update(apply=apply, threshold_pct=threshold_pct, model=model)
+        return {
+            "applied": apply,
+            "threshold_pct": threshold_pct,
+            "model_filter": model,
+            "compared": 1,
+            "drifted": [],
+            "in_sync": 1,
+            "skipped_subscription": [],
+            "no_local_price": [],
+            "coverage_gap": 0,
+            "written": 1,
+        }
+
+    monkeypatch.setattr(pd, "run", _fake_run)
+    cli.main(["pricing", "drift", "--apply", "--threshold", "5", "--model", "m", "--json"])
+    assert captured["apply"] is True
+    assert captured["threshold_pct"] == 5.0
+    assert captured["model"] == "m"
+    assert json.loads(capsys.readouterr().out)["written"] == 1

--- a/tests/test_pricing_drift.py
+++ b/tests/test_pricing_drift.py
@@ -336,6 +336,41 @@ def test_apply_same_model_conflicting_rates_keeps_first(caplog):
     assert "conflicting core rates" in caplog.text
 
 
+def test_apply_skips_and_preserves_malformed_yaml(caplog):
+    import logging
+
+    from hermes_telemetry import paths
+
+    path = paths.get_pricing_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write("models: {m: {input: 1.6, output: 3.2}")  # unclosed flow mapping
+    with caplog.at_level(logging.ERROR, logger="hermes_telemetry.pricing_drift"):
+        written = pricing_drift._apply_drift(
+            [{"provider": "nous", "model": "m", "snap_input": 0.4, "snap_output": 0.8}]
+        )
+    assert written == 0
+    with open(path) as f:
+        assert "input: 1.6" in f.read()  # file left untouched, not clobbered
+
+
+def test_apply_bootstraps_modern_format_when_file_missing():
+    import yaml
+    from hermes_telemetry import paths
+
+    path = paths.get_pricing_path()
+    if path.exists():
+        path.unlink()
+    written = pricing_drift._apply_drift(
+        [{"provider": "nous", "model": "m", "snap_input": 0.4, "snap_output": 0.8}]
+    )
+    assert written == 1
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    assert "models" in data  # modern shape, not a flat map
+    assert data["models"]["m"]["input"] == 0.4
+
+
 def test_cli_pricing_drift_dry_run_default(monkeypatch, capsys):
     import hermes_telemetry.pricing_drift as pd
     import hermes_telemetry.telemetry_cli as cli

--- a/tests/test_pricing_drift.py
+++ b/tests/test_pricing_drift.py
@@ -48,3 +48,16 @@ def test_list_latest_pricing_snapshots_returns_latest_per_pair():
     assert len(ms) == 1
     assert ms[0]["input_cost_per_million"] == 1.5
     assert ms[0]["output_cost_per_million"] == 2.5
+
+
+def test_list_latest_pricing_snapshots_returns_all_pairs():
+    db.record_pricing_snapshot("nous", "a", _snap(1.0, 2.0))
+    db.record_pricing_snapshot("nous", "b", _snap(3.0, 4.0))
+    rows = db.list_latest_pricing_snapshots()
+    pairs = {(r["provider"], r["model"]) for r in rows}
+    assert ("nous", "a") in pairs
+    assert ("nous", "b") in pairs
+
+
+def test_list_latest_pricing_snapshots_empty_returns_empty_list():
+    assert db.list_latest_pricing_snapshots() == []

--- a/tests/test_pricing_drift.py
+++ b/tests/test_pricing_drift.py
@@ -226,3 +226,45 @@ def test_to_json_roundtrips():
     payload = json.loads(pricing_drift.to_json(pricing_drift.run(apply=False)))
     assert len(payload["drifted"]) == 1
     assert payload["drifted"][0]["model"] == "m"
+
+
+def test_apply_rewrites_input_output_and_reloads():
+    db.record_pricing_snapshot("nous", "m", _snap(0.435, 0.87))
+    _write_pricing_yaml({"m": {"input": 1.6, "output": 3.2}})
+    result = pricing_drift.run(apply=True)
+    assert result["written"] == 1
+    # Cache was reloaded → new resolution reflects the snapshot rate.
+    prices = pricing._resolve_pricing("m", "nous")
+    assert prices["input"] == 0.435
+    assert prices["output"] == 0.87
+
+
+def test_apply_tags_source_and_preserves_other_entries():
+    import yaml
+    from hermes_telemetry import paths
+
+    db.record_pricing_snapshot("nous", "m", _snap(0.435, 0.87))
+    _write_pricing_yaml(
+        {"m": {"input": 1.6, "output": 3.2}, "keep/me": {"input": 9.0, "output": 9.0}}
+    )
+    pricing_drift.run(apply=True)
+    with open(paths.get_pricing_path()) as f:
+        data = yaml.safe_load(f)
+    assert data["models"]["m"]["input"] == 0.435
+    assert data["models"]["m"]["output"] == 0.87
+    assert data["models"]["m"]["_source"] == "core-snapshot"
+    # Untouched entry survives the merge.
+    assert data["models"]["keep/me"]["input"] == 9.0
+
+
+def test_apply_does_not_write_subscription_entries():
+    import yaml
+    from hermes_telemetry import paths
+
+    db.record_pricing_snapshot("nous", "sub/model", _snap(5.0, 10.0))
+    _write_pricing_yaml({"sub/model": {"input": 0.0, "output": 0.0, "_subscription": True}})
+    result = pricing_drift.run(apply=True)
+    assert result["written"] == 0
+    with open(paths.get_pricing_path()) as f:
+        data = yaml.safe_load(f)
+    assert data["models"]["sub/model"]["input"] == 0.0  # unchanged

--- a/tests/test_pricing_drift.py
+++ b/tests/test_pricing_drift.py
@@ -184,3 +184,45 @@ def test_run_provider_assumed_routed_to_no_local_price(monkeypatch):
     result = pricing_drift.run(apply=False)
     assert {"provider": "nous", "model": "x"} in result["no_local_price"]
     assert result["drifted"] == []
+
+
+def test_render_dry_run_lists_drift_and_coverage_hint():
+    db.record_pricing_snapshot("nous", "deepseek/deepseek-v4-pro", _snap(0.435, 0.87))
+    _write_pricing_yaml({"deepseek/deepseek-v4-pro": {"input": 1.6, "output": 3.2}})
+    db.record_llm_call("s1", _NOW, "uncovered/model", "nous", 10, 2, 0.01, 100)
+    text = pricing_drift.render(pricing_drift.run(apply=False))
+    assert "dry-run" in text
+    assert "deepseek/deepseek-v4-pro" in text
+    assert "backfill" in text  # coverage-gap hint present on unfiltered run
+    assert "--apply" in text
+
+
+def test_render_zero_snapshot_shows_was_0_not_crash():
+    db.record_pricing_snapshot("nous", "m", _snap(0.0, 0.0))
+    _write_pricing_yaml({"m": {"input": 1.0, "output": 2.0}})
+    text = pricing_drift.render(pricing_drift.run(apply=False))
+    assert "was $0" in text  # None pct rendered safely, no format crash
+
+
+def test_render_coverage_hint_suppressed_when_model_filtered():
+    db.record_pricing_snapshot("nous", "a", _snap(0.435, 0.87))
+    _write_pricing_yaml({"a": {"input": 1.6, "output": 3.2}})
+    db.record_llm_call("s1", _NOW, "uncovered/model", "nous", 10, 2, 0.01, 100)
+    text = pricing_drift.render(pricing_drift.run(apply=False, model="a"))
+    assert "backfill" not in text  # scoped run must not nag about unrelated models
+
+
+def test_render_apply_summary():
+    db.record_pricing_snapshot("nous", "m", _snap(0.435, 0.87))
+    _write_pricing_yaml({"m": {"input": 1.6, "output": 3.2}})
+    text = pricing_drift.render(pricing_drift.run(apply=True))
+    assert "--apply" in text
+    assert "pricing.yaml" in text
+
+
+def test_to_json_roundtrips():
+    db.record_pricing_snapshot("nous", "m", _snap(0.435, 0.87))
+    _write_pricing_yaml({"m": {"input": 1.6, "output": 3.2}})
+    payload = json.loads(pricing_drift.to_json(pricing_drift.run(apply=False)))
+    assert len(payload["drifted"]) == 1
+    assert payload["drifted"][0]["model"] == "m"

--- a/tests/test_pricing_drift.py
+++ b/tests/test_pricing_drift.py
@@ -20,7 +20,7 @@ def isolated_db():
 
 import hermes_telemetry.db as db
 import hermes_telemetry.pricing as pricing
-import hermes_telemetry.pricing_drift as pricing_drift  # noqa: F401 -- exercised by later tasks
+import hermes_telemetry.pricing_drift as pricing_drift
 
 _NOW = "2026-07-16T00:00:00+00:00"
 
@@ -61,3 +61,72 @@ def test_list_latest_pricing_snapshots_returns_all_pairs():
 
 def test_list_latest_pricing_snapshots_empty_returns_empty_list():
     assert db.list_latest_pricing_snapshots() == []
+
+
+def test_run_detects_drift_on_input_and_output():
+    db.record_pricing_snapshot("nous", "deepseek/deepseek-v4-pro", _snap(0.435, 0.87))
+    _write_pricing_yaml({"deepseek/deepseek-v4-pro": {"input": 1.6, "output": 3.2}})
+    result = pricing_drift.run(apply=False)
+    assert len(result["drifted"]) == 1
+    d = result["drifted"][0]
+    assert d["model"] == "deepseek/deepseek-v4-pro"
+    assert d["provider"] == "nous"
+    assert d["snap_input"] == 0.435
+    assert d["local_input"] == 1.6
+    assert d["snap_output"] == 0.87
+    assert d["local_output"] == 3.2
+    assert result["written"] == 0
+    assert result["in_sync"] == 0
+
+
+def test_run_within_threshold_is_in_sync():
+    db.record_pricing_snapshot("nous", "m", _snap(1.0, 2.0))
+    _write_pricing_yaml({"m": {"input": 1.005, "output": 2.0}})  # 0.5% < 1%
+    result = pricing_drift.run(apply=False, threshold_pct=1.0)
+    assert result["drifted"] == []
+    assert result["in_sync"] == 1
+    assert result["compared"] == 1
+
+
+def test_run_skips_subscription_entries():
+    db.record_pricing_snapshot("nous", "sub/model", _snap(5.0, 10.0))
+    _write_pricing_yaml({"sub/model": {"input": 0.0, "output": 0.0, "_subscription": True}})
+    result = pricing_drift.run(apply=False)
+    assert result["drifted"] == []
+    assert {"provider": "nous", "model": "sub/model"} in result["skipped_subscription"]
+
+
+def test_run_collapses_dated_to_canonical():
+    db.record_pricing_snapshot(
+        "nous",
+        "deepseek/deepseek-v4-pro-20260423",
+        _snap(0.435, 0.87),
+        resolved_model="deepseek/deepseek-v4-pro",
+    )
+    _write_pricing_yaml({"deepseek/deepseek-v4-pro": {"input": 1.6, "output": 3.2}})
+    result = pricing_drift.run(apply=False)
+    assert len(result["drifted"]) == 1
+    assert result["drifted"][0]["model"] == "deepseek/deepseek-v4-pro"
+
+
+def test_run_reports_snapshot_without_local_price():
+    db.record_pricing_snapshot("nous", "ghost/model", _snap(1.0, 2.0))
+    _write_pricing_yaml({})  # empty pricing.yaml
+    result = pricing_drift.run(apply=False)
+    assert {"provider": "nous", "model": "ghost/model"} in result["no_local_price"]
+    assert result["drifted"] == []
+
+
+def test_run_flags_coverage_gap():
+    db.record_llm_call("s1", _NOW, "uncovered/model", "nous", 10, 2, 0.01, 100)
+    result = pricing_drift.run(apply=False)
+    assert result["coverage_gap"] >= 1
+
+
+def test_run_model_filter():
+    db.record_pricing_snapshot("nous", "a", _snap(0.435, 0.87))
+    db.record_pricing_snapshot("nous", "b", _snap(0.435, 0.87))
+    _write_pricing_yaml({"a": {"input": 1.6, "output": 3.2}, "b": {"input": 1.6, "output": 3.2}})
+    result = pricing_drift.run(apply=False, model="a")
+    assert len(result["drifted"]) == 1
+    assert result["drifted"][0]["model"] == "a"

--- a/tests/test_pricing_drift.py
+++ b/tests/test_pricing_drift.py
@@ -268,3 +268,69 @@ def test_apply_does_not_write_subscription_entries():
     with open(paths.get_pricing_path()) as f:
         data = yaml.safe_load(f)
     assert data["models"]["sub/model"]["input"] == 0.0  # unchanged
+
+
+def test_apply_creates_new_entry_when_model_absent():
+    import yaml
+    from hermes_telemetry import paths
+
+    _write_pricing_yaml({})  # empty models map
+    written = pricing_drift._apply_drift(
+        [{"provider": "nous", "model": "brand/new", "snap_input": 0.4, "snap_output": 0.8}]
+    )
+    assert written == 1
+    with open(paths.get_pricing_path()) as f:
+        data = yaml.safe_load(f)
+    assert data["models"]["brand/new"]["input"] == 0.4
+    assert data["models"]["brand/new"]["output"] == 0.8
+    assert data["models"]["brand/new"]["_source"] == "core-snapshot"
+
+
+def test_apply_updates_legacy_flat_format_in_place():
+    import yaml
+    from hermes_telemetry import paths
+
+    path = paths.get_pricing_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump({"m": {"input": 1.6, "output": 3.2}}, f)  # legacy flat: no models/defaults
+    pricing.reload_custom_pricing()
+    written = pricing_drift._apply_drift(
+        [{"provider": "nous", "model": "m", "snap_input": 0.4, "snap_output": 0.8}]
+    )
+    assert written == 1
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    assert data["m"]["input"] == 0.4  # updated in the flat map
+    assert "models" not in data
+
+
+def test_apply_same_model_two_providers_writes_once():
+    written = pricing_drift._apply_drift(
+        [
+            {"provider": "nous", "model": "m", "snap_input": 0.4, "snap_output": 0.8},
+            {"provider": "openrouter", "model": "m", "snap_input": 0.4, "snap_output": 0.8},
+        ]
+    )
+    assert written == 1  # same model+rates → written once, not double-counted
+
+
+def test_apply_same_model_conflicting_rates_keeps_first(caplog):
+    import logging
+
+    import yaml
+    from hermes_telemetry import paths
+
+    _write_pricing_yaml({})
+    with caplog.at_level(logging.WARNING, logger="hermes_telemetry.pricing_drift"):
+        written = pricing_drift._apply_drift(
+            [
+                {"provider": "nous", "model": "m", "snap_input": 0.4, "snap_output": 0.8},
+                {"provider": "openrouter", "model": "m", "snap_input": 0.9, "snap_output": 1.8},
+            ]
+        )
+    assert written == 1
+    with open(paths.get_pricing_path()) as f:
+        data = yaml.safe_load(f)
+    assert data["models"]["m"]["input"] == 0.4  # first kept
+    assert "conflicting core rates" in caplog.text


### PR DESCRIPTION
## Summary

Adds `hermes telemetry pricing drift` — compares the plugin's cost source
(`pricing.yaml`) against the core-resolved `pricing_snapshots` (ground truth) and,
on `--apply`, rewrites the drifted rates back into `pricing.yaml`. Motivating case:
an over-priced local entry silently inflating cost (the Faro/Nous incident where
`pricing.yaml` priced a model ~3.7× the core's real rate).

## What it does

- **Dry-run by default**; reports each model whose `pricing.yaml` input/output rate
  drifts from its latest core snapshot beyond `--threshold` (default 1%).
- **`--apply`** merges the core rates back into `pricing.yaml` (never clobbers),
  tags each repaired entry `_source: core-snapshot`, and hot-reloads.
- **Input/output only** — cache/reasoning are derived and `request_cost` has no
  `pricing.yaml` analog, so they're intentionally excluded.
- Skips `_subscription: true` entries (a declared $0 is intentional) and treats
  `_provider_assumed` best-effort guesses as "no local price", not drift.
- **Coverage-gap aware**: if models in `llm_calls` lack any snapshot, the report
  points at `pricing backfill` so a clean drift run isn't a false all-clear.
- `--model` scopes to one canonical model; `--json` for machine output.
- **No schema change** — reads `pricing_snapshots`, reads/writes `pricing.yaml`.

## Implementation

- `db.list_latest_pricing_snapshots()` — latest snapshot per `(provider, model)`.
- `pricing_drift.py` — `run()` / `render()` / `to_json()` / `_apply_drift()`,
  mirroring `pricing_backfill.py`. Dated ids collapse to the canonical write-key
  (`resolved_model or model`); same-model multi-provider writes dedupe (first wins,
  conflict logged); malformed `pricing.yaml` degrades gracefully (skips, never
  clobbers).
- CLI wiring in `telemetry_cli.py`; docs in `ONBOARDING.md` and `README.md`
  (the latter also backfills the previously-undocumented `pricing backfill`).

## Test plan

- [x] `ruff format --check . && ruff check . && pytest tests/ -v` → 575 passed, 6 skipped
- [x] 31 tests in `tests/test_pricing_drift.py` (real SQLite + real `pricing.yaml`,
      no mocks): drift detection, threshold boundary, zero-snapshot, output-only
      drift, subscription skip, `_provider_assumed` routing, dated→canonical
      collapse, coverage-gap, multi-provider dedupe/conflict, apply write-back,
      new-entry creation, legacy flat format, malformed-YAML safety, CLI parsing.
- [x] Manual CLI smoke: `pricing drift` / `pricing drift --json` parse and run.

## Follow-ups (not in this PR)

- `pricing_refresh.PRICING_FILE` resolves from `HERMES_HOME` directly (bypasses
  `HERMES_TELEMETRY_HOME` via `paths.get_pricing_path()`) — pre-existing latent
  bug, deliberately not touched here to avoid coupling.
- Surfacing pricing snapshots / drift in the dashboard (`TelemetryPage`).