### PR TITLE
fix(pricing): honor HERMES_TELEMETRY_HOME in pricing_refresh

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -786,10 +786,20 @@ case) surfaces instead of silently inflating cost:
   core-snapshot`, and hot-reloads. Because `pricing.yaml` is keyed by model only,
   a model that drifted under two providers is written once (first wins; a
   conflicting second rate is logged and skipped). Routes through
-  `paths.get_pricing_path()` (not `HERMES_HOME`-direct like
-  `pricing_refresh.PRICING_FILE`, whose latent bug is a separate follow-up).
+  `paths.get_pricing_path()` (resolved at call time, so `HERMES_TELEMETRY_HOME`
+  outranks `HERMES_HOME` — same as every other pricing.yaml reader/writer).
   `--model` limits to one canonical model; `--json` for machine output. No schema
   change.
+
+Note: `pricing_refresh.py` (the remote-source auto-refresh) previously used a
+module-level `PRICING_FILE` constant computed from `HERMES_HOME` at import time —
+it ignored `HERMES_TELEMETRY_HOME` and could freeze a stale path. Fixed to resolve
+`paths.get_pricing_path()` at call time, matching `pricing.py` and `pricing_drift`.
+Remaining follow-up: `__init__.py::_try_pricing_refresh` still derives its 24h
+`.pricing_refresh` throttle sentinel from `HERMES_HOME` directly, so on a
+consolidated (`HERMES_TELEMETRY_HOME`) install each profile keeps its own timer and
+may trigger redundant remote refreshes — harmless (all merge into the one shared
+file), but should also route through `paths.get_telemetry_home()`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A comprehensive telemetry plugin that captures real usage data, enforces budget 
 
 [![Hermes Agent](https://raw.githubusercontent.com/NousResearch/hermes-agent/HEAD/assets/banner.png)](https://raw.githubusercontent.com/NousResearch/hermes-agent/HEAD/assets/banner.png)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://camo.githubusercontent.com/08cef40a9105b6526ca22088bc514fbfdbc9aac1ddbf8d4e6c750e3a88a44dca/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4c6963656e73652d4d49542d626c75652e737667) [![Tests: 263 passing](https://img.shields.io/badge/Tests-263%20passing-green.svg)](https://img.shields.io/badge/Tests-263%20passing-green.svg) [![Provider Support](https://img.shields.io/badge/Providers-OpenRouter-orange.svg)](https://img.shields.io/badge/Providers-OpenRouter-orange.svg) [![Challenge Entry](https://img.shields.io/badge/Hermes%20Agent-Challenge%20Entry-purple.svg)](https://camo.githubusercontent.com/d0c993fdf35127e435629279025d4b1892e351f5e04ce1547329686aa4223366/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4865726d65732532304167656e742d4368616c6c656e6765253230456e7472792d707572706c652e737667)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://camo.githubusercontent.com/08cef40a9105b6526ca22088bc514fbfdbc9aac1ddbf8d4e6c750e3a88a44dca/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4c6963656e73652d4d49542d626c75652e737667) [![Tests: 587 passing](https://img.shields.io/badge/Tests-587%20passing-green.svg)](https://img.shields.io/badge/Tests-587%20passing-green.svg) [![Provider Support](https://img.shields.io/badge/Providers-OpenRouter-orange.svg)](https://img.shields.io/badge/Providers-OpenRouter-orange.svg) [![Challenge Entry](https://img.shields.io/badge/Hermes%20Agent-Challenge%20Entry-purple.svg)](https://camo.githubusercontent.com/d0c993fdf35127e435629279025d4b1892e351f5e04ce1547329686aa4223366/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4865726d65732532304167656e742d4368616c6c656e6765253230456e7472792d707572706c652e737667)
 
 -----
 
@@ -1338,7 +1338,7 @@ global    $0.1812 / $2.00    9%  [daily]
 |Pricing auto-refresh (OpenRouter API)|✅ 320 models fetched, manual overrides preserved   |
 |Estimated-price model handling       |✅ Negative prices → $0.00, budget degradation      |
 |Dashboard (HTML, auto-refresh 30s)   |✅ Charts, tables, budget bar, provider distribution|
-|263 tests pass                       |✅                                                  |
+|587 tests pass                       |✅                                                  |
 
 -----
 
@@ -1365,23 +1365,38 @@ pip install pytest pyyaml
 pytest tests/ -v
 ```
 
