### PR TITLE
fix(pricing): drift --apply picks most-recent snapshot across providers

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -784,8 +784,10 @@ case) surfaces instead of silently inflating cost:
 - **Dry-run by default**; `--apply` merges the snapshot input/output rates back
   into `pricing.yaml` (never clobber), tags each repaired entry `_source:
   core-snapshot`, and hot-reloads. Because `pricing.yaml` is keyed by model only,
-  a model that drifted under two providers is written once (first wins; a
-  conflicting second rate is logged and skipped). Routes through
+  a model that drifted under two providers is written once — the **most recent
+  snapshot wins** (highest `snapshot_id`), so a stale older capture from one
+  provider never overwrites a fresher one from another sharing the same API
+  (issue #84); a conflicting older rate is logged and skipped. Routes through
   `paths.get_pricing_path()` (resolved at call time, so `HERMES_TELEMETRY_HOME`
   outranks `HERMES_HOME` — same as every other pricing.yaml reader/writer).
   `--model` limits to one canonical model; `--json` for machine output. No schema

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A comprehensive telemetry plugin that captures real usage data, enforces budget 
 
 [![Hermes Agent](https://raw.githubusercontent.com/NousResearch/hermes-agent/HEAD/assets/banner.png)](https://raw.githubusercontent.com/NousResearch/hermes-agent/HEAD/assets/banner.png)
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://camo.githubusercontent.com/08cef40a9105b6526ca22088bc514fbfdbc9aac1ddbf8d4e6c750e3a88a44dca/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4c6963656e73652d4d49542d626c75652e737667) [![Tests: 594 passing](https://img.shields.io/badge/Tests-594%20passing-green.svg)](https://img.shields.io/badge/Tests-594%20passing-green.svg) [![Provider Support](https://img.shields.io/badge/Providers-OpenRouter-orange.svg)](https://img.shields.io/badge/Providers-OpenRouter-orange.svg) [![Challenge Entry](https://img.shields.io/badge/Hermes%20Agent-Challenge%20Entry-purple.svg)](https://camo.githubusercontent.com/d0c993fdf35127e435629279025d4b1892e351f5e04ce1547329686aa4223366/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4865726d65732532304167656e742d4368616c6c656e6765253230456e7472792d707572706c652e737667)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://camo.githubusercontent.com/08cef40a9105b6526ca22088bc514fbfdbc9aac1ddbf8d4e6c750e3a88a44dca/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4c6963656e73652d4d49542d626c75652e737667) [![Tests: 595 passing](https://img.shields.io/badge/Tests-595%20passing-green.svg)](https://img.shields.io/badge/Tests-595%20passing-green.svg) [![Provider Support](https://img.shields.io/badge/Providers-OpenRouter-orange.svg)](https://img.shields.io/badge/Providers-OpenRouter-orange.svg) [![Challenge Entry](https://img.shields.io/badge/Hermes%20Agent-Challenge%20Entry-purple.svg)](https://camo.githubusercontent.com/d0c993fdf35127e435629279025d4b1892e351f5e04ce1547329686aa4223366/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4865726d65732532304167656e742d4368616c6c656e6765253230456e7472792d707572706c652e737667)
 
 -----
 
@@ -1345,7 +1345,7 @@ global    $0.1812 / $2.00    9%  [daily]
 |Pricing auto-refresh (OpenRouter API)|✅ 320 models fetched, manual overrides preserved   |
 |Estimated-price model handling       |✅ Negative prices → $0.00, budget degradation      |
 |Dashboard (HTML, auto-refresh 30s)   |✅ Charts, tables, budget bar, provider distribution|
-|594 tests pass                       |✅                                                  |
+|595 tests pass                       |✅                                                  |
 
 -----
 
@@ -1372,7 +1372,7 @@ pip install pytest pyyaml
 pytest tests/ -v
 ```
 
-**Test suite (600 tests, 594 passing + 6 skipped):**
+**Test suite (601 tests, 595 passing + 6 skipped):**
 
 |File                             |Tests|Coverage                                                                                                                       |
 |---------------------------------|-----|-------------------------------------------------------------------------------------------------------------------------------|
@@ -1382,7 +1382,7 @@ pytest tests/ -v
 |`test_telemetry_cli.py`          |35   |CLI subcommands (stats/budget/pricing/sync-profiles), all window variants, text + `--json` output, entry point smoke test      |
 |`test_budget.py`                 |34   |ok/soft/hard verdicts, estimated-to-soft degradation, anti-spam ledger, cron pause, per-scope routing, `/budget set` (default + per-profile/id override) hot-reload|
 |`test_dashboard_plugin_api.py`   |33   |Plugin dashboard API: per-profile scoping clauses, efficiency/smells/budget endpoints                                          |
-|`test_pricing_drift.py`          |31   |Drift vs core snapshots: threshold, subscription skip, canonical collapse, provider-assumed routing, `--apply` write-back, malformed-YAML safety, CLI|
+|`test_pricing_drift.py`          |32   |Drift vs core snapshots: threshold, subscription skip, canonical collapse, provider-assumed routing, `--apply` write-back, multi-provider recency, malformed-YAML safety, CLI|
 |`test_sync_profiles.py`          |29   |Profile consolidation via `HERMES_TELEMETRY_HOME`: `.env` upsert, name scoping, template preservation                          |
 |`test_stats_smells.py`           |22   |Anti-pattern (smell) detection and scoring                                                                                     |
 |`test_setup.py`                  |21   |First-time setup wizard, pricing/budget file generation, interactive + non-interactive paths                                   |

--- a/pricing_drift.py
+++ b/pricing_drift.py
@@ -98,6 +98,7 @@ def run(*, apply: bool = False, threshold_pct: float = 1.0, model: str | None = 
                 {
                     "provider": provider,
                     "model": write_key,
+                    "snapshot_id": row["id"],
                     "local_input": local_in,
                     "local_output": local_out,
                     "snap_input": float(snap_in),
@@ -189,12 +190,20 @@ def _apply_drift(drifted: list[dict]) -> int:
     hot-reloads pricing.py's cache. Returns the number of entries written.
 
     pricing.yaml is keyed by model only, so if the same model drifted under two
-    providers (run() keys canonical by (provider, model)), only the first is
-    written; a conflicting second rate is logged and skipped rather than silently
-    overwriting.
+    providers (run() keys canonical by (provider, model)), only one rate can be
+    pinned. We keep the MOST RECENT snapshot (highest snapshot_id) so a stale
+    older capture never wins over a fresh one — e.g. a custom provider and a
+    built-in provider sharing the same API where the built-in was captured later
+    (issue #84). A conflicting older rate is logged and skipped rather than
+    silently overwriting. Entries without a snapshot_id (direct callers/tests)
+    fall back to first-wins via a stable sort.
     """
     if not drifted:
         return 0
+
+    # Most-recent-first so the first write per model wins with the newest rate.
+    # Stable sort preserves original order for equal/absent ids (first-wins).
+    drifted = sorted(drifted, key=lambda d: -(d.get("snapshot_id") or 0))
 
     import yaml
 
@@ -225,9 +234,9 @@ def _apply_drift(drifted: list[dict]) -> int:
             if applied[target] != rates:
                 logger.warning(
                     "hermes-telemetry: conflicting core rates for model %r across "
-                    "providers (%s vs %s) — keeping the first, skipping the rest. "
-                    "pricing.yaml is keyed by model only, so per-provider rates "
-                    "cannot both be pinned.",
+                    "providers (kept %s, skipped %s) — keeping the most recent "
+                    "snapshot, skipping the rest. pricing.yaml is keyed by model "
+                    "only, so per-provider rates cannot both be pinned.",
                     d["model"],
                     applied[target],
                     rates,

--- a/tests/test_pricing_drift.py
+++ b/tests/test_pricing_drift.py
@@ -124,6 +124,29 @@ def test_run_flags_coverage_gap():
     assert result["coverage_gap"] >= 1
 
 
+def test_apply_multi_provider_same_model_writes_most_recent_snapshot():
+    # Issue #84: a custom provider and a built-in provider (sharing the same API)
+    # both have snapshots for the same canonical model. The custom snapshot is
+    # older/stale ($0.435); the built-in one is newer/current ($0.348). Apply must
+    # write the MOST RECENT snapshot (highest id), not the alphabetically-first
+    # provider ("custom" < "nous"), which used to win and pinned the stale price.
+    import yaml
+    from hermes_telemetry import paths
+
+    db.record_pricing_snapshot("custom", "deepseek/deepseek-v4-pro", _snap(0.435, 0.87))
+    db.record_pricing_snapshot("nous", "deepseek/deepseek-v4-pro", _snap(0.348, 0.696))
+    _write_pricing_yaml({"deepseek/deepseek-v4-pro": {"input": 1.6, "output": 3.2}})
+
+    result = pricing_drift.run(apply=True)
+    assert result["written"] == 1
+
+    with open(paths.get_pricing_path()) as f:
+        data = yaml.safe_load(f)
+    entry = data["models"]["deepseek/deepseek-v4-pro"]
+    assert entry["input"] == 0.348  # newest snapshot (nous), not stale custom 0.435
+    assert entry["output"] == 0.696
+
+
 def test_run_model_filter():
     db.record_pricing_snapshot("nous", "a", _snap(0.435, 0.87))
     db.record_pricing_snapshot("nous", "b", _snap(0.435, 0.87))


### PR DESCRIPTION
## Problem

When a `custom` provider and a built-in provider (e.g. `nous`) share the same underlying API and both have pricing snapshots for the same canonical model, `pricing drift --apply` picked the **alphabetically-first** provider's snapshot (first-wins), because `pricing.yaml` is keyed by model only and `run()` emits drifted entries sorted by `(provider, model)`. If that provider's snapshot was older/stale, the current price was silently overwritten with the stale one.

Real-world case (issue #84): `custom` snapshot id=11 (Jul 21, $0.435) won over `nous` snapshot id=14 (Jul 23, $0.348) for `deepseek/deepseek-v4-pro`, pinning the stale price into `pricing.yaml`.

## Fix

Disambiguate by **recency** instead of provider name:

- `run()` now carries each drifted entry's `snapshot_id`.
- `_apply_drift()` sorts drifted entries by `snapshot_id` descending (stable sort) before the per-model first-wins write, so the **most recent snapshot wins**. A fresher capture from one provider never loses to an older one from another sharing the same API.
- Ties or entries without an id (direct callers/tests) keep first-wins via the stable sort — no behavior change there.
- The multi-provider conflict warning is retained and reworded to reflect "kept most recent / skipped older".

No schema change.

## Tests

- New: `test_apply_multi_provider_same_model_writes_most_recent_snapshot` reproduces the exact issue-#84 scenario (custom stale + nous current → newest wins). Verified RED before the fix, GREEN after.
- Full suite green: `595 passed, 6 skipped`; `ruff format --check` + `ruff check` clean.

Docs updated in the same PR: ONBOARDING.md (drift apply section) and README test counts.

Closes #84