### PR TITLE
feat(budget): support profile scope in 'budget set' (chat + CLI)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -837,6 +837,20 @@ safe because spend only changes when a new `post_api_request` is recorded
 The cache is keyed by `(scope, scope_id)`. A `reload_config()` call clears it
 (e.g., after `/budget set`).
 
+### Setting budgets (`/budget set`)
+
+`_set_budget(scope, window, usd, scope_id="")` persists a limit to `budget.yaml`
+and hot-reloads. With a `scope_id` it writes `per_<scope>.overrides.<id>`; without
+one it writes the scope's shared `default` bucket. `global` takes no id. The
+id-override form is **generic** across `cron_job` / `sender` / `profile` — the read
+side (`_resolve_limits`) already resolved `overrides.<id> or default` for all of
+them, so `set` just fills the same shape. Surface asymmetry (intentional): the chat
+form takes the id as a positional after the scope
+(`/budget set <scope> [<id>] <window> <usd>`), while the standalone CLI uses a
+`--id` flag — argparse can't express an optional *middle* positional, and the CLI
+already validates `window`/`usd` as typed positionals. Writes are atomic (temp
+file + `os.replace`), then `reload_config()` clears the verdict cache.
+
 ### Anti-spam ledger (`budget_alerts` table)
 
 Soft alerts fire **once per window per scope** — not on every `pre_llm_call`.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A comprehensive telemetry plugin that captures real usage data, enforces budget 
 
 [![Hermes Agent](https://raw.githubusercontent.com/NousResearch/hermes-agent/HEAD/assets/banner.png)](https://raw.githubusercontent.com/NousResearch/hermes-agent/HEAD/assets/banner.png)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://camo.githubusercontent.com/08cef40a9105b6526ca22088bc514fbfdbc9aac1ddbf8d4e6c750e3a88a44dca/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4c6963656e73652d4d49542d626c75652e737667) [![Tests: 587 passing](https://img.shields.io/badge/Tests-587%20passing-green.svg)](https://img.shields.io/badge/Tests-587%20passing-green.svg) [![Provider Support](https://img.shields.io/badge/Providers-OpenRouter-orange.svg)](https://img.shields.io/badge/Providers-OpenRouter-orange.svg) [![Challenge Entry](https://img.shields.io/badge/Hermes%20Agent-Challenge%20Entry-purple.svg)](https://camo.githubusercontent.com/d0c993fdf35127e435629279025d4b1892e351f5e04ce1547329686aa4223366/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4865726d65732532304167656e742d4368616c6c656e6765253230456e7472792d707572706c652e737667)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://camo.githubusercontent.com/08cef40a9105b6526ca22088bc514fbfdbc9aac1ddbf8d4e6c750e3a88a44dca/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4c6963656e73652d4d49542d626c75652e737667) [![Tests: 594 passing](https://img.shields.io/badge/Tests-594%20passing-green.svg)](https://img.shields.io/badge/Tests-594%20passing-green.svg) [![Provider Support](https://img.shields.io/badge/Providers-OpenRouter-orange.svg)](https://img.shields.io/badge/Providers-OpenRouter-orange.svg) [![Challenge Entry](https://img.shields.io/badge/Hermes%20Agent-Challenge%20Entry-purple.svg)](https://camo.githubusercontent.com/d0c993fdf35127e435629279025d4b1892e351f5e04ce1547329686aa4223366/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4865726d65732532304167656e742d4368616c6c656e6765253230456e7472792d707572706c652e737667)
 
 -----
 
@@ -754,8 +754,15 @@ for every threshold.
 /budget set global daily 5.00       → set or raise a limit (persists + hot-reloads)
 /budget set cron_job daily 1.00     → set default per-cron-job limit
 /budget set sender daily 2.00       → set default per-sender limit
+/budget set profile daily 2.00      → set default per-profile limit
+/budget set profile faro monthly 50 → set a per-profile override (id after scope; optional)
 /budget forecast [daily|monthly] [scope] [id]  → project burn rate toward the limit
 ```
+
+`set` takes an optional id after the scope (`set <scope> [<id>] <window> <usd>`): with
+an id it writes a `per_<scope>.overrides.<id>` entry, without one it writes the scope's
+`default` bucket. `global` takes no id. On the standalone CLI the id is a flag:
+`hermes-telemetry budget set profile monthly 50 --id faro`.
 
 `forecast` defaults to the `monthly` window and the `global` scope. It learns a
 recent daily spend rate (moving average over the last 14 days), projects spend
@@ -1338,7 +1345,7 @@ global    $0.1812 / $2.00    9%  [daily]
 |Pricing auto-refresh (OpenRouter API)|✅ 320 models fetched, manual overrides preserved   |
 |Estimated-price model handling       |✅ Negative prices → $0.00, budget degradation      |
 |Dashboard (HTML, auto-refresh 30s)   |✅ Charts, tables, budget bar, provider distribution|
-|587 tests pass                       |✅                                                  |
+|594 tests pass                       |✅                                                  |
 
 -----
 
@@ -1365,18 +1372,18 @@ pip install pytest pyyaml
 pytest tests/ -v
 ```
 
-**Test suite (593 tests, 587 passing + 6 skipped):**
+**Test suite (600 tests, 594 passing + 6 skipped):**
 
 |File                             |Tests|Coverage                                                                                                                       |
 |---------------------------------|-----|-------------------------------------------------------------------------------------------------------------------------------|
 |`test_db.py`                     |114  |Schema migrations (v1→v16), CRUD, aggregations, concurrent WAL writes, `known_free_models`, pricing snapshots, subagent edges, cache layer|
 |`test_pricing.py`                |67   |Cache/reasoning split, no double-counting of `prompt_tokens`, YAML overrides, prefix matching, provider-aware source guard, NIM seeds (incl. `nemotron-3-ultra` paid + `:free` suffix → $0 rule), subscription tag, unknown model handling, `is_explicitly_priced`, `get_known_free_models`|
 |`test_dashboard.py`              |45   |HTML dashboard rendering, auto-refresh, chart data endpoints, viewer-timezone budget windows, cache layer (TTL / serve-stale)  |
-|`test_telemetry_cli.py`          |34   |CLI subcommands (stats/budget/pricing/sync-profiles), all window variants, text + `--json` output, entry point smoke test      |
+|`test_telemetry_cli.py`          |35   |CLI subcommands (stats/budget/pricing/sync-profiles), all window variants, text + `--json` output, entry point smoke test      |
+|`test_budget.py`                 |34   |ok/soft/hard verdicts, estimated-to-soft degradation, anti-spam ledger, cron pause, per-scope routing, `/budget set` (default + per-profile/id override) hot-reload|
 |`test_dashboard_plugin_api.py`   |33   |Plugin dashboard API: per-profile scoping clauses, efficiency/smells/budget endpoints                                          |
 |`test_pricing_drift.py`          |31   |Drift vs core snapshots: threshold, subscription skip, canonical collapse, provider-assumed routing, `--apply` write-back, malformed-YAML safety, CLI|
 |`test_sync_profiles.py`          |29   |Profile consolidation via `HERMES_TELEMETRY_HOME`: `.env` upsert, name scoping, template preservation                          |
-|`test_budget.py`                 |28   |ok/soft/hard verdicts, estimated-to-soft degradation, anti-spam ledger, cron pause, per-scope routing, `/budget set` hot-reload|
 |`test_stats_smells.py`           |22   |Anti-pattern (smell) detection and scoring                                                                                     |
 |`test_setup.py`                  |21   |First-time setup wizard, pricing/budget file generation, interactive + non-interactive paths                                   |
 |`test_pricing_snapshots.py`      |21   |Core-sourced pricing snapshots: append-per-change, `resolved_model` canonicalization, capture throttle                         |

--- a/__init__.py
+++ b/__init__.py
@@ -778,8 +778,8 @@ def register(ctx) -> None:  # noqa: ANN001
     ctx.register_command(
         "budget",
         budget.handle,
-        description="Show/set spend budgets (global, per cron job, per sender)",
-        args_hint="[cron | set <scope> <window> <usd>]",
+        description="Show/set spend budgets (global, per cron job, per sender, per profile)",
+        args_hint="[cron | set <scope> [<id>] <window> <usd>]",
     )
 
     # ------------------------------------------------------------------

--- a/budget.py
+++ b/budget.py
@@ -628,16 +628,24 @@ def _cron_block() -> str:
     return "\n".join(lines)
 
 
-def _set_budget(scope: str, window: str, usd: float) -> str:
-    """Persist a limit to budget.yaml and hot-reload."""
+def _set_budget(scope: str, window: str, usd: float, scope_id: str = "") -> str:
+    """Persist a limit to budget.yaml and hot-reload.
+
+    ``scope_id`` targets a per-id override (``per_<scope>.overrides.<id>``);
+    omitted, the limit lands in the scope's shared ``default`` bucket. The
+    ``global`` scope takes no id. Mirrors the read structure in
+    ``_resolve_limits``.
+    """
     import os
 
     import yaml
 
-    if scope not in ("global", "cron_job", "sender"):
-        return f"Unknown scope {scope!r}. Use: global | cron_job | sender"
+    if scope not in ("global", "cron_job", "sender", "profile"):
+        return f"Unknown scope {scope!r}. Use: global | cron_job | sender | profile"
     if window not in ("daily", "monthly"):
         return f"Unknown window {window!r}. Use: daily | monthly"
+    if scope == "global" and scope_id:
+        return "The global scope takes no id. Use: set global <daily|monthly> <usd>"
     key = f"{window}_usd"
 
     path = _budget_path()
@@ -652,10 +660,17 @@ def _set_budget(scope: str, window: str, usd: float) -> str:
     budgets = raw.setdefault("budgets", {})
     if scope == "global":
         budgets.setdefault("global", {})[key] = usd
-    elif scope == "cron_job":
-        budgets.setdefault("per_cron_job", {}).setdefault("default", {})[key] = usd
-    else:  # sender
-        budgets.setdefault("per_sender", {}).setdefault("default", {})[key] = usd
+    else:
+        per_key = {
+            "cron_job": "per_cron_job",
+            "sender": "per_sender",
+            "profile": "per_profile",
+        }[scope]
+        node = budgets.setdefault(per_key, {})
+        if scope_id:
+            node.setdefault("overrides", {}).setdefault(scope_id, {})[key] = usd
+        else:
+            node.setdefault("default", {})[key] = usd
 
     # Atomic write: temp file + os.replace (POSIX atomic)
     # Prevents watchdog from reading partial/empty YAML on IN_MODIFY
@@ -664,7 +679,8 @@ def _set_budget(scope: str, window: str, usd: float) -> str:
         yaml.safe_dump(raw, f, default_flow_style=False, sort_keys=False)
     os.replace(tmp, path)
     reload_config()
-    return f"Set {scope} {window} budget to ${usd:.2f}. Saved to {path}."
+    target = f"{scope} '{scope_id}'" if scope_id else scope
+    return f"Set {target} {window} budget to ${usd:.2f}. Saved to {path}."
 
 
 def _days_ago_utc(days: int) -> str:
@@ -699,20 +715,28 @@ def handle(raw_args: str) -> str:
         return _forecast_block(scope, scope_id, window)
 
     if sub == "set":
-        if len(parts) != 4:
-            return "Usage: /budget set <global|cron_job|sender> <daily|monthly> <usd>"
-        _, scope, window, usd_s = parts
+        rest = parts[1:]
+        if len(rest) == 3:
+            scope, window, usd_s = rest
+            scope_id = ""
+        elif len(rest) == 4:
+            scope, scope_id, window, usd_s = rest
+        else:
+            return (
+                "Usage: /budget set <global|cron_job|sender|profile> [<id>] <daily|monthly> <usd>"
+            )
         try:
             usd = float(usd_s)
         except ValueError:
             return f"Invalid amount {usd_s!r} — must be a number, e.g. 5.00"
         if usd < 0:
             return "Amount must be non-negative."
-        return _set_budget(scope.lower(), window.lower(), usd)
+        return _set_budget(scope.lower(), window.lower(), usd, scope_id)
 
     return (
-        "Usage: /budget [cron | set <scope> <window> <usd>]\n"
-        "  /budget                       — status of all scopes\n"
-        "  /budget cron                  — per-cron-job budgets\n"
-        "  /budget set global daily 5.00 — set/raise a limit (hot-reloads)"
+        "Usage: /budget [cron | set <scope> [<id>] <window> <usd>]\n"
+        "  /budget                             — status of all scopes\n"
+        "  /budget cron                        — per-cron-job budgets\n"
+        "  /budget set global daily 5.00       — set/raise a limit (hot-reloads)\n"
+        "  /budget set profile faro monthly 50 — per-profile override (id optional)"
     )

--- a/telemetry_cli.py
+++ b/telemetry_cli.py
@@ -145,9 +145,15 @@ def _build_parser_into(sub) -> None:
     bc.add_argument("--json", action="store_true", help="Output as JSON")
 
     bs = bsub.add_parser("set", help="Set a budget limit")
-    bs.add_argument("scope", choices=["global", "cron_job", "sender"])
+    bs.add_argument("scope", choices=["global", "cron_job", "sender", "profile"])
     bs.add_argument("window", choices=["daily", "monthly"])
     bs.add_argument("usd", type=float)
+    bs.add_argument(
+        "--id",
+        dest="scope_id",
+        default="",
+        help="Override id (e.g. a profile name); omit to set the scope's default bucket",
+    )
 
     bf = bsub.add_parser("forecast", help="Project burn rate toward the budget limit")
     bf.add_argument("window", nargs="?", choices=["daily", "monthly"], default="monthly")
@@ -267,7 +273,7 @@ def _handle_budget(args: argparse.Namespace) -> None:
     from . import budget as _budget
 
     if args.budget_command == "set":
-        print(_budget._set_budget(args.scope, args.window, args.usd))
+        print(_budget._set_budget(args.scope, args.window, args.usd, getattr(args, "scope_id", "")))
         return
 
     if args.budget_command == "forecast":

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -347,6 +347,49 @@ def test_budget_set_validation(tmp_path):
     assert "window" in budget.handle("set global yearly 5").lower()
 
 
+def test_budget_set_profile_default(tmp_path):
+    """`set profile <window> <usd>` (no id) writes per_profile.default."""
+    out = budget.handle("set profile daily 3.00")
+    assert "3.00" in out
+    assert "profile" in out.lower()
+    # default applies to any profile with no explicit override
+    assert budget._resolve_limits("profile", "anything")["daily_usd"] == 3.00
+
+
+def test_budget_set_profile_override(tmp_path):
+    """`set profile <id> <window> <usd>` writes per_profile.overrides.<id>."""
+    out = budget.handle("set profile faro monthly 50.00")
+    assert "50.00" in out
+    assert "faro" in out
+    assert budget._resolve_limits("profile", "faro")["monthly_usd"] == 50.00
+    # a different profile has no monthly limit (default not set)
+    assert "monthly_usd" not in budget._resolve_limits("profile", "other")
+
+
+def test_budget_set_profile_override_and_default_coexist(tmp_path):
+    budget.handle("set profile daily 2.00")  # default
+    budget.handle("set profile faro daily 25.00")  # override
+    assert budget._resolve_limits("profile", "faro")["daily_usd"] == 25.00
+    assert budget._resolve_limits("profile", "other")["daily_usd"] == 2.00
+
+
+def test_budget_set_global_rejects_id(tmp_path):
+    out = budget.handle("set global faro daily 5.00")
+    assert "global" in out.lower()
+    assert "no id" in out.lower()
+
+
+def test_budget_set_id_form_generic_for_cron(tmp_path):
+    """The optional-id override form works for any id-scope, not just profile."""
+    budget.handle("set cron_job nightly daily 3.00")
+    assert budget._resolve_limits("cron_job", "nightly")["daily_usd"] == 3.00
+
+
+def test_budget_set_usage_mentions_profile(tmp_path):
+    out = budget.handle("set")  # no args after subcommand → usage
+    assert "profile" in out.lower()
+
+
 def test_budget_status_no_config(tmp_path):
     out = budget.handle("")
     assert "No budgets configured" in out

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -131,7 +131,13 @@ def test_budget_set_text(capsys):
         main(["budget", "set", "global", "daily", "10.00"])
     out, _ = capsys.readouterr()
     assert out == "Budget updated.\n"
-    m.assert_called_once_with("global", "daily", 10.0)
+    m.assert_called_once_with("global", "daily", 10.0, "")
+
+
+def test_budget_set_profile_cli(capsys):
+    with patch("hermes_telemetry.budget._set_budget", return_value="ok") as m:
+        main(["budget", "set", "profile", "monthly", "50.00", "--id", "faro"])
+    m.assert_called_once_with("profile", "monthly", 50.0, "faro")
 
 
 def test_budget_set_invalid_amount_exits():


### PR DESCRIPTION
## Summary

Closes the `/budget set` half of issue #70. The `profile` budget scope was already
honored by enforcement (`evaluate_run`), forecast, and manual YAML — but
`budget set profile …` was rejected as "Unknown scope". This wires `profile` into
`budget set` on **both** surfaces (chat `/budget set` and standalone
`hermes-telemetry budget set`), with an optional per-id override.

## Behavior

`_set_budget(scope, window, usd, scope_id="")` now:
- Accepts `global | cron_job | sender | profile`.
- With an id → writes `budgets.per_<scope>.overrides.<id>`; without → the scope's
  `default` bucket. `global` takes no id.
- The id-override form is **generic** across the id-scopes — the read side
  (`_resolve_limits`) already resolved `overrides.<id> or default` for all of them,
  so `set` just fills the same shape (cron_job/sender gain override-setting too).
- Atomic write (temp + `os.replace`) + `reload_config()` hot-reload, unchanged.

Command shapes:
- **Chat:** `/budget set <scope> [<id>] <window> <usd>` (id positional, after scope).
  e.g. `/budget set profile faro monthly 50` or `/budget set profile daily 2`.
- **CLI:** `hermes-telemetry budget set <scope> <window> <usd> [--id <name>]` — the id
  is a flag because argparse can't express an optional *middle* positional and the
  CLI validates `window`/`usd` as typed positionals.

## Out of scope (per request)

- The `/budget` **status** "Profiles:" section (needs a new `db.list_profile_ids`) —
  small follow-up.
- The web dashboard value — separate PR.

## Tests

- `tests/test_budget.py`: profile default, profile override, override+default
  coexist, global-rejects-id, generic cron override, usage-mentions-profile. Real
  `budget.yaml` round-trip via `handle()`/`_set_budget` + `_resolve_limits` (no mocks).
- `tests/test_telemetry_cli.py`: profile `--id` passed through; existing set test
  updated for the new 4-arg signature.
- Full suite: **594 passed, 6 skipped**; ruff clean. No schema change.
- README test-count table synced (600 tests).

## Docs

README `/budget` block + ONBOARDING "Setting budgets" design note (incl. the
chat-positional vs CLI-`--id` asymmetry and the generic id-override shape).