-**Test suite (263 tests):**
+**Test suite (593 tests, 587 passing + 6 skipped):**
 
 |File                             |Tests|Coverage                                                                                                                       |
 |---------------------------------|-----|-------------------------------------------------------------------------------------------------------------------------------|
-|`test_pricing.py`                |61   |Cache/reasoning split, no double-counting of `prompt_tokens`, YAML overrides, prefix matching, provider-aware source guard, NIM seeds (incl. `nemotron-3-ultra` paid + `:free` suffix → $0 rule), subscription tag, unknown model handling, `is_explicitly_priced`, `get_known_free_models`|
-|`test_telemetry_cli.py`          |32   |CLI subcommands (stats/budget), all window variants, text + `--json` output, entry point smoke test                            |
-|`test_db.py`                     |45   |Schema v1→v5 migrations, CRUD, aggregations, concurrent WAL writes (10 threads × 5 writes), `known_free_models` CRUD, `backfill_known_free_models`, `is_free_tier_transition` (id-change detection)|
+|`test_db.py`                     |114  |Schema migrations (v1→v16), CRUD, aggregations, concurrent WAL writes, `known_free_models`, pricing snapshots, subagent edges, cache layer|
+|`test_pricing.py`                |67   |Cache/reasoning split, no double-counting of `prompt_tokens`, YAML overrides, prefix matching, provider-aware source guard, NIM seeds (incl. `nemotron-3-ultra` paid + `:free` suffix → $0 rule), subscription tag, unknown model handling, `is_explicitly_priced`, `get_known_free_models`|
+|`test_dashboard.py`              |45   |HTML dashboard rendering, auto-refresh, chart data endpoints, viewer-timezone budget windows, cache layer (TTL / serve-stale)  |
+|`test_telemetry_cli.py`          |34   |CLI subcommands (stats/budget/pricing/sync-profiles), all window variants, text + `--json` output, entry point smoke test      |
+|`test_dashboard_plugin_api.py`   |33   |Plugin dashboard API: per-profile scoping clauses, efficiency/smells/budget endpoints                                          |
+|`test_pricing_drift.py`          |31   |Drift vs core snapshots: threshold, subscription skip, canonical collapse, provider-assumed routing, `--apply` write-back, malformed-YAML safety, CLI|
+|`test_sync_profiles.py`          |29   |Profile consolidation via `HERMES_TELEMETRY_HOME`: `.env` upsert, name scoping, template preservation                          |
+|`test_budget.py`                 |28   |ok/soft/hard verdicts, estimated-to-soft degradation, anti-spam ledger, cron pause, per-scope routing, `/budget set` hot-reload|
+|`test_stats_smells.py`           |22   |Anti-pattern (smell) detection and scoring                                                                                     |
 |`test_setup.py`                  |21   |First-time setup wizard, pricing/budget file generation, interactive + non-interactive paths                                   |
-|`test_dashboard.py`              |21   |HTML dashboard rendering, auto-refresh, chart data endpoints, viewer-timezone budget windows                                   |
-|`test_budget.py`                 |20   |ok/soft/hard verdicts, estimated-to-soft degradation, anti-spam ledger, cron pause, per-scope routing, `/budget set` hot-reload|
+|`test_pricing_snapshots.py`      |21   |Core-sourced pricing snapshots: append-per-change, `resolved_model` canonicalization, capture throttle                         |
+|`test_init.py`                   |19   |Cron session ID regex, tool success/failure parsing, free→paid transition alert (detection, queueing, injection, backfill)     |
+|`test_stats_models.py`           |18   |Per-model breakdown, `/stats models` output format                                                                             |
+|`test_subagent_reconciliation.py`|15   |Parent + child hook sequence, token reconciliation, no double-counting                                                         |
+|`test_pricing_refresh.py`        |15   |Auto-refresh from OpenRouter API, change detection, manual override preservation, subscription-model metadata, `HERMES_TELEMETRY_HOME` resolution|
 |`test_stats_providers.py`        |14   |Real vs estimated per provider, `/stats providers` output format, Nous warning dedup                                           |
-|`test_pricing_refresh.py`        |14   |Auto-refresh from OpenRouter API, change detection, manual override preservation, subscription-model metadata                  |
-|`test_init.py`                   |13   |Cron session ID regex, tool success/failure parsing, free→paid transition alert (detection, queueing, injection, backfill)     |
-|`test_subagent_reconciliation.py`|9    |Parent + child hook sequence, token reconciliation, no double-counting                                                         |
-|`test_stats_models.py`           |8    |Per-model breakdown, `/stats models` output format                                                                             |
+|`test_stats_efficiency.py`       |12   |Per-session efficiency scoring (0–100)                                                                                         |
+|`test_moa.py`                    |11   |Mixture-of-Agents (MoA) telemetry capture                                                                                      |
+|`test_sync_profiles_cli.py`      |7    |`sync-profiles` CLI wiring, dry-run + `--apply`                                                                                |
+|`test_pricing_backfill.py`       |7    |Seed pricing snapshots for historical models (coverage seed, fail-open, idempotent)                                            |
+|`test_paths.py`                  |6    |Telemetry path resolution precedence: `HERMES_TELEMETRY_HOME` > `HERMES_HOME` > `~/.hermes`                                     |
+|`test_dashboard_plugin_isolation.py`|6 |Enforces zero shared Python code between the two dashboard surfaces                                                             |
+|`test_isolation.py`              |5    |`HERMES_HOME` redirect, no writes to real `~/.hermes`                                                                          |
 |`test_pricing_hot_reload.py`     |3    |In-process cache invalidation on pricing update                                                                                |
-|`test_isolation.py`              |2    |HERMES_HOME redirect, no writes to real `~/.hermes`                                                                            |
+|`test_moa_integration.py`        |3    |MoA end-to-end integration                                                                                                     |
+|`test_budget_per_profile.py`     |3    |Per-profile budget scoping                                                                                                     |
+|`test_profile_capture.py`        |2    |Per-profile attribution capture                                                                                                |
+|`test_logging_isolation.py`      |2    |Plugin logger state isolation between tests                                                                                    |
 
 No live Hermes is required — all tests are self-contained with in-memory SQLite.
 

--- a/pricing_refresh.py
+++ b/pricing_refresh.py
@@ -13,17 +13,17 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
+try:
+    from . import paths
+except ImportError:  # pragma: no cover - pricing_refresh loaded standalone (no package context)
+    import paths
 
-PRICING_FILE = (
-    Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "telemetry" / "pricing.yaml"
-)
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -222,7 +222,11 @@ def refresh_pricing(dry_run: bool = False) -> tuple[dict[str, dict], list[dict]]
         changes: {model: {old, new, source}}
         manual_overrides: [{model, local_input, remote_input, local_output, remote_output}]
     """
-    existing = _load_yaml(PRICING_FILE)
+    # Resolve at call time (not import time) via paths so HERMES_TELEMETRY_HOME
+    # outranks HERMES_HOME — a module-level constant froze the wrong path and
+    # ignored the consolidated cost-center dir.
+    pricing_file = paths.get_pricing_path()
+    existing = _load_yaml(pricing_file)
     existing_models = existing.get("models", {})
     defaults = existing.get(
         "defaults", {"cache_read_multiplier": 0.10, "cache_write_multiplier": 1.25}
@@ -313,7 +317,7 @@ def refresh_pricing(dry_run: bool = False) -> tuple[dict[str, dict], list[dict]]
     existing["_meta"] = meta
 
     if not dry_run and changes:
-        _save_yaml(PRICING_FILE, existing)
+        _save_yaml(pricing_file, existing)
         logger.info("pricing.yaml updated: %d changes", len(changes))
     elif dry_run:
         logger.info("dry-run: %d changes would be made", len(changes))

--- a/tests/test_pricing_refresh.py
+++ b/tests/test_pricing_refresh.py
@@ -179,9 +179,11 @@ def test_manual_subscription_entry_survives_refresh(tmp_path, monkeypatch):
     it in _meta.subscription_models — not in estimated_price_models."""
     import yaml
 
+    import paths
     import pricing_refresh
 
-    pfile = tmp_path / "pricing.yaml"
+    pfile = paths.get_pricing_path()
+    pfile.parent.mkdir(parents=True, exist_ok=True)
     pfile.write_text(
         yaml.safe_dump(
             {
@@ -192,7 +194,6 @@ def test_manual_subscription_entry_survives_refresh(tmp_path, monkeypatch):
             }
         )
     )
-    monkeypatch.setattr(pricing_refresh, "PRICING_FILE", pfile)
     # OpenRouter returns the PREFIXED form — a different key, so no collision.
     monkeypatch.setattr(
         pricing_refresh,
@@ -213,3 +214,36 @@ def test_manual_subscription_entry_survives_refresh(tmp_path, monkeypatch):
     # Meta classifies the subscription model correctly
     assert "qwen3.7-plus" in meta["subscription_models"]
     assert "qwen3.7-plus" not in meta.get("estimated_price_models", [])
+
+
+def test_refresh_pricing_honors_telemetry_home_over_hermes_home(tmp_path, monkeypatch):
+    """refresh_pricing must resolve pricing.yaml via paths.get_pricing_path(),
+    honoring HERMES_TELEMETRY_HOME over HERMES_HOME. Regression: it wrote to a
+    module-level PRICING_FILE computed from HERMES_HOME at import time, so a set
+    HERMES_TELEMETRY_HOME (the consolidated cost-center dir used to unify profiles
+    on the VPS) was silently ignored and refresh landed in the wrong file."""
+    import yaml
+
+    import paths
+    import pricing_refresh
+
+    hermes_home = tmp_path / "hermes_home"
+    telemetry_home = tmp_path / "telemetry_home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_TELEMETRY_HOME", str(telemetry_home))
+
+    monkeypatch.setattr(
+        pricing_refresh,
+        "_SOURCES",
+        [_StubSource({"acme/model-x": {"input": 1.0, "output": 2.0}})],
+    )
+
+    pricing_refresh.refresh_pricing()
+
+    # HERMES_TELEMETRY_HOME outranks HERMES_HOME → refresh must write here.
+    target = telemetry_home / "telemetry" / "pricing.yaml"
+    assert target == paths.get_pricing_path()
+    assert target.exists()
+    assert yaml.safe_load(target.read_text())["models"]["acme/model-x"]["input"] == 1.0
+    # ...and must NOT write to the HERMES_HOME location.
+    assert not (hermes_home / "telemetry" / "pricing.yaml").exists()


### PR DESCRIPTION
## Problem

`pricing_refresh.py` resolved its target file via a **module-level constant computed at import time**:

```python
PRICING_FILE = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "telemetry" / "pricing.yaml"
```

Two bugs in one line:
1. **Ignores `HERMES_TELEMETRY_HOME`**, which per `paths.py` (and the File Isolation Rule in CLAUDE.md) **outranks** `HERMES_HOME`. On a consolidated install — e.g. the prod VPS where profiles are unified via `HERMES_TELEMETRY_HOME` (sync-profiles) — the auto-refresh would write to the wrong per-profile `pricing.yaml`, silently, while the cost path reads the consolidated one.
2. **Import-time constant** can freeze a stale path and can't reflect a later env change (a test-isolation trap).

Every other `pricing.yaml` reader/writer (`pricing.py::_load_custom_pricing`, and the recently-added `pricing_drift._apply_drift`) already resolves `paths.get_pricing_path()` at **call time**. `pricing_refresh` was the outlier.

## Fix

- Remove `PRICING_FILE` (and the now-unused `import os`); add the dual-import of `paths` (`try: from . import paths / except ImportError: import paths`) mirroring `pricing.py`.
- `refresh_pricing()` resolves `pricing_file = paths.get_pricing_path()` at call time and uses it for both load and save.

## Tests

- **New** `test_refresh_pricing_honors_telemetry_home_over_hermes_home`: sets both env vars, asserts refresh writes to the `HERMES_TELEMETRY_HOME` location and **not** the `HERMES_HOME` one. Confirmed RED against the old code, GREEN after.
- **Updated** `test_manual_subscription_entry_survives_refresh`: it used to `monkeypatch.setattr(PRICING_FILE, ...)`, which **masked** the bug; now it writes to `paths.get_pricing_path()` — exercising the real resolution.
- Full suite: **587 passed, 6 skipped**; ruff clean.

## Scope / follow-up

Deliberately **not** in this PR: `__init__.py::_try_pricing_refresh` still derives its 24h `.pricing_refresh` throttle sentinel from `HERMES_HOME` directly. Impact is limited to redundant remote refreshes per profile on a consolidated install (all merge into the one shared file — no wrong-file write, no corruption). It needs its own `paths`-based resolution and is documented as a follow-up in `ONBOARDING.md`.

No schema change.